### PR TITLE
fix mandates loading + clear store when logout

### DIFF
--- a/src/core/pages/AccountInfo.vue
+++ b/src/core/pages/AccountInfo.vue
@@ -126,6 +126,16 @@ export default {
       this.$q.cookies.remove('refresh_token', { path: '/' });
       this.$q.cookies.remove('user_id', { path: '/' });
       this.$q.localStorage.clear();
+      this.$store.commit('company/saveCompany', null);
+      this.$store.commit('course/saveCourse', null);
+      this.$store.commit('program/saveProgram', null);
+      this.$store.commit('customer/saveCustomer', null);
+      this.$store.commit('customer/saveNotification', null);
+      this.$store.commit('rh/saveUserProfile', null);
+      this.$store.commit('rh/saveNotification', null);
+      this.$store.commit('planning/setFilters', []);
+      this.$store.commit('planning/setElementToAdd', []);
+      this.$store.commit('planning/setElementToRemove', []);
       this.$router.replace('/login');
     },
   },

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -166,7 +166,7 @@ export default {
       tmpInput: null,
       newESignModal: false,
       embeddedUrl: '',
-      mandatesLoading: true,
+      mandatesLoading: false,
       mandatesColumns: [
         {
           name: 'rum',

--- a/src/modules/client/store/customer/mutations.js
+++ b/src/modules/client/store/customer/mutations.js
@@ -3,6 +3,10 @@ export function saveCustomer (state, data) {
 }
 
 export function saveNotification (state, notification) {
+  if (!notification) {
+    state.notifications = {}
+    return;
+  }
   state.notifications[notification.type] = Object.assign({}, state.notifications[notification.type], {
     [notification._id]: notification.exists,
   });

--- a/src/modules/client/store/rh/mutations.js
+++ b/src/modules/client/store/rh/mutations.js
@@ -3,6 +3,10 @@ export function saveUserProfile (state, data) {
 }
 
 export function saveNotification (state, notification) {
+  if (!notification) {
+    state.notifications = {}
+    return;
+  }
   state.notifications[notification.type] = Object.assign({}, state.notifications[notification.type], {
     [notification._id]: notification.exists,
   });


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : tous

- Cas d'usage : lorsque l'on arrive sur la page souscription par le menu sur l'interface aidant, le tableau mandat ne load pas indefiniment + lorsque l'on change de compte, le store a bien ete clear (par exemple lorsque l'on passe entre deux comptes aidants) 
