### PR TITLE
COM-1282 change UI for send sms part on profile follow up

### DIFF
--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -45,13 +45,6 @@
       </div>
       <q-item>
         <q-item-section side>
-          <q-btn color="primary" size="sm" :disable="disabledFollowUp || isFinished" icon="mdi-cellphone-message" flat
-            dense @click="openSmsModal" />
-        </q-item-section>
-        <q-item-section>Envoyer un SMS de convocation ou de rappel aux stagiaires</q-item-section>
-      </q-item>
-      <q-item>
-        <q-item-section side>
           <q-btn color="primary" size="sm" :disable="disabledFollowUp" icon="file_download" flat dense
             type="a" :href="!disabledFollowUp && downloadAttendanceSheet()" target="_blank" />
         </q-item-section>
@@ -67,8 +60,9 @@
       </q-item>
     </div>
     <div class="q-mb-xl">
-      <p class="text-weight-bold">Historique d'envoi</p>
-      <ni-responsive-table :data="smsSent" :columns="smsSentColumns" :pagination.sync="pagination"
+      <p class="text-weight-bold">Envoi de SMS</p>
+      <p>Historique d'envoi </p>
+      <ni-responsive-table :data="smsSent" :columns="smsSentColumns" :pagination.sync="pagination" class="q-mb-md"
         :loading="smsLoading">
         <template v-slot:body="{ props }">
           <q-tr :props="props">
@@ -85,6 +79,13 @@
           </q-tr>
         </template>
       </ni-responsive-table>
+      <q-item>
+        <q-item-section side>
+          <q-btn color="primary" size="sm" :disable="disabledFollowUp || isFinished" icon="mdi-cellphone-message" flat
+            dense @click="openSmsModal" />
+        </q-item-section>
+        <q-item-section>Envoyer un SMS de convocation ou de rappel aux stagiaires</q-item-section>
+      </q-item>
     </div>
 
     <!-- Modal envoi message -->
