### PR TITLE
COM-1358 fix display switch interface when uer does not have two roles

### DIFF
--- a/src/core/components/menu/SideMenuFooter.vue
+++ b/src/core/components/menu/SideMenuFooter.vue
@@ -64,7 +64,7 @@ export default {
           '/favicon-32x32.png';
     },
     accessBothInterface () {
-      return get(this.loggedUser, 'role.client') && get(this.loggedUser, 'role.vendor');
+      return get(this.loggedUser, 'role.client.name') && get(this.loggedUser, 'role.vendor.name');
     },
   },
   methods: {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : vendeur

- Périmetre roles : tous

- Cas d'usage : lorsque je n'ai qu'un role vendeur, je n'ai plus acces au bouton pour changer d'interface
