### PR TITLE
COM-1000 rename admin client to administrateur

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -154,7 +154,7 @@ export const TRAINER = 'trainer';
 
 // ROLE TRANSLATION
 export const ROLES_TRANSLATION = {
-  [CLIENT_ADMIN]: 'Admin Client',
+  [CLIENT_ADMIN]: 'Administrateur',
   [COACH]: 'Coach',
 };
 


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client/vendeur

- Périmetre roles : admin

- Cas d'usage : sur la tableaux des coach/admin, les admin ont pour role administrateur
