### PR TITLE
COM-1167 change right event:own:edit

### DIFF
--- a/src/core/helpers/rules.js
+++ b/src/core/helpers/rules.js
@@ -2,7 +2,7 @@ import get from 'lodash/get';
 import { AUXILIARY } from '@data/constants';
 
 export default {
-  isAuxiliaryOrOwner (params) {
+  canEdit (params) {
     if (!params.user._id || !params.auxiliaryIdEvent) throw new Error('[can] wrong rule parameters');
     return get(params, 'user.role.client.name') !== AUXILIARY || params.user._id === params.auxiliaryIdEvent;
   },

--- a/src/core/helpers/rules.js
+++ b/src/core/helpers/rules.js
@@ -1,6 +1,9 @@
+import get from 'lodash/get';
+import { AUXILIARY } from '@data/constants';
+
 export default {
-  isOwner (params) {
+  isAuxiliaryOrOwner (params) {
     if (!params.user._id || !params.auxiliaryIdEvent) throw new Error('[can] wrong rule parameters');
-    return params.user._id === params.auxiliaryIdEvent;
+    return get(params, 'user.role.client.name') !== AUXILIARY || params.user._id === params.auxiliaryIdEvent;
   },
 }

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -292,9 +292,7 @@ export default {
         isAllowed = can({
           user: this.loggedUser,
           auxiliaryIdEvent: eventInfo.person._id,
-          permissions: [
-            { name: 'events:edit' },
-            { name: 'events:own:edit', rule: 'isOwner' },
+          permissions: [{ name: 'events:edit', rule: 'isAuxiliaryOrOwner' },
           ],
         });
       }

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -103,6 +103,7 @@ import {
   PLANNING_REFERENT,
   COACH_ROLES,
   NOT_INVOICED_AND_NOT_PAID,
+  AUXILIARY,
 } from '@data/constants';
 import NiPlanningEvent from 'src/modules/client/components/planning/PlanningEvent';
 import ChipAuxiliaryIndicator from 'src/modules/client/components/planning/ChipAuxiliaryIndicator';
@@ -286,14 +287,13 @@ export default {
     },
     createEvent (eventInfo) {
       let isAllowed = true;
-      if (this.personKey === 'auxiliary' && eventInfo.sectorId) { // Unassigned event
+      if (this.personKey === AUXILIARY && eventInfo.sectorId) { // Unassigned event
         isAllowed = can({ user: this.loggedUser, permissions: [{ name: 'events:edit' }] });
-      } else if (this.personKey === 'auxiliary') {
+      } else if (this.personKey === AUXILIARY) {
         isAllowed = can({
           user: this.loggedUser,
           auxiliaryIdEvent: eventInfo.person._id,
-          permissions: [{ name: 'events:edit', rule: 'isAuxiliaryOrOwner' },
-          ],
+          permissions: [{ name: 'events:edit', rule: 'canEdit' }],
         });
       }
       if (!isAllowed) return NotifyWarning('Vous n\'avez pas les droits pour réaliser cette action.');

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -381,7 +381,7 @@ export const planningActionMixin = {
       return can({
         user: this.loggedUser,
         auxiliaryIdEvent: event.auxiliary._id,
-        permissions: [{ name: 'events:edit' }, { name: 'events:own:edit', rule: 'isOwner' }],
+        permissions: [{ name: 'events:edit', rule: 'isAuxiliaryOrOwner' }],
       });
     },
     resetEditionForm () {

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -381,7 +381,7 @@ export const planningActionMixin = {
       return can({
         user: this.loggedUser,
         auxiliaryIdEvent: event.auxiliary._id,
-        permissions: [{ name: 'events:edit', rule: 'isAuxiliaryOrOwner' }],
+        permissions: [{ name: 'events:edit', rule: 'canEdit' }],
       });
     },
     resetEditionForm () {

--- a/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -158,7 +158,7 @@ export default {
       const isAllowed = can({
         user: this.loggedUser,
         auxiliaryIdEvent: this.selectedAuxiliary._id,
-        permissions: [{ name: 'events:edit', rule: 'isAuxiliaryOrOwner' }],
+        permissions: [{ name: 'events:edit', rule: 'canEdit' }],
       });
       if (!isAllowed) return NotifyWarning('Vous n\'avez pas les droits pour réaliser cette action');
 

--- a/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -158,7 +158,7 @@ export default {
       const isAllowed = can({
         user: this.loggedUser,
         auxiliaryIdEvent: this.selectedAuxiliary._id,
-        permissions: [{ name: 'events:edit' }, { name: 'events:own:edit', rule: 'isOwner' }],
+        permissions: [{ name: 'events:edit', rule: 'isAuxiliaryOrOwner' }],
       });
       if (!isAllowed) return NotifyWarning('Vous n\'avez pas les droits pour réaliser cette action');
 


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : auxiliaire/referent planning/coach

- Cas d'usage:
un auxiliaire peut creer/editer un evenement pour elle ou en 'a affecter'
un referent planning peut creer/editer n'importe quel evenement