@@ -357,4 +358,6 @@ export default {
       &-disabled
         opacity: 0.7 !important;
         cursor: not-allowed !important
+.q-item
+  padding-left: 0px;
 </style>

--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -63,7 +63,7 @@
       <p class="text-weight-bold">Envoi de SMS</p>
       <p>Historique d'envoi </p>
       <ni-responsive-table :data="smsSent" :columns="smsSentColumns" :pagination.sync="pagination" class="q-mb-md"
-        :loading="smsLoading">
+        :loading="smsLoading" :hide-bottom="!!smsSent.length">
         <template v-slot:body="{ props }">
           <q-tr :props="props">
             <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
@@ -77,6 +77,12 @@
               <template v-else>{{ col.value }}</template>
             </q-td>
           </q-tr>
+        </template>
+        <template v-slot:no-data="props">
+          <div v-show="!loading" class="full-width row q-gutter-sm">
+            <q-icon :name="props.icon" size="2em" />
+            <span>Pas de données disponibles</span>
+          </div>
         </template>
       </ni-responsive-table>
       <q-item>

--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -63,7 +63,7 @@
       <p class="text-weight-bold">Envoi de SMS</p>
       <p>Historique d'envoi </p>
       <ni-simple-table :data="smsSent" :columns="smsSentColumns" :pagination.sync="pagination" class="q-mb-md"
-        :loading="smsLoading" :show-bottom="!smsSent.length">
+        :loading="smsLoading">
         <template v-slot:body="{ props }">
           <q-tr :props="props">
             <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"

--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -62,8 +62,8 @@
     <div class="q-mb-xl">
       <p class="text-weight-bold">Envoi de SMS</p>
       <p>Historique d'envoi </p>
-      <ni-responsive-table :data="smsSent" :columns="smsSentColumns" :pagination.sync="pagination" class="q-mb-md"
-        :loading="smsLoading" :hide-bottom="!!smsSent.length">
+      <ni-simple-table :data="smsSent" :columns="smsSentColumns" :pagination.sync="pagination" class="q-mb-md"
+        :loading="smsLoading" :show-bottom="!smsSent.length">
         <template v-slot:body="{ props }">
           <q-tr :props="props">
             <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
@@ -78,13 +78,7 @@
             </q-td>
           </q-tr>
         </template>
-        <template v-slot:no-data="props">
-          <div v-show="!loading" class="full-width row q-gutter-sm">
-            <q-icon :name="props.icon" size="2em" />
-            <span>Pas de données disponibles</span>
-          </div>
-        </template>
-      </ni-responsive-table>
+      </ni-simple-table>
       <q-item>
         <q-item-section side>
           <q-btn color="primary" size="sm" :disable="disabledFollowUp || isFinished" icon="mdi-cellphone-message" flat
@@ -128,7 +122,7 @@ import Input from '@components/form/Input';
 import Select from '@components/form/Select';
 import Modal from '@components/modal/Modal';
 import Banner from '@components/Banner';
-import ResponsiveTable from '@components/table/ResponsiveTable';
+import SimpleTable from '@components/table/SimpleTable';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
 import { CONVOCATION, REMINDER, REQUIRED_LABEL } from '@data/constants';
 import { frPhoneNumber } from '@helpers/vuelidateCustomVal.js';
@@ -141,7 +135,7 @@ export default {
     'ni-input': Input,
     'ni-select': Select,
     'ni-modal': Modal,
-    'ni-responsive-table': ResponsiveTable,
+    'ni-simple-table': SimpleTable,
     'ni-banner': Banner,
   },
   mixins: [courseMixin],

--- a/src/core/components/table/LargeTable.vue
+++ b/src/core/components/table/LargeTable.vue
@@ -18,7 +18,7 @@
         <ni-pagination :props="props" :pagination.sync="pagination" :data="data"/>
       </template>
       <template v-slot:no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm">
+        <div v-show="!loading" class="full-width row q-gutter-sm grey-text">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/LargeTable.vue
+++ b/src/core/components/table/LargeTable.vue
@@ -17,9 +17,8 @@
       <template v-slot:bottom="props">
         <ni-pagination :props="props" :pagination.sync="pagination" :data="data"/>
       </template>
-      <template v-slot:no-data="props">
+      <template v-slot:no-data>
         <div v-show="!loading" class="full-width row q-gutter-sm">
-          <q-icon :name="props.icon" size="2em" />
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/ResponsiveTable.vue
+++ b/src/core/components/table/ResponsiveTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :row-key="rowKey" :pagination="pagination"
-      binary-state-sort :visible-columns="visibleColumns" flat :separator="separator" :hide-bottom="!!data.length"
+      binary-state-sort :visible-columns="visibleColumns" flat :separator="separator" :hide-bottom="hideBottom"
       :rows-per-page-options="rowsPerPageOptions" class="table-responsive q-pa-sm" v-on="$listeners">
       <template v-slot:header="props">
         <slot name="header" :props="props">
@@ -46,6 +46,7 @@ export default {
     visibleColumns: Array,
     separator: { type: String, default: 'horizontal' },
     loading: { type: Boolean, default: false },
+    hideBottom: { type: Boolean, default: true },
   },
 }
 </script>

--- a/src/core/components/table/ResponsiveTable.vue
+++ b/src/core/components/table/ResponsiveTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative-position table-spinner-container">
-    <q-table v-if="!loading" :data="data" :columns="columns" :row-key="rowKey" :pagination="pagination" hide-bottom
-      binary-state-sort :visible-columns="visibleColumns" flat :separator="separator"
+    <q-table v-if="!loading" :data="data" :columns="columns" :row-key="rowKey" :pagination="pagination"
+      binary-state-sort :visible-columns="visibleColumns" flat :separator="separator" :hide-bottom="!!data.length"
       :rows-per-page-options="rowsPerPageOptions" class="table-responsive q-pa-sm" v-on="$listeners">
       <template v-slot:header="props">
         <slot name="header" :props="props">
@@ -19,6 +19,12 @@
             </q-td>
           </q-tr>
         </slot>
+      </template>
+      <template v-slot:no-data="props">
+        <div v-show="!loading" class="full-width row q-gutter-sm">
+          <q-icon :name="props.icon" size="2em" />
+          <span>Pas de données disponibles</span>
+        </div>
       </template>
     </q-table>
     <div v-else class="loading-container" />

--- a/src/core/components/table/ResponsiveTable.vue
+++ b/src/core/components/table/ResponsiveTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :row-key="rowKey" :pagination="pagination"
-      binary-state-sort :visible-columns="visibleColumns" flat :separator="separator" :hide-bottom="hideBottom"
+      binary-state-sort :visible-columns="visibleColumns" flat :separator="separator" hide-bottom
       :rows-per-page-options="rowsPerPageOptions" class="table-responsive q-pa-sm" v-on="$listeners">
       <template v-slot:header="props">
         <slot name="header" :props="props">
@@ -19,12 +19,6 @@
             </q-td>
           </q-tr>
         </slot>
