### PR TITLE
COM-1153 print 'trade name'(formerly 'name') in companies repo

### DIFF
--- a/src/modules/vendor/pages/ni/users/companies/CompaniesDirectory.vue
+++ b/src/modules/vendor/pages/ni/users/companies/CompaniesDirectory.vue
@@ -55,7 +55,7 @@ export default {
       companies: [],
       tableLoading: false,
       visibleColumns: ['name'],
-      columns: [{ name: 'name', label: 'Nom', align: 'left', field: 'name', sortable: true }],
+      columns: [{ name: 'tradeName', label: 'Nom commercial', align: 'left', field: 'tradeName', sortable: true }],
       pagination: { sortBy: 'name', ascending: true, page: 1, rowsPerPage: 15 },
       searchStr: '',
       companyCreationModal: false,


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendor

- Périmetre roles : admin

- Cas d'usage : dans l'onglet 'Structures' les structures sont affichées dans le repo avec leur nom commercial
