### PR TITLE
Com-1201 change default page for coach/admin without erp

### DIFF
--- a/src/modules/client/router/routes.js
+++ b/src/modules/client/router/routes.js
@@ -37,7 +37,7 @@ const routes = [
         }
         if (COACH_ROLES.includes(userClientRole)) {
           if (get(company, 'subscriptions.erp')) return next({ name: 'ni auxiliaries' });
-          return next({ name: 'account client', params: { id: loggedUser._id } });
+          return next({ name: 'ni courses' });
         }
         return next({ name: '404' });
       } catch (e) {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : admin/coach sans erp

- Cas d'usage : lorsqu'un admin/coach sans erp se connecte a l'application, il arrive sur la page des formations. 