-      </template>
-      <template v-slot:no-data="props">
-        <div v-show="!loading" class="full-width row q-gutter-sm">
-          <q-icon :name="props.icon" size="2em" />
-          <span>Pas de données disponibles</span>
-        </div>
       </template>
     </q-table>
     <div v-else class="loading-container" />
@@ -46,7 +40,6 @@ export default {
     visibleColumns: Array,
     separator: { type: String, default: 'horizontal' },
     loading: { type: Boolean, default: false },
-    hideBottom: { type: Boolean, default: true },
   },
 }
 </script>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -19,9 +19,8 @@
       <template v-slot:bottom-row="props">
         <slot name="bottom-row" :props="props" />
       </template>
-      <template v-slot:no-data="props">
+      <template v-slot:no-data>
         <div v-show="!loading" class="full-width row q-gutter-sm">
-          <q-icon :name="props.icon" size="2em" />
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -20,7 +20,7 @@
         <slot name="bottom-row" :props="props" />
       </template>
       <template v-slot:no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm">
+        <div v-show="!loading" class="full-width row q-gutter-sm grey-text">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :row-key="rowKey" flat :pagination="pagination"
-      :hide-bottom="!showBottom && pagination.rowsPerPage === 0" :visible-columns="visibleColumns"
+      :hide-bottom="!!data.length && pagination.rowsPerPage === 0" :visible-columns="visibleColumns"
       :rows-per-page-options="[]" v-on="$listeners" :class="[{'table-simple': responsive }]">
       <template v-if="$scopedSlots['top-row']" v-slot:top-row="props">
         <slot name="top-row" :props="props" />
@@ -43,7 +43,6 @@ export default {
     pagination: { type: Object, default: () => ({ rowsPerPage: 0 }) },
     loading: { type: Boolean, default: false },
     responsive: { type: Boolean, default: true },
-    showBottom: { type: Boolean, default: false },
   },
 }
 </script>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :row-key="rowKey" flat :pagination="pagination"
-      :hide-bottom="pagination.rowsPerPage === 0" :visible-columns="visibleColumns" :rows-per-page-options="[]"
-      v-on="$listeners" :class="[{'table-simple': responsive }]">
+      :hide-bottom="!showBottom && pagination.rowsPerPage === 0" :visible-columns="visibleColumns"
+      :rows-per-page-options="[]" v-on="$listeners" :class="[{'table-simple': responsive }]">
       <template v-if="$scopedSlots['top-row']" v-slot:top-row="props">
         <slot name="top-row" :props="props" />
       </template>
@@ -18,6 +18,12 @@
       </template>
       <template v-slot:bottom-row="props">
         <slot name="bottom-row" :props="props" />
+      </template>
+      <template v-slot:no-data="props">
+        <div v-show="!loading" class="full-width row q-gutter-sm">
+          <q-icon :name="props.icon" size="2em" />
+          <span>Pas de données disponibles</span>
+        </div>
       </template>
     </q-table>
     <div v-else class="loading-container" />
@@ -38,6 +44,7 @@ export default {
     pagination: { type: Object, default: () => ({ rowsPerPage: 0 }) },
     loading: { type: Boolean, default: false },
     responsive: { type: Boolean, default: true },
+    showBottom: { type: Boolean, default: false },
   },
 }
 </script>

--- a/src/core/components/table/TableList.vue
+++ b/src/core/components/table/TableList.vue
@@ -15,7 +15,7 @@
         </q-tr>
       </template>
       <template v-slot:no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm">
+        <div v-show="!loading" class="full-width row q-gutter-sm grey-text">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/TableList.vue
+++ b/src/core/components/table/TableList.vue
@@ -14,9 +14,8 @@
           </q-td>
         </q-tr>
       </template>
-      <template v-slot:no-data="props">
+      <template v-slot:no-data>
         <div v-show="!loading" class="full-width row q-gutter-sm">
-          <q-icon :name="props.icon" size="2em" />
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -94,3 +94,6 @@ div h4:only-child
   background-color: $middle-grey
 .beige-background
   background-color: $middle-beige
+
+.grey-text
+  color: $grey;

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -96,4 +96,4 @@ div h4:only-child
   background-color: $middle-beige
 
 .grey-text
-  color: $grey;
+  color: $dark-grey;


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client/vendeur

- Périmetre roles : admin

- Cas d'usage : changement UI pour profilefollowup des formations (partie SMS)
Pour que ca rende bien sur mobile j'ai ajoute un message lorsqu'il n'y avait pas de données. Dites moi ce que vous en pensez puisque du coup le responsive table n'est plus pareil partout.