### PR TITLE
COM-1297 add banner if missing trainees phone number

### DIFF
--- a/src/core/components/Banner.vue
+++ b/src/core/components/Banner.vue
@@ -1,6 +1,6 @@
 <template>
   <q-banner :class="`full-width warning q-mb-md ${backgroundClass}`" dense>
-    <slot name="icon"><q-icon size="sm" name="warning" /></slot>
+    <q-icon size="sm" :name="icon" />
     <div><slot name="message" /></div>
   </q-banner>
 </template>
@@ -11,7 +11,7 @@ import { CLIENT, VENDOR } from '@data/constants';
 export default {
   name: 'Banner',
   props: {
-    icon: { type: String, default: 'icon' },
+    icon: { type: String, default: 'warning' },
   },
   data () {
     const interfaceType = /\/ad\//.test(this.$router.currentRoute.path) ? VENDOR : CLIENT;

--- a/src/core/components/Banner.vue
+++ b/src/core/components/Banner.vue
@@ -1,6 +1,6 @@
 <template>
   <q-banner :class="`full-width warning q-mb-md ${backgroundClass}`" dense>
-    <q-icon size="sm" name="warning" />
+    <slot name="icon"><q-icon size="sm" name="warning" /></slot>
     <div><slot name="message" /></div>
   </q-banner>
 </template>

--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -79,6 +79,13 @@
           </q-tr>
         </template>
       </ni-simple-table>
+      <ni-banner v-if="missingTraineesPhone.length">
+        <template v-slot:icon><q-icon size="sm" name="info" /></template>
+        <template v-slot:message>
+          Il manque le(s) numéro(s) de téléphone de {{ missingTraineesPhone.length }} stagiaire(s) sur {{course.trainees.length}}:
+          {{ missingTraineesPhone.join(', ') }}.
+        </template>
+      </ni-banner>
       <q-item>
         <q-item-section side>
           <q-btn color="primary" size="sm" :disable="disabledFollowUp || isFinished" icon="mdi-cellphone-message" flat
@@ -236,6 +243,10 @@ export default {
       return this.courseNotStartedYet
         ? this.messageTypeOptions
         : this.messageTypeOptions.filter(t => t.value === REMINDER);
+    },
+    missingTraineesPhone () {
+      return this.course.trainees.filter(trainee => !get(trainee, 'contact.phone'))
+        .map(trainee => formatIdentity(trainee.identity, 'FL'));
     },
   },
   methods: {

--- a/src/core/components/courses/ProfileFollowUp.vue
+++ b/src/core/components/courses/ProfileFollowUp.vue
@@ -79,10 +79,9 @@
           </q-tr>
         </template>
       </ni-simple-table>
-      <ni-banner v-if="missingTraineesPhone.length">
-        <template v-slot:icon><q-icon size="sm" name="info" /></template>
+      <ni-banner v-if="missingTraineesPhone.length" icon="info_outline">
         <template v-slot:message>
-          Il manque le(s) numéro(s) de téléphone de {{ missingTraineesPhone.length }} stagiaire(s) sur {{course.trainees.length}}:
+          Il manque le(s) numéro(s) de téléphone de {{ missingTraineesPhone.length }} stagiaire(s) sur {{course.trainees.length}} :
           {{ missingTraineesPhone.join(', ') }}.
         </template>
       </ni-banner>


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : les deux

- Périmetre roles : coach admin rof formateur

- Cas d'usage : Affichage d'une baniere s'il manque des numeros de telephone de stagiaire.
Je n'ai que change le logo de la baniere pour la differencier des autres. J'ai essaye d'ajouter de l'opacité mais ca ne rendait pas tres bien et je ne sais pas si changer la couleur est une bonne idee. Dites moi ce que vous en pensez :) 
