### PR TITLE
fix-warning-msg

### DIFF
--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -195,8 +195,8 @@ export default {
       if (!this.course.trainer) missingInfo.push('le formateur');
       if (!this.course.trainees || !this.course.trainees.length) missingInfo.push('le ou les stagiaire(s)');
       if (!this.course.slots || !this.course.slots.length) missingInfo.push('le ou les créneau(x)');
-      if (!get(this.course, 'contact.name')) missingInfo.push('le nom du référent structure');
-      if (!get(this.course, 'contact.phone')) missingInfo.push('le numéro du référent structure');
+      if (!get(this.course, 'contact.name')) missingInfo.push('le nom du contact pour la formation');
+      if (!get(this.course, 'contact.phone')) missingInfo.push('le numéro du contact pour la formation');
 
       return missingInfo;
     },


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client/vendeur

- Périmetre roles : admin

- Cas d'usage : enlever l'ancine nom 'referant formation' dans le champs du warning de profilFollowUp
