### PR TITLE
COM-1342 - add missing trim on email

### DIFF
--- a/src/core/components/table/CoachList.vue
+++ b/src/core/components/table/CoachList.vue
@@ -37,7 +37,7 @@
       <template slot="title">
         Ajouter un <span class="text-weight-bold">utilisateur</span>
       </template>
-      <ni-input :disable="!firstStep" in-modal v-model="newUser.local.email" :error="$v.newUser.local.email.$error"
+      <ni-input :disable="!firstStep" in-modal v-model.trim="newUser.local.email" :error="$v.newUser.local.email.$error"
         caption="Email" @blur="$v.newUser.local.email.$touch" :error-message="emailError($v.newUser)" required-field />
       <ni-select :disable="!firstStep" in-modal caption="Role" :options="roleOptions" v-model="newUser.role"
         :error="$v.newUser.role.$error" @blur="$v.newUser.role.$touch" :last="firstStep" required-field />

--- a/src/modules/client/components/customers/AddHelperModal.vue
+++ b/src/modules/client/components/customers/AddHelperModal.vue
@@ -3,8 +3,8 @@
     <template slot="title">
       Ajouter un <span class="text-weight-bold">aidant</span>
     </template>
-    <ni-input :disable="!firstStep" in-modal v-model="newHelper.local.email" :error="validations.local.email.$error"
-      caption="Email" @blur="validations.local.email.$touch" :error-message="emailError" required-field
+    <ni-input :disable="!firstStep" in-modal v-model.trim="newHelper.local.email" caption="Email" required-field
+      :error="validations.local.email.$error" @blur="validations.local.email.$touch" :error-message="emailError"
       :last="firstStep" />
     <template v-if="!firstStep">
       <ni-input in-modal v-model="newHelper.identity.firstname" caption="Prénom" />

--- a/src/modules/client/pages/ni/auxiliaries/Directory.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Directory.vue
@@ -29,8 +29,9 @@
       <template slot="title">
         Créer une nouvelle <span class="text-weight-bold">fiche auxiliaire</span>
       </template>
-      <ni-input in-modal :disable="!firstStep" v-model="newUser.local.email" :error="$v.newUser.local.email.$error"
-        @blur="$v.newUser.local.email.$touch" :error-message="emailError($v.newUser)" caption="Email" required-field />
+      <ni-input in-modal :disable="!firstStep" v-model.trim="newUser.local.email" caption="Email"
+        :error="$v.newUser.local.email.$error" @blur="$v.newUser.local.email.$touch" required-field
+        :error-message="emailError($v.newUser)"  />
       <template v-if="!firstStep">
         <ni-select in-modal v-model="newUser.identity.title" :options="civilityOptions" caption="Civilité"
           required-field :error="$v.newUser.identity.title.$error" @blur="$v.newUser.identity.title.$touch" />


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : 

- Périmetre roles : 

- Cas d'usage : retirer les espaces de debut et de fin sur les emails des stagiaires, auxiliaires et aidants pour eviter le message d'erreur
