### PR TITLE
Com 665

### DIFF
--- a/src/components/planning/ChipAuxiliaryIndicator.vue
+++ b/src/components/planning/ChipAuxiliaryIndicator.vue
@@ -60,7 +60,7 @@ export default {
   props: {
     person: { type: Object, default: () => ({ picture: { link: '' }, administrative: {}, contracts: [] }) },
     events: { type: Array, default: () => [] },
-    startOfWeekAsString: { type: String, default: '' },
+    startOfWeek: { type: String, default: '' },
     dm: { type: Array, default: () => [] },
   },
   data () {
@@ -89,14 +89,14 @@ export default {
       return this.ratio.contractHours !== 0 && this.ratio.weeklyHours >= this.ratio.contractHours;
     },
     endOfWeek () {
-      return this.$moment(this.startOfWeekAsString).endOf('w').toISOString();
+      return this.$moment(this.startOfWeek).endOf('w').toISOString();
     },
     days () {
       let range;
-      if (this.selectedTab === WEEK_STATS) range = this.$moment.range(this.startOfWeekAsString, this.endOfWeek);
+      if (this.selectedTab === WEEK_STATS) range = this.$moment.range(this.startOfWeek, this.endOfWeek);
       else {
-        const start = this.$moment(this.startOfWeekAsString).startOf('month');
-        const end = this.$moment(this.startOfWeekAsString).endOf('month');
+        const start = this.$moment(this.startOfWeek).startOf('month');
+        const end = this.$moment(this.startOfWeek).endOf('month');
         range = this.$moment.range(start, end);
       }
 
@@ -124,8 +124,8 @@ export default {
       return companyContracts.some(contract => {
         return (this.$moment(contract.startDate).isSameOrBefore(this.endOfWeek) &&
           (!contract.endDate || this.$moment(contract.endDate).isAfter(this.endOfWeek))) ||
-          (this.$moment(contract.startDate).isSameOrBefore(this.startOfWeekAsString) &&
-          (!contract.endDate || this.$moment(contract.endDate).isAfter(this.startOfWeekAsString)));
+          (this.$moment(contract.startDate).isSameOrBefore(this.startOfWeek) &&
+          (!contract.endDate || this.$moment(contract.endDate).isAfter(this.startOfWeek)));
       });
     },
     companyContracts () {
@@ -173,8 +173,8 @@ export default {
       if (!this.hasCompanyContractOnEvent) return;
       try {
         this.monthEvents = await this.$events.list({
-          startDate: this.$moment(this.startOfWeekAsString).startOf('month').toDate(),
-          endDate: this.$moment(this.startOfWeekAsString).endOf('month').toDate(),
+          startDate: this.$moment(this.startOfWeek).startOf('month').toDate(),
+          endDate: this.$moment(this.startOfWeek).endOf('month').toDate(),
           auxiliary: this.person._id,
         });
       } catch (e) {
@@ -298,7 +298,7 @@ export default {
     },
     getContractHours () {
       let contractHours = 0;
-      const contractDaysRange = Array.from(this.$moment.range(this.startOfWeekAsString, this.$moment(this.endOfWeek).subtract(1, 'd')).by('days')) // from Monday to Saturday
+      const contractDaysRange = Array.from(this.$moment.range(this.startOfWeek, this.$moment(this.endOfWeek).subtract(1, 'd')).by('days')) // from Monday to Saturday
       for (const day of contractDaysRange) {
         const absences = this.events.filter(event =>
           event.type === ABSENCE &&

--- a/src/components/planning/Planning.vue
+++ b/src/components/planning/Planning.vue
@@ -66,7 +66,7 @@
                     <ni-chip-customer-indicator v-if="isCustomerPlanning" :person="person"
                       :events="getPersonEvents(person)" />
                     <ni-chip-auxiliary-indicator v-else :person="person" :events="getPersonEvents(person)"
-                      :startOfWeekAsString="startOfWeekAsString" :dm="distanceMatrix" />
+                      :startOfWeek="startOfWeek" :dm="distanceMatrix" />
                   </div>
                   <div class="person-name overflow-hidden-nowrap">
                     <template v-if="isCustomerPlanning">{{ person.identity | formatIdentity('fL') }}</template>
@@ -144,7 +144,7 @@ export default {
       terms: [],
       loading: false,
       draggedObject: {},
-      startOfWeekAsString: this.$moment().startOf('week').toISOString(),
+      startOfWeek: this.$moment().startOf('week').toISOString(),
       days: [],
       maxDays: 7,
       staffingView: false,
@@ -202,7 +202,7 @@ export default {
     // Table
     updateTimeline () {
       this.getTimelineDays();
-      this.$emit('updateStartOfWeek', { startOfWeekAsString: this.startOfWeekAsString });
+      this.$emit('updateStartOfWeek', { startOfWeek: this.startOfWeek });
     },
     // Event display
     getRowEvents (rowId) {

--- a/src/components/planning/Planning.vue
+++ b/src/components/planning/Planning.vue
@@ -66,7 +66,7 @@
                     <ni-chip-customer-indicator v-if="isCustomerPlanning" :person="person"
                       :events="getPersonEvents(person)" />
                     <ni-chip-auxiliary-indicator v-else :person="person" :events="getPersonEvents(person)"
-                      :startOfWeekAsString="startOfWeek.toISOString()" :dm="distanceMatrix" />
+                      :startOfWeekAsString="startOfWeekAsString" :dm="distanceMatrix" />
                   </div>
                   <div class="person-name overflow-hidden-nowrap">
                     <template v-if="isCustomerPlanning">{{ person.identity | formatIdentity('fL') }}</template>
@@ -144,7 +144,7 @@ export default {
       terms: [],
       loading: false,
       draggedObject: {},
-      startOfWeek: this.$moment().startOf('week'),
+      startOfWeekAsString: this.$moment().startOf('week').toISOString(),
       days: [],
       maxDays: 7,
       staffingView: false,
@@ -202,7 +202,7 @@ export default {
     // Table
     updateTimeline () {
       this.getTimelineDays();
-      this.$emit('updateStartOfWeek', { startOfWeek: this.startOfWeek });
+      this.$emit('updateStartOfWeek', { startOfWeekAsString: this.startOfWeekAsString });
     },
     // Event display
     getRowEvents (rowId) {

--- a/src/components/planning/Planning.vue
+++ b/src/components/planning/Planning.vue
@@ -171,7 +171,6 @@ export default {
   computed: {
     ...mapGetters({
       mainUser: 'main/user',
-      filters: 'planning/getFilters',
     }),
     isCoach () {
       return [COACH, ADMIN].includes(this.mainUser.role.name);

--- a/src/mixins/planningActionMixin.js
+++ b/src/mixins/planningActionMixin.js
@@ -163,7 +163,7 @@ export const planningActionMixin = {
       payload = this.$_.pickBy(payload);
 
       if (event.auxiliary) {
-        const auxiliary = this.auxiliaries.find(aux => aux._id === event.auxiliary);
+        const auxiliary = this.activeAuxiliaries.find(aux => aux._id === event.auxiliary);
         payload.sector = auxiliary.sector._id;
       }
 
@@ -412,7 +412,7 @@ export const planningActionMixin = {
         payload.sector = draggedObject.sector;
       } else {
         payload.auxiliary = target._id;
-        const auxiliary = this.auxiliaries.find(aux => aux._id === target._id);
+        const auxiliary = this.activeAuxiliaries.find(aux => aux._id === target._id);
         payload.sector = auxiliary.sector._id;
       }
 

--- a/src/mixins/planningActionMixin.js
+++ b/src/mixins/planningActionMixin.js
@@ -32,7 +32,6 @@ export const planningActionMixin = {
           endHour: { required: requiredIf((item, parent) => parent && (parent.type === ABSENCE && parent.absenceNature === HOURLY)) },
         },
         auxiliary: { required: requiredIf((item) => item.type !== INTERVENTION) },
-        sector: { required },
         customer: { required: requiredIf((item) => item.type === INTERVENTION) },
         subscription: { required: requiredIf((item) => item.type === INTERVENTION) },
         internalHour: { required: requiredIf((item) => item.type === INTERNAL_HOUR) },

--- a/src/mixins/planningModalMixin.js
+++ b/src/mixins/planningModalMixin.js
@@ -141,8 +141,6 @@ export const planningModalMixin = {
       return EVENT_TYPES;
     },
     auxiliariesOptions () {
-      if (this.activeAuxiliaries.length === 0) return [];
-
       if (this.personKey === CUSTOMER && this.creationModal) {
         return this.activeAuxiliaries.map(aux => this.formatPersonOptions(aux));
       }

--- a/src/mixins/planningTimelineMixin.js
+++ b/src/mixins/planningTimelineMixin.js
@@ -16,6 +16,10 @@ export const planningTimelineMixin = {
       if (this.viewMode) return this.viewMode === THREE_DAYS_VIEW;
       return false;
     },
+    endOfWeek () {
+      const gapDays = this.isThreeDaysView ? 2 : 6;
+      return this.$moment(this.startOfWeek).add(gapDays, 'd').endOf('d').toISOString();
+    },
   },
   watch: {
     startOfWeek () {
@@ -28,14 +32,10 @@ export const planningTimelineMixin = {
       const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).add(gapDays, 'd'));
       this.days = Array.from(range.by('days'));
     },
-    endOfWeek () {
-      const gapDays = this.isThreeDaysView ? 2 : 6;
-      return this.$moment(this.startOfWeek).add(gapDays, 'd').endOf('d');
-    },
     timelineTitle () {
       if (this.startOfWeek === '') return '';
-      if (this.$moment(this.startOfWeek).month() === this.$moment(this.endOfWeek()).month()) return this.$moment(this.startOfWeek).format('MMMM YYYY');
-      return `${this.$moment(this.startOfWeek).format('MMM')} - ${this.$moment(this.endOfWeek()).format('MMM YYYY')}`
+      if (this.$moment(this.startOfWeek).month() === this.$moment(this.endOfWeek).month()) return this.$moment(this.startOfWeek).format('MMMM YYYY');
+      return `${this.$moment(this.startOfWeek).format('MMM')} - ${this.$moment(this.endOfWeek).format('MMM YYYY')}`
     },
     goToNextWeek () {
       const gapDays = this.isThreeDaysView ? 3 : 7;

--- a/src/mixins/planningTimelineMixin.js
+++ b/src/mixins/planningTimelineMixin.js
@@ -18,47 +18,47 @@ export const planningTimelineMixin = {
     },
   },
   watch: {
-    startOfWeek () {
-      this.targetDate = this.startOfWeek.toISOString();
+    startOfWeekAsString () {
+      this.targetDate = this.startOfWeekAsString;
     },
   },
   methods: {
     getTimelineDays () {
       const gapDays = this.isThreeDaysView ? 2 : 6;
-      const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).add(gapDays, 'd'));
+      const range = this.$moment.range(this.startOfWeekAsString, this.$moment(this.startOfWeekAsString).add(gapDays, 'd'));
       this.days = Array.from(range.by('days'));
     },
     endOfWeek () {
       const gapDays = this.isThreeDaysView ? 2 : 6;
-      return this.$moment(this.startOfWeek).add(gapDays, 'd').endOf('d');
+      return this.$moment(this.startOfWeekAsString).add(gapDays, 'd').endOf('d');
     },
     timelineTitle () {
-      if (this.startOfWeek === '') return '';
-      if (this.$moment(this.startOfWeek).month() === this.$moment(this.endOfWeek()).month()) return this.$moment(this.startOfWeek).format('MMMM YYYY');
-      return `${this.$moment(this.startOfWeek).format('MMM')} - ${this.$moment(this.endOfWeek()).format('MMM YYYY')}`
+      if (this.startOfWeekAsString === '') return '';
+      if (this.$moment(this.startOfWeekAsString).month() === this.$moment(this.endOfWeek()).month()) return this.$moment(this.startOfWeekAsString).format('MMMM YYYY');
+      return `${this.$moment(this.startOfWeekAsString).format('MMM')} - ${this.$moment(this.endOfWeek()).format('MMM YYYY')}`
     },
     goToNextWeek () {
       const gapDays = this.isThreeDaysView ? 3 : 7;
-      this.startOfWeek.add(gapDays, 'd');
+      this.startOfWeekAsString = this.$moment(this.startOfWeekAsString).add(gapDays, 'd').toISOString();
       this.updateTimeline();
     },
     goToPreviousWeek () {
       const gapDays = this.isThreeDaysView ? -3 : -7;
-      this.startOfWeek.add(gapDays, 'd');
+      this.startOfWeekAsString = this.$moment(this.startOfWeekAsString).add(gapDays, 'd').toISOString();
       this.updateTimeline();
     },
     goToToday () {
-      this.startOfWeek = this.isThreeDaysView ? this.$moment() : this.$moment().startOf('week');
+      this.startOfWeekAsString = this.isThreeDaysView ? this.$moment().toISOString() : this.$moment().startOf('week').toISOString();
       this.updateTimeline();
     },
     goToWeek (value) {
-      this.startOfWeek = this.isThreeDaysView ? this.$moment(value) : this.$moment(value).startOf('week');
+      this.startOfWeekAsString = this.isThreeDaysView ? this.$moment(value).toISOString() : this.$moment(value).startOf('week').toISOString();
       this.updateTimeline();
       this.datimeModal = false;
     },
     updateViewMode (viewMode) {
       this.viewMode = viewMode;
-      if (!this.isThreeDaysView) this.startOfWeek = this.startOfWeek.startOf('week');
+      if (!this.isThreeDaysView) this.startOfWeekAsString = this.startOfWeekAsString.startOf('week').toISOString();
       this.updateTimeline();
     },
   },

--- a/src/mixins/planningTimelineMixin.js
+++ b/src/mixins/planningTimelineMixin.js
@@ -18,47 +18,47 @@ export const planningTimelineMixin = {
     },
   },
   watch: {
-    startOfWeekAsString () {
-      this.targetDate = this.startOfWeekAsString;
+    startOfWeek () {
+      this.targetDate = this.startOfWeek;
     },
   },
   methods: {
     getTimelineDays () {
       const gapDays = this.isThreeDaysView ? 2 : 6;
-      const range = this.$moment.range(this.startOfWeekAsString, this.$moment(this.startOfWeekAsString).add(gapDays, 'd'));
+      const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).add(gapDays, 'd'));
       this.days = Array.from(range.by('days'));
     },
     endOfWeek () {
       const gapDays = this.isThreeDaysView ? 2 : 6;
-      return this.$moment(this.startOfWeekAsString).add(gapDays, 'd').endOf('d');
+      return this.$moment(this.startOfWeek).add(gapDays, 'd').endOf('d');
     },
     timelineTitle () {
-      if (this.startOfWeekAsString === '') return '';
-      if (this.$moment(this.startOfWeekAsString).month() === this.$moment(this.endOfWeek()).month()) return this.$moment(this.startOfWeekAsString).format('MMMM YYYY');
-      return `${this.$moment(this.startOfWeekAsString).format('MMM')} - ${this.$moment(this.endOfWeek()).format('MMM YYYY')}`
+      if (this.startOfWeek === '') return '';
+      if (this.$moment(this.startOfWeek).month() === this.$moment(this.endOfWeek()).month()) return this.$moment(this.startOfWeek).format('MMMM YYYY');
+      return `${this.$moment(this.startOfWeek).format('MMM')} - ${this.$moment(this.endOfWeek()).format('MMM YYYY')}`
     },
     goToNextWeek () {
       const gapDays = this.isThreeDaysView ? 3 : 7;
-      this.startOfWeekAsString = this.$moment(this.startOfWeekAsString).add(gapDays, 'd').toISOString();
+      this.startOfWeek = this.$moment(this.startOfWeek).add(gapDays, 'd').toISOString();
       this.updateTimeline();
     },
     goToPreviousWeek () {
       const gapDays = this.isThreeDaysView ? -3 : -7;
-      this.startOfWeekAsString = this.$moment(this.startOfWeekAsString).add(gapDays, 'd').toISOString();
+      this.startOfWeek = this.$moment(this.startOfWeek).add(gapDays, 'd').toISOString();
       this.updateTimeline();
     },
     goToToday () {
-      this.startOfWeekAsString = this.isThreeDaysView ? this.$moment().toISOString() : this.$moment().startOf('week').toISOString();
+      this.startOfWeek = this.isThreeDaysView ? this.$moment().toISOString() : this.$moment().startOf('week').toISOString();
       this.updateTimeline();
     },
     goToWeek (value) {
-      this.startOfWeekAsString = this.isThreeDaysView ? this.$moment(value).toISOString() : this.$moment(value).startOf('week').toISOString();
+      this.startOfWeek = this.isThreeDaysView ? this.$moment(value).toISOString() : this.$moment(value).startOf('week').toISOString();
       this.updateTimeline();
       this.datimeModal = false;
     },
     updateViewMode (viewMode) {
       this.viewMode = viewMode;
-      if (!this.isThreeDaysView) this.startOfWeekAsString = this.startOfWeekAsString.startOf('week').toISOString();
+      if (!this.isThreeDaysView) this.startOfWeek = this.startOfWeek.startOf('week').toISOString();
       this.updateTimeline();
     },
   },

--- a/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -56,7 +56,7 @@ export default {
   mixins: [planningTimelineMixin, planningActionMixin],
   data () {
     return {
-      startOfWeek: '',
+      startOfWeekAsString: '',
       events: [],
       height: 0,
       selectedAuxiliary: {},
@@ -96,7 +96,7 @@ export default {
   async mounted () {
     this.viewMode = this.$q.platform.is.mobile ? THREE_DAYS_VIEW : WEEK_VIEW;
     this.height = window.innerHeight;
-    this.startOfWeek = this.$moment().startOf('week');
+    this.startOfWeekAsString = this.$moment().startOf('week').toISOString();
     this.selectedAuxiliary = this.currentUser;
     this.getTimelineDays();
     await Promise.all([this.getAuxiliaries(), this.getCustomers(), this.refresh()]);
@@ -123,7 +123,7 @@ export default {
     async refresh () {
       try {
         const params = {
-          startDate: this.startOfWeek.toDate(),
+          startDate: this.startOfWeekAsString,
           endDate: this.endOfWeek().toDate(),
           auxiliary: this.selectedAuxiliary._id,
         }

--- a/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -5,7 +5,8 @@
         <div class="col-xs-12 col-md-5 auxiliary-name" v-if="Object.keys(selectedAuxiliary).length > 0">
           <img :src="getAvatar(selectedAuxiliary)" class="avatar">
           <q-select filter :value="selectedAuxiliary._id" color="white" inverted-light :options="auxiliariesOptions"
-            @input="updateAuxiliary" ref="auxiliarySelect" :after="[{ icon: 'swap_vert', class: 'select-icon pink-icon', handler () { toggleAuxiliarySelect(); }, }]"
+            @input="updateAuxiliary" ref="auxiliarySelect"
+            :after="[{ icon: 'swap_vert', class: 'select-icon pink-icon', handler () { toggleAuxiliarySelect(); }, }]"
             :filter-placeholder="`${selectedAuxiliary.identity.firstname} ${selectedAuxiliary.identity.lastname}`" />
         </div>
         <div class="col-xs-12 col-md-7">
@@ -79,7 +80,8 @@ export default {
       return this.$store.getters['main/user'];
     },
     activeAuxiliaries () {
-      return this.auxiliaries.filter(aux => this.hasCompanyContractOnEvent(aux, this.days[0]) || this.hasCustomerContractOnEvent(aux, this.days[0]));
+      return this.auxiliaries.filter(aux => this.hasCompanyContractOnEvent(aux, this.days[0], this.days[6]) ||
+        this.hasCustomerContractOnEvent(aux, this.days[0], this.days[6]));
     },
     auxiliariesOptions () {
       return this.activeAuxiliaries.length === 0 ? [] : this.activeAuxiliaries.map(aux => ({
@@ -97,9 +99,7 @@ export default {
     this.startOfWeek = this.$moment().startOf('week');
     this.selectedAuxiliary = this.currentUser;
     this.getTimelineDays();
-    await this.getAuxiliaries();
-    await this.refresh();
-    await this.getCustomers();
+    await Promise.all([this.getAuxiliaries(), this.getCustomers(), this.refresh()]);
     this.setInternalHours();
   },
   methods: {
@@ -134,7 +134,7 @@ export default {
     },
     async getAuxiliaries () {
       try {
-        this.auxiliaries = await this.$users.showAll({ sector: this.currentUser.sector });
+        this.auxiliaries = await this.$users.showAll();
       } catch (e) {
         this.auxiliaries = [];
       }

--- a/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -124,7 +124,7 @@ export default {
       try {
         const params = {
           startDate: this.startOfWeek,
-          endDate: this.endOfWeek().toDate(),
+          endDate: this.endOfWeek,
           auxiliary: this.selectedAuxiliary._id,
         }
         this.events = await this.$events.list(params);

--- a/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -56,7 +56,7 @@ export default {
   mixins: [planningTimelineMixin, planningActionMixin],
   data () {
     return {
-      startOfWeekAsString: '',
+      startOfWeek: '',
       events: [],
       height: 0,
       selectedAuxiliary: {},
@@ -96,7 +96,7 @@ export default {
   async mounted () {
     this.viewMode = this.$q.platform.is.mobile ? THREE_DAYS_VIEW : WEEK_VIEW;
     this.height = window.innerHeight;
-    this.startOfWeekAsString = this.$moment().startOf('week').toISOString();
+    this.startOfWeek = this.$moment().startOf('week').toISOString();
     this.selectedAuxiliary = this.currentUser;
     this.getTimelineDays();
     await Promise.all([this.getAuxiliaries(), this.getCustomers(), this.refresh()]);
@@ -123,7 +123,7 @@ export default {
     async refresh () {
       try {
         const params = {
-          startDate: this.startOfWeekAsString,
+          startDate: this.startOfWeek,
           endDate: this.endOfWeek().toDate(),
           auxiliary: this.selectedAuxiliary._id,
         }

--- a/src/pages/customers/CustomerAgenda.vue
+++ b/src/pages/customers/CustomerAgenda.vue
@@ -35,7 +35,7 @@ export default {
   data () {
     return {
       customer: {},
-      startOfWeekAsString: '',
+      startOfWeek: '',
       events: [],
       height: 0,
       viewMode: WEEK_VIEW,
@@ -50,7 +50,7 @@ export default {
   },
   async mounted () {
     this.height = window.innerHeight;
-    this.startOfWeekAsString = this.$moment().startOf('week').toISOString();
+    this.startOfWeek = this.$moment().startOf('week').toISOString();
     this.getTimelineDays();
     await this.refreshCustomer();
     await this.getEvents();
@@ -75,7 +75,7 @@ export default {
     async getEvents () {
       try {
         const params = {
-          startDate: this.startOfWeekAsString,
+          startDate: this.startOfWeek,
           endDate: this.endOfWeek().toDate(),
           customer: this.customer._id,
         }

--- a/src/pages/customers/CustomerAgenda.vue
+++ b/src/pages/customers/CustomerAgenda.vue
@@ -76,7 +76,7 @@ export default {
       try {
         const params = {
           startDate: this.startOfWeek,
-          endDate: this.endOfWeek().toDate(),
+          endDate: this.endOfWeek,
           customer: this.customer._id,
         }
         this.events = await this.$events.list(params);

--- a/src/pages/customers/CustomerAgenda.vue
+++ b/src/pages/customers/CustomerAgenda.vue
@@ -35,7 +35,7 @@ export default {
   data () {
     return {
       customer: {},
-      startOfWeek: '',
+      startOfWeekAsString: '',
       events: [],
       height: 0,
       viewMode: WEEK_VIEW,
@@ -50,7 +50,7 @@ export default {
   },
   async mounted () {
     this.height = window.innerHeight;
-    this.startOfWeek = this.$moment().startOf('week');
+    this.startOfWeekAsString = this.$moment().startOf('week').toISOString();
     this.getTimelineDays();
     await this.refreshCustomer();
     await this.getEvents();
@@ -75,7 +75,7 @@ export default {
     async getEvents () {
       try {
         const params = {
-          startDate: this.startOfWeek.toDate(),
+          startDate: this.startOfWeekAsString,
           endDate: this.endOfWeek().toDate(),
           customer: this.customer._id,
         }

--- a/src/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/pages/ni/planning/AuxiliaryPlanning.vue
@@ -60,7 +60,7 @@ export default {
       // Event edition
       editedEvent: {},
       editionModal: false,
-      startOfWeekAsString: null,
+      startOfWeekAsString: '',
       personKey: AUXILIARY,
       displayAllSectors: false,
       eventHistories: [],
@@ -129,8 +129,8 @@ export default {
     }),
     // Dates
     async updateStartOfWeek (vEvent) {
-      const { startOfWeek } = vEvent;
-      this.startOfWeekAsString = startOfWeek.startOf('d').toISOString();
+      const { startOfWeekAsString } = vEvent;
+      this.startOfWeekAsString = startOfWeekAsString;
 
       const range = this.$moment.range(this.startOfWeekAsString, this.$moment(this.startOfWeekAsString).add(6, 'd'));
       this.days = Array.from(range.by('days'));

--- a/src/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/pages/ni/planning/AuxiliaryPlanning.vue
@@ -114,7 +114,7 @@ export default {
         this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek));
     },
     endOfWeek () {
-      return this.$moment(this.startOfWeek).endOf('w');
+      return this.$moment(this.startOfWeek).endOf('w').toISOString();
     },
     activeAuxiliaries () {
       return this.filters
@@ -170,8 +170,8 @@ export default {
     async refresh () {
       try {
         let params = {
-          startDate: this.$moment(this.startOfWeek).toDate(),
-          endDate: this.endOfWeek.toDate(),
+          startDate: this.startOfWeek,
+          endDate: this.endOfWeek,
           groupBy: AUXILIARY,
         };
         if (!this.displayAllSectors) {

--- a/src/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/pages/ni/planning/AuxiliaryPlanning.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="neutral-background">
-    <ni-planning-manager :events="events" :persons="activeAuxiliaries" @updateStartOfWeek="updateStartOfWeek"
+    <ni-planning-manager :events="events" :persons="displayedAuxiliaries" @updateStartOfWeek="updateStartOfWeek"
       @createEvent="openCreationModal" @editEvent="openEditionModal" @onDrop="updateEventOnDrop"
       :filteredSectors="filteredSectors" :can-edit="canEditEvent" :personKey="personKey"
       @toggleAllSectors="toggleAllSectors" :eventHistories="eventHistories" ref="planningManager"
@@ -9,14 +9,16 @@
     <!-- Event creation modal -->
     <ni-auxiliary-event-creation-modal :validations="$v.newEvent" :loading="loading" :newEvent="newEvent"
       :creationModal="creationModal" :internalHours="internalHours" :selectedAuxiliary="selectedAuxiliary"
-      :activeAuxiliaries="activeAuxiliaries" :customers="customers" @resetForm="resetCreationForm" @deleteDocument="deleteDocument"
-      @documentUploaded="documentUploaded" @createEvent="createEvent" @close="closeCreationModal" />
+      :activeAuxiliaries="activeAuxiliaries" :customers="customers" @resetForm="resetCreationForm"
+      @deleteDocument="deleteDocument" @documentUploaded="documentUploaded" @createEvent="createEvent"
+      @close="closeCreationModal" />
 
     <!-- Event edition modal -->
     <ni-auxiliary-event-edition-modal :validations="$v.editedEvent" :loading="loading" :editedEvent="editedEvent"
-      :editionModal="editionModal" :internalHours="internalHours" :selectedAuxiliary="selectedAuxiliary" :activeAuxiliaries="activeAuxiliaries"
-      :customers="customers" @resetForm="resetEditionForm" @deleteDocument="deleteDocument" @documentUploaded="documentUploaded"
-      @updateEvent="updateEvent" @close="closeEditionModal" @deleteEvent="deleteEvent" @deleteEventRepetition="deleteEventRepetition" />
+      :editionModal="editionModal" :internalHours="internalHours" :selectedAuxiliary="selectedAuxiliary"
+      :activeAuxiliaries="activeAuxiliaries" :customers="customers" @resetForm="resetEditionForm"
+      @deleteDocument="deleteDocument" @documentUploaded="documentUploaded" @updateEvent="updateEvent"
+      @close="closeEditionModal" @deleteEvent="deleteEvent" @deleteEventRepetition="deleteEventRepetition" />
   </q-page>
 </template>
 
@@ -107,12 +109,18 @@ export default {
       }
       return { picture: {}, identity: { lastname: '' } };
     },
-    activeAuxiliaries () {
+    displayedAuxiliaries () {
       return this.auxiliaries.filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek) ||
         this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek));
     },
     endOfWeek () {
       return this.$moment(this.startOfWeekAsString).endOf('w');
+    },
+    activeAuxiliaries () {
+      return this.filters
+        .filter(f => f.type === PERSON)
+        .filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek) ||
+          this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek));
     },
   },
   methods: {

--- a/src/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/pages/ni/planning/AuxiliaryPlanning.vue
@@ -94,14 +94,14 @@ export default {
     }),
     selectedAuxiliary () {
       if (this.creationModal && this.newEvent.auxiliary) {
-        const aux = this.auxiliaries.find(aux => aux._id === this.newEvent.auxiliary);
+        const aux = this.activeAuxiliaries.find(aux => aux._id === this.newEvent.auxiliary);
         const hasCustomerContractOnEvent = this.hasCustomerContractOnEvent(aux, this.newEvent.dates.startDate);
         const hasCompanyContractOnEvent = this.hasCompanyContractOnEvent(aux, this.newEvent.dates.startDate);
 
         return { ...aux, hasCustomerContractOnEvent, hasCompanyContractOnEvent };
       }
       if (this.editionModal && this.editedEvent.auxiliary) {
-        const aux = this.auxiliaries.find(aux => aux._id === this.editedEvent.auxiliary);
+        const aux = this.activeAuxiliaries.find(aux => aux._id === this.editedEvent.auxiliary);
         const hasCustomerContractOnEvent = this.hasCustomerContractOnEvent(aux, this.editedEvent.dates.startDate);
         const hasCompanyContractOnEvent = this.hasCompanyContractOnEvent(aux, this.editedEvent.dates.startDate);
 

--- a/src/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/pages/ni/planning/AuxiliaryPlanning.vue
@@ -60,7 +60,7 @@ export default {
       // Event edition
       editedEvent: {},
       editionModal: false,
-      startOfWeekAsString: '',
+      startOfWeek: '',
       personKey: AUXILIARY,
       displayAllSectors: false,
       eventHistories: [],
@@ -110,17 +110,17 @@ export default {
       return { picture: {}, identity: { lastname: '' } };
     },
     displayedAuxiliaries () {
-      return this.auxiliaries.filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek) ||
-        this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek));
+      return this.auxiliaries.filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek) ||
+        this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek));
     },
     endOfWeek () {
-      return this.$moment(this.startOfWeekAsString).endOf('w');
+      return this.$moment(this.startOfWeek).endOf('w');
     },
     activeAuxiliaries () {
       return this.filters
         .filter(f => f.type === PERSON)
-        .filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek) ||
-          this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek));
+        .filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek) ||
+          this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek));
     },
   },
   methods: {
@@ -129,10 +129,10 @@ export default {
     }),
     // Dates
     async updateStartOfWeek (vEvent) {
-      const { startOfWeekAsString } = vEvent;
-      this.startOfWeekAsString = startOfWeekAsString;
+      const { startOfWeek } = vEvent;
+      this.startOfWeek = startOfWeek;
 
-      const range = this.$moment.range(this.startOfWeekAsString, this.$moment(this.startOfWeekAsString).add(6, 'd'));
+      const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).add(6, 'd'));
       this.days = Array.from(range.by('days'));
       if (this.auxiliaries && this.auxiliaries.length) await this.refresh();
     },
@@ -170,7 +170,7 @@ export default {
     async refresh () {
       try {
         let params = {
-          startDate: this.$moment(this.startOfWeekAsString).toDate(),
+          startDate: this.$moment(this.startOfWeek).toDate(),
           endDate: this.endOfWeek.toDate(),
           groupBy: AUXILIARY,
         };

--- a/src/pages/ni/planning/CustomerPlanning.vue
+++ b/src/pages/ni/planning/CustomerPlanning.vue
@@ -209,7 +209,9 @@ export default {
       return true;
     },
     activeAuxiliaries () {
-      return this.auxiliaries.filter(aux => this.hasCompanyContractOnEvent(aux, this.days[0]) || this.hasCustomerContractOnEvent(aux, this.days[0]));
+      return this.auxiliaries
+        .filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek) ||
+          this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek));
     },
   },
   methods: {

--- a/src/pages/ni/planning/CustomerPlanning.vue
+++ b/src/pages/ni/planning/CustomerPlanning.vue
@@ -122,7 +122,7 @@ export default {
       events: [],
       customers: [],
       auxiliaries: [],
-      startOfWeekAsString: '',
+      startOfWeek: '',
       filteredSectors: [],
       filteredCustomers: [],
       DEFAULT_AVATAR,
@@ -165,7 +165,7 @@ export default {
       elementToRemove: 'planning/getElementToRemove',
     }),
     endOfWeek () {
-      return this.$moment(this.startOfWeekAsString).endOf('w');
+      return this.$moment(this.startOfWeek).endOf('w');
     },
     selectedCustomer () {
       if (this.creationModal && this.newEvent.customer !== '') return this.customers.find(cus => cus._id === this.newEvent.customer);
@@ -210,8 +210,8 @@ export default {
     },
     activeAuxiliaries () {
       return this.auxiliaries
-        .filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek) ||
-          this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeekAsString), this.endOfWeek));
+        .filter(aux => this.hasCustomerContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek) ||
+          this.hasCompanyContractOnEvent(aux, this.$moment(this.startOfWeek), this.endOfWeek));
     },
   },
   methods: {
@@ -220,10 +220,10 @@ export default {
     }),
     // Dates
     async updateStartOfWeek (vEvent) {
-      const { startOfWeekAsString } = vEvent;
-      this.startOfWeekAsString = startOfWeekAsString.startOf('d').toISOString();
+      const { startOfWeek } = vEvent;
+      this.startOfWeek = startOfWeek.startOf('d').toISOString();
 
-      const range = this.$moment.range(this.startOfWeekAsString, this.$moment(this.startOfWeekAsString).endOf('w'));
+      const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).endOf('w'));
       this.days = Array.from(range.by('days'));
       if (this.filteredSectors.length !== 0 || this.filteredCustomers.length !== 0) await this.refreshCustomers();
       if (this.customers.length !== 0) await this.refresh();
@@ -280,7 +280,7 @@ export default {
     async refresh () {
       try {
         this.events = await this.$events.list({
-          startDate: this.$moment(this.startOfWeekAsString).toDate(),
+          startDate: this.$moment(this.startOfWeek).toDate(),
           endDate: this.endOfWeek.toDate(),
           customer: this.customers.map(cus => cus._id),
           groupBy: CUSTOMER,
@@ -330,7 +330,7 @@ export default {
     },
     async getSectorCustomers (sectors) {
       return sectors.length === 0 ? [] : this.$customers.listBySector({
-        startDate: this.$moment(this.startOfWeekAsString).toDate(),
+        startDate: this.$moment(this.startOfWeek).toDate(),
         endDate: this.endOfWeek.toDate(),
         sector: JSON.stringify(sectors),
       });

--- a/src/pages/ni/planning/CustomerPlanning.vue
+++ b/src/pages/ni/planning/CustomerPlanning.vue
@@ -165,7 +165,7 @@ export default {
       elementToRemove: 'planning/getElementToRemove',
     }),
     endOfWeek () {
-      return this.$moment(this.startOfWeek).endOf('w');
+      return this.$moment(this.startOfWeek).endOf('w').toISOString();
     },
     selectedCustomer () {
       if (this.creationModal && this.newEvent.customer !== '') return this.customers.find(cus => cus._id === this.newEvent.customer);
@@ -280,8 +280,8 @@ export default {
     async refresh () {
       try {
         this.events = await this.$events.list({
-          startDate: this.$moment(this.startOfWeek).toDate(),
-          endDate: this.endOfWeek.toDate(),
+          startDate: this.startOfWeek,
+          endDate: this.endOfWeek,
           customer: this.customers.map(cus => cus._id),
           groupBy: CUSTOMER,
         });
@@ -330,8 +330,8 @@ export default {
     },
     async getSectorCustomers (sectors) {
       return sectors.length === 0 ? [] : this.$customers.listBySector({
-        startDate: this.$moment(this.startOfWeek).toDate(),
-        endDate: this.endOfWeek.toDate(),
+        startDate: this.startOfWeek,
+        endDate: this.endOfWeek,
         sector: JSON.stringify(sectors),
       });
     },

--- a/src/pages/ni/planning/CustomerPlanning.vue
+++ b/src/pages/ni/planning/CustomerPlanning.vue
@@ -220,8 +220,8 @@ export default {
     }),
     // Dates
     async updateStartOfWeek (vEvent) {
-      const { startOfWeek } = vEvent;
-      this.startOfWeekAsString = startOfWeek.startOf('d').toISOString();
+      const { startOfWeekAsString } = vEvent;
+      this.startOfWeekAsString = startOfWeekAsString.startOf('d').toISOString();
 
       const range = this.$moment.range(this.startOfWeekAsString, this.$moment(this.startOfWeekAsString).endOf('w'));
       this.days = Array.from(range.by('days'));

--- a/src/pages/ni/planning/CustomerPlanning.vue
+++ b/src/pages/ni/planning/CustomerPlanning.vue
@@ -221,7 +221,7 @@ export default {
     // Dates
     async updateStartOfWeek (vEvent) {
       const { startOfWeek } = vEvent;
-      this.startOfWeek = startOfWeek.startOf('d').toISOString();
+      this.startOfWeek = startOfWeek;
 
       const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).endOf('w'));
       this.days = Array.from(range.by('days'));


### PR DESCRIPTION
Dans cette PR : 
- Périmetre du ticket : avoir la liste des tous les auxiliaires actifs sur le planning et l'agenda
- Refacto : sur le planning / agenda on avait deux variables ( `startOfWeek` = objet moment et `startOfWeekAsString` = string ). J'ai mutualisé les deux en `stratOfWeek` qui est une string.
- Refacto de `endOfWeek` : passage de objet moment à string