### PR TITLE
add textarea 'Objectif Pédagogique' in 'program/ProfileInfo'

### DIFF
--- a/src/modules/vendor/components/programs/ProfileInfo.vue
+++ b/src/modules/vendor/components/programs/ProfileInfo.vue
@@ -5,6 +5,10 @@
         <ni-input caption="Nom" v-model.trim="program.name" @focus="saveTmp('name')" @blur="updateProgram('name')"
           :error="$v.program.name.$error" />
       </div>
+      <div class="row gutter-profile">
+        <ni-input caption="Objectifs pédagogiques" v-model.trim="program.learningGoals" type="textarea"
+          @focus="saveTmp('learningGoals')" @blur="updateProgram('learningGoals')"/>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : sur la page d'information d'un programme dans l'onglet 'Configuration/Catalogue' du menu, je peut consulter et modifier un champs "Objectifs pédagogiques"
