### PR TITLE
COM-1400

### DIFF
--- a/src/core/helpers/alenvi.js
+++ b/src/core/helpers/alenvi.js
@@ -7,7 +7,7 @@ export const canNavigate = async () => {
   if (!loggedUser && !Cookies.get('user_id') && !Cookies.get('refresh_token')) return false;
 
   if (!loggedUser && !Cookies.get('user_id')) {
-    const refresh = refreshAlenviCookies(); // refresh Cookies.get('user_id')
+    const refresh = await refreshAlenviCookies(); // refresh Cookies.get('user_id')
     if (!refresh) return false;
   }
 

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -17,17 +17,6 @@
     <link rel="manifest" href="statics/favicon_metadata/site.webmanifest">
     <link rel="mask-icon" href="https://res.cloudinary.com/alenvi/image/upload/v1546865717/images/business/Compani/favicon/favicon.ico?v=A0mxgJvdbx">
     <link rel="shortcut icon" href="https://res.cloudinary.com/alenvi/image/upload/v1546865717/images/business/Compani/favicon/favicon.ico?v=A0mxgJvdbx">
-    <!-- Hotjar Tracking Code for app.compani.fr -->
-    <script>
-      (function(h,o,t,j,a,r){
-          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-          h._hjSettings={hjid:1159405,hjsv:6};
-          a=o.getElementsByTagName('head')[0];
-          r=o.createElement('script');r.async=1;
-          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-          a.appendChild(r);
-      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-    </script>
   </head>
   <body>
     <!-- DO NOT touch the following DIV -->


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Toutes

- Périmetre roles : Tous

- Cas d'usage : 
hypothese : Il manquait un await pour l'appel de `refreshAlenviCookies` donc ca enchainait directement avec le `store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'))` mais le cookies etait null et appelait la route avec `/users/null` => 401 => logout

**Si vous voulez je peux vous montrer le chemin dans le code**