### PR TITLE
Fix helpers subscriptions display

### DIFF
--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -256,7 +256,12 @@ export default {
   },
   async mounted () {
     if (!this.customer) await this.refreshCustomer();
-    await this.checkMandates();
+    else {
+      this.refreshSubscriptions();
+      this.refreshFundings();
+      await this.checkMandates();
+      this.$v.customer.$touch();
+    }
   },
   methods: {
     documentUploadedForFinancialCertificates () {
@@ -268,6 +273,7 @@ export default {
         this.$store.commit('customer/saveCustomer', customer);
         this.refreshSubscriptions();
         this.refreshFundings();
+        await this.checkMandates();
         this.$v.customer.$touch();
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client / Aidants

- Périmetre pages : Souscriptions

- Cas d'usage : Quand j'arrive sur la page abonnements, je vois le tableau des souscriptions et non "Pas d'abonnement"
