### PR TITLE
COM-1398 change alenviAxios + login

### DIFF
--- a/src/core/api/ressources/alenviAxios.js
+++ b/src/core/api/ressources/alenviAxios.js
@@ -9,17 +9,19 @@ const instance = axios.create({
 });
 
 instance.interceptors.request.use(async function (config) {
+  if (!Cookies.get('refresh_token')) {
+    logOutAndRedirectToLogin();
+    throw new Error('No refresh token');
+  }
+
   if (!Cookies.get('alenvi_token')) {
     const refresh = await refreshAlenviCookies();
     if (!refresh) {
       logOutAndRedirectToLogin();
-      return config;
+      throw new Error('No alenvi token');
     }
   }
-  if (!Cookies.get('refresh_token')) {
-    logOutAndRedirectToLogin();
-    return config;
-  }
+
   // Headers for request only to API (alenvi)
   config.headers.common['x-access-token'] = Cookies.get('alenvi_token');
   return config;

--- a/src/core/mixins/logInMixin.js
+++ b/src/core/mixins/logInMixin.js
@@ -1,4 +1,4 @@
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 import Users from '@api/Users';
 
 export const logInMixin = {
@@ -7,6 +7,7 @@ export const logInMixin = {
       clientRole: 'main/getClientRole',
       vendorRole: 'main/getVendorRole',
     }),
+    ...mapState('main', ['loggedUser']),
   },
   methods: {
     async logInUser (authenticationPayload) {
@@ -18,7 +19,7 @@ export const logInMixin = {
       const options = {
         path: '/',
         expires: expiresInDays,
-        secure: process.env.NODE_ENV === 'production',
+        secure: process.env.NODE_ENV !== 'development',
         sameSite: 'Strict',
       };
       this.$q.cookies.set('alenvi_token', auth.token, options);
@@ -26,6 +27,8 @@ export const logInMixin = {
       this.$q.cookies.set('refresh_token', auth.refreshToken, { ...options, expires: 365 });
       this.$q.cookies.set('user_id', auth.user._id, options);
       await this.$store.dispatch('main/fetchLoggedUser', auth.user._id);
+
+      if (!this.loggedUser) throw new Error('Error on login');
 
       if (this.$route.query.from) return this.$router.replace({ path: this.$route.query.from });
       if (this.vendorRole && !this.clientRole) return this.$router.replace('/ad').catch(e => {});

--- a/src/router/redirect.js
+++ b/src/router/redirect.js
@@ -17,6 +17,7 @@ export const logOutAndRedirectToLogin = (params) => {
   store.dispatch('rh/resetRh');
   store.dispatch('planning/resetPlanning');
 
+  if (router.currentRoute.path === '/login') return;
   if (params && params.to) return router.replace({ path: '/login', query: { from: params.to.fullPath } });
   return router.replace('/login');
 };


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : np

- Périmetre roles : np

- Cas d'usage : 
changement AlenviAxios: verification refreshtoken avant alenvi token et envoie d'erreur si les token ne sont pas definis
+ envoie d'une erreur si loggedUser n'est pas defini a la fin de la fonction login
+ on ne redirige pas vers login si il y a eu un soucis lors de l'authentification (cela engendrait une erreur navigationDuplicate). 