### PR TITLE
close modal if helper is created even if email is not sent

### DIFF
--- a/src/modules/client/mixins/helperMixin.js
+++ b/src/modules/client/mixins/helperMixin.js
@@ -120,17 +120,24 @@ export const helperMixin = {
         const payload = await this.formatHelper();
         await Users.create(pickBy(payload));
         NotifyPositive('Aidant créé');
-
-        await Email.sendWelcome({ email: this.newHelper.local.email, type: HELPER });
-        NotifyPositive('Email envoyé');
-
         await this.getUserHelpers();
         this.openNewHelperModal = false;
+
+        await this.sendWelcome();
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors de la création de l\'aidant.');
       } finally {
         this.loading = false;
+      }
+    },
+    async sendWelcome () {
+      try {
+        await Email.sendWelcome({ email: this.newHelper.local.email, type: HELPER });
+        NotifyPositive('Email envoyé');
+      } catch (e) {
+        console.error(e);
+        NotifyNegative('Erreur lors de l\'envoi du mail.');
       }
     },
     async nextStep () {

--- a/src/modules/vendor/pages/ni/users/trainers/TrainersDirectory.vue
+++ b/src/modules/vendor/pages/ni/users/trainers/TrainersDirectory.vue
@@ -150,8 +150,7 @@ export default {
         this.trainerCreationModal = false;
         NotifyPositive('Formateur créé.')
 
-        await Email.sendWelcome({ email: this.newTrainer.local.email, type: TRAINER });
-        NotifyPositive('Email envoyé');
+        this.sendWelcome();
         await this.refreshTrainers();
       } catch (e) {
         console.error(e);
@@ -159,6 +158,15 @@ export default {
         NotifyNegative('Erreur lors de la création du formateur.');
       } finally {
         this.modalLoading = false;
+      }
+    },
+    async sendWelcome () {
+      try {
+        await Email.sendWelcome({ email: this.newTrainer.local.email, type: TRAINER });
+        NotifyPositive('Email envoyé');
+      } catch (e) {
+        console.error(e);
+        NotifyNegative('Erreur lors de l\'envoi du mail.');
       }
     },
   },

--- a/src/modules/vendor/pages/ni/users/trainers/TrainersDirectory.vue
+++ b/src/modules/vendor/pages/ni/users/trainers/TrainersDirectory.vue
@@ -150,7 +150,7 @@ export default {
         this.trainerCreationModal = false;
         NotifyPositive('Formateur créé.')
 
-        this.sendWelcome();
+        await this.sendWelcome();
         await this.refreshTrainers();
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : coach

- Cas d'usage : lorsque l'on cree un aidant et qu'il y a un soucis sur l'envoie d'email, la modale se ferme et le tableau des aidants mis a jour. Idem pour formateur.
