### PR TITLE
COM-1392 weird fix ...

### DIFF
--- a/src/modules/client/components/planning/ChipsAutocomplete.vue
+++ b/src/modules/client/components/planning/ChipsAutocomplete.vue
@@ -38,7 +38,7 @@ export default {
       this.$emit('input', el);
     },
     removeEvent (el) {
-      this.$store.dispatch('planning/setElementToRemove', this.filters.find(elem => elem.value === el.value[0]));
+      this.$store.dispatch('planning/setElementToRemove', this.filters.find(elem => elem.value === el.value));
     },
     async search (terms, done) {
       try {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile np

- Périmetre interface : vendeur

- Périmetre roles : admin/ auxiliaire

- Cas d'usage : fix du planning. En fait, c'est dû a la nouvelle version de quasar. Du coup pour la mep il faut verifier que ca upgrade bien, car Chloé avait fait des "npm i" en local sans que quasar ne se maj
