### PR TITLE
COM-1198 -- NEXT SPRINT -- add last month selection on end contract

### DIFF
--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -185,10 +185,10 @@ export const payMixin = {
           format: formatPrice,
         },
       ],
-      period: 1,
+      period: 0,
       periodOptions: [
-        { label: 'Mois en cours', value: 1 },
-        { label: 'Mois précédent', value: 0 },
+        { label: 'Mois en cours', value: 0 },
+        { label: 'Mois précédent', value: 1 },
       ],
       dates: {
         startDate: this.$moment().startOf('M').toISOString(),
@@ -227,17 +227,10 @@ export const payMixin = {
 
       return parseFloat(hours).toFixed(2);
     },
-    setSelectedPeriod (value) {
-      if (value) {
-        this.dates = {
-          startDate: this.$moment().startOf('M').toISOString(),
-          endDate: this.$moment().endOf('M').toISOString(),
-        }
-      } else {
-        this.dates = {
-          startDate: this.$moment().subtract(1, 'M').startOf('M').toISOString(),
-          endDate: this.$moment().subtract(1, 'M').endOf('M').toISOString(),
-        }
+    setSelectedPeriod (offset) {
+      this.dates = {
+        startDate: this.$moment().subtract(offset, 'M').startOf('M').toISOString(),
+        endDate: this.$moment().subtract(offset, 'M').endOf('M').toISOString(),
       }
     },
     async exportToCSV () {

--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -185,6 +185,15 @@ export const payMixin = {
           format: formatPrice,
         },
       ],
+      period: 1,
+      periodOptions: [
+        { label: 'Mois en cours', value: 1 },
+        { label: 'Mois précédent', value: 0 },
+      ],
+      dates: {
+        startDate: this.$moment().startOf('M').toISOString(),
+        endDate: this.$moment().endOf('M').toISOString(),
+      },
     }
   },
   methods: {
@@ -217,6 +226,19 @@ export const payMixin = {
       if (pay.diff[key]) hours += pay.diff[key];
 
       return parseFloat(hours).toFixed(2);
+    },
+    setSelectedPeriod (value) {
+      if (value) {
+        this.dates = {
+          startDate: this.$moment().startOf('M').toISOString(),
+          endDate: this.$moment().endOf('M').toISOString(),
+        }
+      } else {
+        this.dates = {
+          startDate: this.$moment().subtract(1, 'M').startOf('M').toISOString(),
+          endDate: this.$moment().subtract(1, 'M').endOf('M').toISOString(),
+        }
+      }
     },
     async exportToCSV () {
       const csvData = [[

--- a/src/modules/client/pages/ni/auxiliaries/AuxiliaryProfile.vue
+++ b/src/modules/client/pages/ni/auxiliaries/AuxiliaryProfile.vue
@@ -63,7 +63,7 @@ export default {
       ],
     }
   },
-  async mounted () {
+  async created () {
     await this.$store.dispatch('rh/getUserProfile', { userId: this.auxiliaryId });
   },
   watch: {

--- a/src/modules/client/pages/ni/pay/ContractEnds.vue
+++ b/src/modules/client/pages/ni/pay/ContractEnds.vue
@@ -3,7 +3,6 @@
     <ni-title-header title="Fin de contrats" padding slots>
       <template slot="content">
         <div class=" col-xs-12 row items-baseline justify-end fill-width">
-          <div>Afficher</div>
           <div class="col-xs-12 col-sm-6 col-md-3">
             <ni-select class="q-pl-sm" :options="periodOptions" v-model="period" separator in-form />
           </div>
@@ -100,7 +99,6 @@ export default {
     'ni-pay-surcharge-details-modal': PaySurchargeDetailsModal,
     'ni-title-header': TitleHeader,
     'ni-select': Select,
-
   },
   data () {
     return {

--- a/src/modules/client/pages/ni/pay/ContractEnds.vue
+++ b/src/modules/client/pages/ni/pay/ContractEnds.vue
@@ -1,8 +1,15 @@
 <template>
   <q-page class="client-background q-pb-xl">
-    <div class="title-padding">
-      <h4>Fins de contrats</h4>
-    </div>
+    <ni-title-header title="Fin de contrats" padding slots>
+      <template slot="content">
+        <div class=" col-xs-12 row items-baseline justify-end fill-width">
+          <div>Afficher</div>
+          <div class="col-xs-12 col-sm-6 col-md-3">
+            <ni-select class="q-pl-sm" :options="periodOptions" v-model="period" separator in-form />
+          </div>
+        </div>
+      </template>
+    </ni-title-header>
     <ni-large-table :data="draftFinalPay" :columns="columns" :loading="tableLoading" :pagination.sync="pagination"
       row-key="auxiliaryId" selection="multiple" :selected.sync="selected">
       <template v-slot:header="{ props }" >
@@ -76,6 +83,8 @@
 import FinalPay from '@api/FinalPay';
 import EditableTd from '@components/table/EditableTd';
 import LargeTable from '@components/table/LargeTable';
+import TitleHeader from '@components/TitleHeader'
+import Select from '@components/form/Select';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
 import { payMixin } from 'src/modules/client/mixins/payMixin';
 import { editableTdMixin } from 'src/modules/client/mixins/editableTdMixin';
@@ -89,6 +98,9 @@ export default {
     'ni-editable-td': EditableTd,
     'ni-large-table': LargeTable,
     'ni-pay-surcharge-details-modal': PaySurchargeDetailsModal,
+    'ni-title-header': TitleHeader,
+    'ni-select': Select,
+
   },
   data () {
     return {
@@ -107,7 +119,14 @@ export default {
       return this.selected.length > 0;
     },
   },
-  async mounted () {
+  watch: {
+    async period (value) {
+      this.selected = [];
+      this.setSelectedPeriod(value);
+      await this.refreshFinalPay();
+    },
+  },
+  async created () {
     this.tableLoading = true;
     await this.refreshFinalPay();
     this.tableLoading = false;
@@ -115,10 +134,7 @@ export default {
   methods: {
     async refreshFinalPay () {
       try {
-        const draftFinalPay = await FinalPay.getDraftFinalPay({
-          startDate: this.$moment().startOf('M').toISOString(),
-          endDate: this.$moment().endOf('M').toISOString(),
-        });
+        const draftFinalPay = await FinalPay.getDraftFinalPay(this.dates);
         this.draftFinalPay = draftFinalPay.map(dp => ({
           ...dp,
           hoursCounterEdition: false,
@@ -132,7 +148,6 @@ export default {
         console.error(e);
       }
     },
-    // Surcharge modal
     openSurchargeDetailModal (id, details) {
       const draft = this.draftFinalPay.find(ds => ds.auxiliary._id === id);
       if (!draft) return;
@@ -145,7 +160,6 @@ export default {
       this.pay = {};
       this.surchargeDetailKey = '';
     },
-    // Creation
     validateFinalPayListCreation () {
       this.$q.dialog({
         title: 'Confirmation',

--- a/src/modules/client/pages/ni/pay/ToPay.vue
+++ b/src/modules/client/pages/ni/pay/ToPay.vue
@@ -157,15 +157,6 @@ export default {
         { label: 'Transport', value: 'transport' },
         { label: 'Autres frais', value: 'otherFees' },
       ],
-      period: 1,
-      periodOptions: [
-        { label: 'Mois en cours', value: 1 },
-        { label: 'Mois précédent', value: 0 },
-      ],
-      dates: {
-        startDate: this.$moment().startOf('M').toISOString(),
-        endDate: this.$moment().endOf('M').toISOString(),
-      },
       sortOption: 'auxiliary',
     };
   },
@@ -192,17 +183,7 @@ export default {
     },
     async period (value) {
       this.selected = [];
-      if (value) {
-        this.dates = {
-          startDate: this.$moment().startOf('M').toISOString(),
-          endDate: this.$moment().endOf('M').toISOString(),
-        }
-      } else {
-        this.dates = {
-          startDate: this.$moment().subtract(1, 'M').startOf('M').toISOString(),
-          endDate: this.$moment().subtract(1, 'M').endOf('M').toISOString(),
-        }
-      }
+      this.setSelectedPeriod(value);
       await this.refreshDraftPay();
     },
   },
@@ -231,7 +212,6 @@ export default {
         this.tableLoading = false;
       }
     },
-    // Surcharge modal
     openSurchargeDetailModal (id, details) {
       const draft = this.draftPay.find(dp => dp.auxiliary._id === id);
       if (!draft) return;
@@ -244,7 +224,6 @@ export default {
       this.pay = {};
       this.surchargeDetailKey = '';
     },
-    // Creation
     validateCreation () {
       this.$q.dialog({
         title: 'Confirmation',


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : sur la page ni/pay/contract-ends (STC) je peux afficher les fin de contrat du mois précedent

note : j'ai du mal a voir ce qu'il faut mutualiser ou pas dans les mixins, j'aurai envie de le faire aussi pour validateCreation et createList (qui existe dans ToPay et ContractEnd)... mais j'attend vos retours.
