### PR TITLE
COM-1250 - update pay export

### DIFF
--- a/src/core/components/TitleHeader.vue
+++ b/src/core/components/TitleHeader.vue
@@ -1,8 +1,10 @@
 <template functional>
   <div class="row items-start" :class="[data.class, data.staticClass, props.padding && 'title-padding']">
     <div class="col-xs-12 col-md-4 row">
-      <h4>{{ props.title }}</h4>
-      <slot name="title" />
+      <h4>
+        {{ props.title }}
+        <slot name="title" />
+      </h4>
     </div>
     <div class="col-xs-12 col-md-8 row justify-end">
       <slot name="content" />


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - non pertinent

- Périmetre interface : Client

- Périmetre roles : Admin

- Cas d'usage : Dans l'export temporaire sur la page de la paie mensuelle : 
Separer en deux colonnes Nom et prenom de l'auxiliaire
Mettre des , plutot que des . dans les nombres
Enlever les retours de lignes dans le detail
