### PR TITLE
COM-1409 fix warning error when there is only one tag with error

### DIFF
--- a/src/core/helpers/vuelidateCustomVal.js
+++ b/src/core/helpers/vuelidateCustomVal.js
@@ -131,7 +131,8 @@ export const validTagsCount = (value) => {
   if (!value) return true;
   const { gapAcc } = parseTagCode(value);
 
-  return gapAcc.length === 1 || (gapAcc.length === 2 && validTagging(value));
+  return (gapAcc.length === 0 && !validTagging(value)) || gapAcc.length === 1 ||
+    (gapAcc.length === 2 && validTagging(value));
 };
 
 export const min2Answers = value => value.filter(a => !!a.label).length > 1;


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage :  Lorsqu'il n'y a qu'une balise `<trou></trou>` mal orthographié, le warning indique le fait que c'est mal ortographie et pas qu'il n'y a pas de balise.
