### PR TITLE
COM-1163 small change in tabs title display

### DIFF
--- a/src/modules/client/components/ProfileTabs.vue
+++ b/src/modules/client/components/ProfileTabs.vue
@@ -79,6 +79,10 @@ export default {
           justify-content: start
           margin-right: 24px
           text-transform: none
+          @media (max-width: 767px)
+            max-width: 66%
+          @media (min-width: 768px)
+            max-width: 33%
           & .q-tab__content
             & .q-tab__label
               color: $dark-grey

--- a/src/modules/vendor/pages/ni/management/CourseProfile.vue
+++ b/src/modules/vendor/pages/ni/management/CourseProfile.vue
@@ -40,13 +40,13 @@ export default {
       courseName: '',
       tabsContent: [
         {
-          label: 'Organisation de la formation',
+          label: 'Organisation',
           name: 'organization',
           default: this.defaultTab === 'organization',
           component: ProfileOrganization,
         },
         {
-          label: 'Suivi de la formation',
+          label: 'Suivi',
           name: 'followUp',
           default: this.defaultTab === 'course',
           component: ProfileFollowUp,


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur / client

- Périmetre roles : admin

- Cas d'usage : dans tous les profileInfo (beneficiaires, auxiliaires, programmes, formations, structures, formateurs). Le but etait de limiter la taille d'un onglet à 33% pour que ça se sente mieux visuellement. Je suis pas hyper satisfait de mon truc:

   -> (coté écran large) il me semble (au souvenir de ce qu'en disait Romain) ce ticket devait faire en sorte de casser l'alignement des onglets avec les deux inputs dans le corps (ex page profileInfo formation, première onglet). J'ai bien résolu le truc quand on a deux onglets (ils sont limité à 33%) mais quand y en a 4, en retrouve un peu l'alignement car deux onglets font 50%.
   -> (coté ecran etroit) je sais pas si ça vous va, couper a 33% c'etait pas possible car pas assés de place pour le label, du coup 66%...

