### PR TITLE
Com 1107 fix

### DIFF
--- a/src/modules/vendor/components/courses/ProfileFollowUp.vue
+++ b/src/modules/vendor/components/courses/ProfileFollowUp.vue
@@ -90,6 +90,7 @@ export default {
       ],
       message: '',
       loading: false,
+      courseLoading: false,
     };
   },
   computed: {
@@ -116,6 +117,9 @@ export default {
         `trainees/courses/${this.course._id}`;
     },
   },
+  async mounted () {
+    await this.refreshCourse();
+  },
   methods: {
     handleCopySuccess () {
       return NotifyPositive('Lien copié !');
@@ -123,6 +127,16 @@ export default {
     openSmsModal () {
       this.updateMessage();
       this.smsModal = true;
+    },
+    async refreshCourse () {
+      try {
+        this.courseLoading = true;
+        await this.$store.dispatch('course/getCourse', { courseId: this.profileId });
+      } catch (e) {
+        console.error(e);
+      } finally {
+        this.courseLoading = false;
+      }
     },
     updateMessage () {
       if (this.messageType === 'convocation') this.setConvocationMessage();


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : correction du bug relevé par Romain : "si je mets un numéro de téléphone invalide (par exemple : “test”), les boutons de l’onglet “suivi de la formation” ne sont pas bloqués."
=> maintenant si
