### PR TITLE
COM-1173 add message if can't download completion certificate

### DIFF
--- a/src/modules/vendor/components/courses/ProfileFollowUp.vue
+++ b/src/modules/vendor/components/courses/ProfileFollowUp.vue
@@ -7,6 +7,12 @@
         {{ followUpMissingInfo.join(', ') }}.
       </div>
     </q-banner>
+    <q-banner v-if="!get(this.course, 'program.learningGoals')" class="full-width warning q-mb-md" dense>
+      <q-icon size="sm" name="warning" />
+      <div>
+        Merci de renseigner les objectifs pédagogiques du programme pour pouvoir télécharger les attestations de fin de formation.
+      </div>
+    </q-banner>
     <div class="q-mb-xl">
       <p class="text-weight-bold">Actions utiles</p>
       <div class="course-link">
@@ -46,12 +52,7 @@
             flat dense type="a" target="_blank"
             :href="!disableDownloadCompletionCertificates && downloadCompletionCertificates()" />
         </q-item-section>
-        <q-item-section>
-          <q-item-label>Télécharger les attestations de fin de formation</q-item-label>
-          <q-item-label v-if="!get(this.course, 'program.learningGoals')" caption>
-            Merci de renseigner les objectifs pédagogiques du programme pour pouvoir télécharger les attestations de fin de formation.
-          </q-item-label>
-        </q-item-section>
+        <q-item-section>Télécharger les attestations de fin de formation</q-item-section>
       </q-item>
     </div>
     <div class="q-mb-xl">

--- a/src/modules/vendor/components/courses/ProfileFollowUp.vue
+++ b/src/modules/vendor/components/courses/ProfileFollowUp.vue
@@ -46,7 +46,12 @@
             flat dense type="a" target="_blank"
             :href="!disableDownloadCompletionCertificates && downloadCompletionCertificates()" />
         </q-item-section>
-        <q-item-section>Télécharger les attestations de fin de formation</q-item-section>
+        <q-item-section>
+          <q-item-label>Télécharger les attestations de fin de formation</q-item-label>
+          <q-item-label v-if="!get(this.course, 'program.learningGoals')" caption>
+            Merci de renseigner les objectifs pédagogiques du programme pour pouvoir télécharger les attestations de fin de formation.
+          </q-item-label>
+        </q-item-section>
       </q-item>
     </div>
     <div class="q-mb-xl">
@@ -180,6 +185,7 @@ export default {
     },
   },
   methods: {
+    get,
     getType (value) {
       const type = this.messageTypeOptions.find(type => type.value === value);
       return type ? type.label : '';


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : admin/rof

- Cas d'usage : lorsque les objectifs pedagogiques du programme ne sont pas defini, j'ai un message m'expliquant pourquoi je ne peux pas telecharger les attestations de fin de formation
