### PR TITLE
COM-1108 add referent on customer planning

### DIFF
--- a/src/modules/client/components/planning/ChipCustomerIndicator.vue
+++ b/src/modules/client/components/planning/ChipCustomerIndicator.vue
@@ -24,6 +24,7 @@ export default {
     events: { type: Array, default: () => [] },
     person: { type: Object, default: () => ({}) },
     staffingView: { type: Boolean, default: false },
+    startOfWeek: { type: String, default: '' },
   },
   computed: {
     indicators () {
@@ -38,7 +39,12 @@ export default {
   },
   methods: {
     getReferent (person) {
-      return get(person, 'referent.identity', {});
+      const referentHistory = person.referentHistories
+        .filter(rh => this.$moment(this.startOfWeek).isSameOrAfter(rh.startDate) &&
+          (!rh.endDate || this.$moment(this.startOfWeek).isBefore(rh.endDate)))
+        .sort((a, b) => a.startDate - b.startDate);
+
+      return get(referentHistory[0], 'auxiliary.identity', {});
     },
     getAvatar (picture) {
       return (!picture || !picture.link) ? DEFAULT_AVATAR : picture.link;

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -61,7 +61,7 @@
             <tr class="person-row" v-for="person in personsGroupedBySector[sectorId]" :key="person._id">
               <td valign="top">
                 <ni-chip-customer-indicator v-if="isCustomerPlanning" :person="person" :events="getPersonEvents(person)"
-                  :staffing-view="staffingView"  />
+                  :staffing-view="staffingView" :startOfWeek="startOfWeek" />
                 <ni-chip-auxiliary-indicator v-else :person="person" :events="getPersonEvents(person)"
                   :startOfWeek="startOfWeek" :working-stats="workingStats[person._id]" :staffing-view="staffingView" />
               </td>


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach/auxiliaire

- Cas d'usage : affichage du referent beneficiaire sur le planning en fonction de la date