### PR TITLE
Fix TableList cell display

### DIFF
--- a/src/core/components/table/TableList.vue
+++ b/src/core/components/table/TableList.vue
@@ -8,7 +8,7 @@
         <q-td v-for="col in props.cols" :key="col.name" :props="props" :data-label="col.label" :style="col.style"
           :class="col.name">
           <slot name="body" :props="props" :col="col">
-            {{ col.value }}
+            <template v-if="col.value">{{ col.value }}</template>
           </slot>
         </q-td>
       </q-tr>

--- a/src/modules/client/pages/ni/auxiliaries/Directory.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Directory.vue
@@ -14,12 +14,10 @@
         <template v-else-if="col.name === 'profileErrors'">
           <q-icon v-if="notificationsProfiles[props.row.auxiliary._id] && props.row.isActive" name="error"
             color="secondary" size="1rem" />
-            <span v-else />
         </template>
         <template v-else-if="col.name === 'tasksErrors'">
           <q-icon v-if="notificationsTasks[props.row.auxiliary._id] && props.row.isActive" name="error"
             color="secondary" size="1rem" />
-          <span v-else />
         </template>
         <template v-else-if="col.name === 'active'">
           <div :class="{ 'dot dot-active': col.value, 'dot dot-inactive': !col.value }"></div>

--- a/src/modules/client/pages/ni/customers/CustomersDirectory.vue
+++ b/src/modules/client/pages/ni/customers/CustomersDirectory.vue
@@ -9,7 +9,7 @@
           <q-item-section>{{ col.value }}</q-item-section>
         </q-item>
         <template v-else-if="col.name === 'client'">
-          <div :class="{ 'dot dot-active': col.value, 'dot dot-inactive': !col.value }"></div>
+          <div :class="{ 'dot dot-active': col.value, 'dot dot-inactive': !col.value }" />
         </template>
         <template v-else-if="col.name === 'info'">
           <q-icon v-if="props.row.missingInfo" name="error" color="secondary" size="1rem" />


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - non pertinent

- Périmetre interface :  coach/client_admin

- Périmetre pages : repertoires auxiliaires/bénéficiaires

- Cas d'usage :  affichage des pastilles d'alerte d'infos manquantes
