### PR TITLE
COM-1017 Fix customer planning date display

### DIFF
--- a/src/components/planning/Planning.vue
+++ b/src/components/planning/Planning.vue
@@ -241,7 +241,7 @@ export default {
           this.$moment(day).isBetween(event.startDate, event.endDate, 'day', '[]') &&
           (!this.staffingView || !event.isCancelled)
         )
-        .map((event) => this.isCustomerPlanning ? event : this.getDisplayedEvent(event, day, STAFFING_VIEW_START_HOUR, STAFFING_VIEW_END_HOUR))
+        .map((event) => this.getDisplayedEvent(event, day, STAFFING_VIEW_START_HOUR, STAFFING_VIEW_END_HOUR))
         .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
     },
     getPersonEvents (person) {

--- a/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -20,13 +20,13 @@
     </div>
 
     <!-- Event creation modal -->
-    <ni-event-creation-modal :validations="$v.newEvent" :loading="loading" :newEvent="newEvent" :personKey="personKey"
+    <ni-event-creation-modal :validations="$v.newEvent" :loading="loading" :newEvent.sync="newEvent" :personKey="personKey"
       :creationModal="creationModal" :internalHours="internalHours" :activeAuxiliaries="activeAuxiliaries"
       :customers="customers" @resetForm="resetCreationForm" @deleteDocument="validateDocumentDeletion"
       @documentUploaded="documentUploaded" @createEvent="validateCreationEvent" @close="closeCreationModal" />
 
     <!-- Event edition modal -->
-    <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :editedEvent="editedEvent"
+    <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :editedEvent.sync="editedEvent"
       :editionModal="editionModal" :internalHours="internalHours" :activeAuxiliaries="activeAuxiliaries"
       :customers="customers" @resetForm="resetEditionForm" @deleteDocument="validateDocumentDeletion"
       @documentUploaded="documentUploaded" @updateEvent="updateEvent" @deleteEvent="validateEventDeletion"
@@ -176,10 +176,8 @@ export default {
         auxiliary: this.selectedAuxiliary._id,
         sector: '',
         dates: {
-          startDate: selectedDay.toISOString(),
-          startHour: '08:00',
-          endDate: selectedDay.toISOString(),
-          endHour: '10:00',
+          startDate: this.$moment(selectedDay).hours(8).toISOString(),
+          endDate: this.$moment(selectedDay).hours(10).toISOString(),
         },
       };
 

--- a/src/pages/ni/planning/CustomerPlanning.vue
+++ b/src/pages/ni/planning/CustomerPlanning.vue
@@ -5,12 +5,12 @@
       @onDrop="updateEventOnDrop" ref="planningManager" :filters="filters" @refresh="refresh" />
 
     <!-- Event creation modal -->
-    <ni-event-creation-modal :validations="$v.newEvent" :loading="loading" :newEvent="newEvent" :personKey="personKey"
+    <ni-event-creation-modal :validations="$v.newEvent" :loading="loading" :newEvent.sync="newEvent" :personKey="personKey"
       :creationModal="creationModal" :activeAuxiliaries="activeAuxiliaries" :customers="customers"
       @resetForm="resetCreationForm" @createEvent="validateCreationEvent" @close="closeCreationModal" />
 
     <!-- Event edition modal -->
-    <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :editedEvent="editedEvent"
+    <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :editedEvent.sync="editedEvent"
       :editionModal="editionModal" :activeAuxiliaries="activeAuxiliaries" :customers="customers" :personKey="personKey"
       @resetForm="resetEditionForm" @updateEvent="updateEvent" @close="closeEditionModal"
       @deleteEventRepetition="validationDeletionEventRepetition" @deleteEvent="validateEventDeletion" />
@@ -172,10 +172,8 @@ export default {
         auxiliary: '',
         sector: '',
         dates: {
-          startDate: selectedDay.toISOString(),
-          startHour: '08:00',
-          endDate: selectedDay.toISOString(),
-          endHour: '10:00',
+          startDate: this.$moment(selectedDay).hours(8).toISOString(),
+          endDate: this.$moment(selectedDay).hours(10).toISOString(),
         },
       };
       this.creationModal = true;


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - non pertinent

- Périmetre interface : coach

- Périmetre pages : planning bénéficiaire et agenda

- Cas d'usage : les heures affichées sur le planning bénéficiaire étaient fausses + correction sur les props de modal de création et d'édition (`.sync` manquant sur planning bénéficiaire et agenda)