### PR TITLE
COM-1005 add min and max date for export

### DIFF
--- a/src/components/form/DateInput.vue
+++ b/src/components/form/DateInput.vue
@@ -28,6 +28,7 @@ export default {
     errorLabel: { type: String, default: REQUIRED_LABEL },
     value: { type: String, default: '' },
     min: { type: String, default: '' },
+    max: { type: String, default: '' },
     disable: { type: Boolean, default: false },
     inModal: { type: Boolean, default: false },
     requiredField: { type: Boolean, default: false },
@@ -45,8 +46,11 @@ export default {
   },
   methods: {
     dateOptions (date) {
-      if (this.min) return date >= this.$moment(this.min).format('YYYY/MM/DD');
-      else return true;
+      let isBeforeMax = true;
+      let isAfterMin = true;
+      if (this.min) isAfterMin = date >= this.$moment(this.min).format('YYYY/MM/DD');
+      if (this.max) isBeforeMax = date <= this.$moment(this.max).format('YYYY/MM/DD');
+      return isAfterMin && isBeforeMax;
     },
     select (value) {
       const momentValue = this.$moment(value, 'YYYY/MM/DD', true)

--- a/src/components/form/DateRange.vue
+++ b/src/components/form/DateRange.vue
@@ -6,10 +6,11 @@
     </div>
     <q-field dense borderless :error="error" :error-message="errorLabel">
       <div class="date-container justify-center items-center row">
-        <ni-date-input :value="value.startDate" @input="update($event, 'startDate')" class="date-item" :min="min"/>
+        <ni-date-input :value="value.startDate" @input="update($event, 'startDate')" class="date-item" :min="min"
+          @blur="blur" />
         <p class="delimiter">-</p>
         <ni-date-input :value="value.endDate" @input="update($event, 'endDate')" class="date-item"
-          :min="value.startDate" :max="max" />
+          :min="value.startDate" :max="max" @blur="blur" />
       </div>
     </q-field>
   </div>
@@ -50,6 +51,9 @@ export default {
         };
       }
       this.$emit('input', dates);
+    },
+    blur () {
+      this.$emit('blur');
     },
   },
 }

--- a/src/components/form/DateRange.vue
+++ b/src/components/form/DateRange.vue
@@ -6,10 +6,10 @@
     </div>
     <q-field dense borderless :error="error" :error-message="errorLabel">
       <div class="date-container justify-center items-center row">
-        <ni-date-input :value="value.startDate" @input="update($event, 'startDate')" class="date-item" />
+        <ni-date-input :value="value.startDate" @input="update($event, 'startDate')" class="date-item" :min="min"/>
         <p class="delimiter">-</p>
         <ni-date-input :value="value.endDate" @input="update($event, 'endDate')" class="date-item"
-          :min="value.startDate" />
+          :min="value.startDate" :max="max" />
       </div>
     </q-field>
   </div>
