### PR TITLE
COM-562 Using url of API to display pdf

### DIFF
--- a/src/api/Bills.js
+++ b/src/api/Bills.js
@@ -1,3 +1,4 @@
+import { Cookies } from 'quasar';
 import { alenviAxios } from './ressources/alenviAxios';
 
 export default {
@@ -12,10 +13,7 @@ export default {
     const bills = await alenviAxios.get(`${process.env.API_HOSTNAME}/bills`, { params });
     return bills.data.data.bills;
   },
-  async getPDF (id) {
-    return alenviAxios.get(
-      `${process.env.API_HOSTNAME}/bills/${id}/pdfs`,
-      { responseType: 'arraybuffer', headers: { 'Accept': 'application/pdf' } }
-    );
+  getPDFUrl (id) {
+    return `${process.env.API_HOSTNAME}/bills/${id}/pdfs?x-access-token=${Cookies.get('alenvi_token')}`;
   },
 }

--- a/src/api/CreditNotes.js
+++ b/src/api/CreditNotes.js
@@ -1,4 +1,5 @@
-import { alenviAxios } from './ressources/alenviAxios'
+import { Cookies } from 'quasar';
+import { alenviAxios } from './ressources/alenviAxios';
 
 export default {
   async showAll (params) {
@@ -16,10 +17,7 @@ export default {
   async remove (id) {
     await alenviAxios.delete(`${process.env.API_HOSTNAME}/creditNotes/${id}`);
   },
-  async getPDF (id) {
-    return alenviAxios.get(
-      `${process.env.API_HOSTNAME}/creditNotes/${id}/pdfs`,
-      { responseType: 'arraybuffer', headers: { 'Accept': 'application/pdf' } }
-    );
+  getPDFUrl (id) {
+    return `${process.env.API_HOSTNAME}/creditNotes/${id}/pdfs?x-access-token=${Cookies.get('alenvi_token')}`;
   },
 }

--- a/src/components/customers/CustomerBillingTable.vue
+++ b/src/components/customers/CustomerBillingTable.vue
@@ -17,7 +17,7 @@
                 Facture {{ props.row.number || 'tiers' }}
               </a>
               <div v-else>
-                <a :href="getPdfUrl(props.row._id, 'bills')" target="_blank">Facture {{ props.row.number || 'tiers' }}</a>
+                <a :href="$bills.getPDFUrl(props.row._id)" target="_blank">Facture {{ props.row.number || 'tiers' }}</a>
               </div>
             </div>
           </template>
@@ -27,7 +27,7 @@
                 Avoir {{ props.row.number }}
               </a>
               <div v-else>
-                <a :href="getPdfUrl(props.row._id, 'creditNotes')" target="_blank">Avoir {{ props.row.number }}</a>
+                <a :href="$creditNotes.getPDFUrl(props.row._id)" target="_blank">Avoir {{ props.row.number }}</a>
               </div>
             </div>
           </template>
@@ -62,7 +62,6 @@
 </template>
 
 <script>
-import { Cookies } from 'quasar';
 import {
   CREDIT_NOTE,
   BILL,
@@ -162,9 +161,6 @@ export default {
     },
     openEditionModal (payment) {
       this.$emit('openEditionModal', payment);
-    },
-    getPdfUrl (docId, type) {
-      return `${process.env.API_HOSTNAME}/${type}/${docId}/pdfs?x-access-token=${Cookies.get('alenvi_token')}`;
     },
     canDownloadBill (bill) {
       return (bill.number && bill.origin === COMPANI) || (bill.driveFile && bill.driveFile.link);


### PR DESCRIPTION
Actuellement, on génère un blob sur la webapp afin de l'afficher dans le navigateur. Cela pose trop de problèmes en fonction des différents navigateurs (affichage, téléchargement, ...) comparé à l'utilisation d'un pdf natif. Etant donné, que l'API renvoie un PDF je mets son lien directement ds la webapp afin d'obtenir le PDF original.