### PR TITLE
COM-1395 avoid clicking on event to open creation modal

### DIFF
--- a/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
+++ b/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
@@ -52,7 +52,7 @@ loggedUsers.forEach(user => describe(`Auxiliary planning - actions - ${user.role
     cy.get('[data-cy=planning-search]').eq(1).type('{backspace}Auxiliary TEST{downarrow}{enter}');
     cy.get('[data-cy=planning-event]').should('have.length', 1);
 
-    cy.get('[data-cy=planning-cell]').eq(0).click();
+    cy.get('[data-cy=planning-cell]').eq(0).click('bottom');
     cy.get('[data-cy=event-creation-customer]').eq(0).type('Romain{downarrow}{enter}');
     cy.get('[data-cy=event-creation-button]').click();
     cy.get('[data-cy=planning-event]').should('have.length', 2);


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile np

- Périmetre interface : client

- Périmetre roles : 

- Cas d'usage : l'evenement déjà existant est populate a la date du jour, donc si on execute le test un lundi on se retrouve a cliquer sur l'evenement au lieu de cliquer sur le fond blanc du planning (pour ouvrir la modale de creation on clique sur planning-cell eq(0)).
