### PR TITLE
COM-1409 change wording in warning for fill the gaps

### DIFF
--- a/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
+++ b/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
@@ -36,7 +36,7 @@ export default {
     textTagCodeErrorMsg () {
       if (this.$v.card.text.required === false) return REQUIRED_LABEL;
       if (!this.$v.card.text.validTagsCount) {
-        return 'Le nombre de couple de balises doit être de 1 ou 2';
+        return 'Le nombre de trous doit être de 1 ou 2';
       }
       if (!this.$v.card.text.validTagging) {
         return 'Balisage non valide, la bonne syntaxe est : <trou>la réponse</trou>';


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : vendeur

- Périmetre roles : admin/rof

- Cas d'usage : changement texte lorsqu'il n'y a pas le bon nombre de balises dans texte a trou