@@ -29,6 +29,8 @@ export default {
     requiredField: { type: Boolean, default: false },
     error: { type: Boolean, default: false },
     errorLabel: { type: String, default: REQUIRED_LABEL },
+    min: { type: String, default: '' },
+    max: { type: String, default: '' },
   },
   methods: {
     update (value, key) {

--- a/src/components/form/DateRange.vue
+++ b/src/components/form/DateRange.vue
@@ -25,7 +25,15 @@ export default {
   },
   props: {
     caption: { type: String, default: '' },
-    value: { type: Object, default: function () { return { startDate: this.$moment().startOf('d').toISOString(), endDate: this.$moment().endOf('d').toISOString() } } },
+    value: {
+      type: Object,
+      default: function () {
+        return {
+          startDate: this.$moment().startOf('d').toISOString(),
+          endDate: this.$moment().endOf('d').toISOString(),
+        };
+      },
+    },
     requiredField: { type: Boolean, default: false },
     error: { type: Boolean, default: false },
     errorLabel: { type: String, default: REQUIRED_LABEL },

--- a/src/helpers/vuelidateCustomVal.js
+++ b/src/helpers/vuelidateCustomVal.js
@@ -76,6 +76,10 @@ export const minDate = (min) => {
   return (value) => moment(min).isSameOrBefore(value);
 };
 
+export const maxDate = (max) => {
+  return (value) => moment(max).isSameOrAfter(value);
+};
+
 export const apeCode = value => !value || /^\d{3,4}[A-Z]$/.test(value);
 
 export const validWorkHealthService = value => !value || workHealthServices.map(whs => whs.value).includes(value);

--- a/src/pages/ni/exports/HistoryExports.vue
+++ b/src/pages/ni/exports/HistoryExports.vue
@@ -4,10 +4,10 @@
     <div class="row q-col-gutter-sm">
       <ni-select caption="Type d'export" :options="exportTypeOptions" v-model="type" in-form />
       <ni-date-range class="col-md-6 col-xs-12" caption="Période" v-model="dateRange" :min="min" :max="max"
-        :error.sync="dateRangeHasError || $v.dateRange.$error" @input="input" error-label="Date(s) Invalide(s)"/>
+        :error="$v.dateRange.$error" @input="input" error-label="Date(s) invalide(s)" @blur="$v.dateRange.$touch" />
     </div>
     <q-btn label="Exporter" no-caps unelevated text-color="white" color="primary" icon="import_export"
-      @click="exportCsv" :disable="dateRangeHasError || loading" :loading="loading" />
+      @click="exportCsv" :disable="loading || $v.dateRange.$error" :loading="loading" />
   </q-page>
 </template>
 
@@ -31,7 +31,6 @@ export default {
       exportTypeOptions: EXPORT_HISTORY_TYPES,
       type: WORKING_EVENT,
       dateRange: { startDate: this.$moment().startOf('M').toISOString(), endDate: this.$moment().endOf('M').toISOString() },
-      dateRangeHasError: false,
       min: this.$moment().endOf('M').subtract(1, 'year').toISOString(),
       max: this.$moment().startOf('M').add(1, 'year').toISOString(),
       loading: false,

--- a/src/pages/ni/exports/HistoryExports.vue
+++ b/src/pages/ni/exports/HistoryExports.vue
@@ -3,8 +3,8 @@
     <h4>Historique</h4>
     <div class="row q-col-gutter-sm">
       <ni-select caption="Type d'export" :options="exportTypeOptions" v-model="type" in-form />
-      <ni-date-range class="col-md-6 col-xs-12" caption="Période" v-model="dateRange" :error.sync="dateRangeHasError"
-        :min="min" :max="max" v-on="$listeners" @input="input" />
+      <ni-date-range class="col-md-6 col-xs-12" caption="Période" v-model="dateRange" :min="min" :max="max"
+        :error.sync="dateRangeHasError || $v.dateRange.$error" @input="input" error-label="Date(s) Invalide(s)"/>
     </div>
     <q-btn label="Exporter" no-caps unelevated text-color="white" color="primary" icon="import_export"
       @click="exportCsv" :disable="dateRangeHasError || loading" :loading="loading" />
@@ -12,11 +12,12 @@
 </template>
 
 <script>
-import { NotifyNegative, NotifyPositive } from '../../../components/popup/notify';
+import { NotifyNegative, NotifyPositive, NotifyWarning } from '../../../components/popup/notify';
 import { downloadFile } from '../../../helpers/downloadFile';
 import Select from '../../../components/form/Select';
 import DateRange from '../../../components/form/DateRange';
 import { EXPORT_HISTORY_TYPES, WORKING_EVENT } from '../../../data/constants';
+import { minDate, maxDate } from '../../../helpers/vuelidateCustomVal';
 
 export default {
   name: 'History',
@@ -31,25 +32,29 @@ export default {
       type: WORKING_EVENT,
       dateRange: { startDate: this.$moment().startOf('M').toISOString(), endDate: this.$moment().endOf('M').toISOString() },
       dateRangeHasError: false,
-      min: '',
-      max: '',
+      min: this.$moment().endOf('M').subtract(1, 'year').toISOString(),
+      max: this.$moment().startOf('M').add(1, 'year').toISOString(),
       loading: false,
     }
   },
-  mounted () {
-    if (this.type === WORKING_EVENT) {
-      this.min = this.$moment().endOf('M').subtract(1, 'year').toISOString();
-      this.max = this.$moment().startOf('M').add(1, 'year').toISOString();
-    }
+  validations () {
+    return {
+      dateRange: {
+        startDate: { minDate: minDate(this.min) },
+        endDate: { maxDate: maxDate(this.max) },
+      },
+    };
   },
   methods: {
     input (date) {
-      this.min = this.$moment(date.endDate).subtract(1, 'year').add(1, 'day').toISOString()
-      this.max = this.$moment(date.startDate).add(1, 'year').subtract(1, 'day').toISOString()
+      this.min = this.$moment(date.endDate).subtract(1, 'year').add(1, 'day').toISOString();
+      this.max = this.$moment(date.startDate).add(1, 'year').subtract(1, 'day').toISOString();
     },
     async exportCsv () {
       try {
         this.loading = true;
+        await this.$v.dateRange.$touch();
+        if (this.$v.dateRange.$error) return NotifyWarning('Date(s) invalide(s)')
         const type = EXPORT_HISTORY_TYPES.find(type => type.value === this.type);
         if (!type) return NotifyNegative('Impossible de téléchager le document');
 


### PR DESCRIPTION
Lorsque l'on exporte les évènements, ne permettre d'exporter que sur un an. 
J'ai également ajouter un loader sur le bouton pour notifier l'utilisateur que l'export est bien en train d'être fait car il peut être long.  