### PR TITLE
COM-1410-template-fix remove useless dbCount and fix custom validation

### DIFF
--- a/src/core/helpers/vuelidateCustomVal.js
+++ b/src/core/helpers/vuelidateCustomVal.js
@@ -108,7 +108,7 @@ export const validAnswerInTag = (value) => {
   return !gapAcc.some(v => v.trim() !== v);
 };
 
-export const validCaracters = value => /^[a-zA-Z0-9àâçéèêëîïôûùü\s'-]*$/.test(value);
+export const validCaracters = value => /^[a-zA-Z0-9àâçéèêëîïôûùü\040'-]*$/.test(value);
 
 export const validCaractersTags = (value) => {
   if (!value) return true;
@@ -135,6 +135,6 @@ export const validTagsCount = (value) => {
     (gapAcc.length === 2 && validTagging(value));
 };
 
-export const minArrayLength = minLength => value => value.filter(a => !!a).length > minLength;
+export const minArrayLength = minLength => value => value.filter(a => !!a).length >= minLength;
 
 export const minOneCorrectAnswer = value => value.filter(a => a.correct).length >= 1;

--- a/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
+++ b/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
@@ -38,11 +38,6 @@ export default {
     'ni-input': Input,
   },
   mixins: [templateMixin],
-  data () {
-    return {
-      falsyAnswersCountInDb: 0,
-    };
-  },
   validations () {
     return {
       card: {
@@ -81,7 +76,6 @@ export default {
     },
   },
   async mounted () {
-    this.falsyAnswersCountInDb = this.card.falsyAnswers.length;
     this.initializeFalsyAnswers();
   },
   watch: {
@@ -109,7 +103,7 @@ export default {
     },
     requiredFalsyAnswerIsMissing (index) {
       return this.$v.card.falsyAnswers.$error && !this.$v.card.falsyAnswers.minLength && index < 2 &&
-        this.card.falsyAnswers.filter(a => !!a).length < this.falsyAnswersCountInDb && !this.card.falsyAnswers[index];
+        !this.card.falsyAnswers[index];
     },
     async updateAnswer (index) {
       try {
@@ -123,7 +117,6 @@ export default {
         await Cards.updateById(this.card._id, { falsyAnswers: this.card.falsyAnswers.filter(a => !!a) });
 
         await this.refreshCard();
-        this.falsyAnswersCountInDb = this.card.falsyAnswers.length;
 
         NotifyPositive('Carte mise à jour.');
       } catch (e) {

--- a/src/modules/vendor/components/programs/cards/templates/OrderTheSequence.vue
+++ b/src/modules/vendor/components/programs/cards/templates/OrderTheSequence.vue
@@ -28,16 +28,11 @@ export default {
     'ni-input': Input,
   },
   mixins: [templateMixin],
-  data () {
-    return {
-      orderedAnswersCountInDb: 0,
-    };
-  },
   validations () {
     return {
       card: {
         question: { required },
-        orderedAnswers: { minLength: minArrayLength(1) },
+        orderedAnswers: { minLength: minArrayLength(2) },
         explanation: { required },
       },
     };
@@ -57,14 +52,10 @@ export default {
   },
   methods: {
     initializeOrderedAnswers () {
-      this.orderedAnswersCountInDb = this.card.orderedAnswers.length;
       this.card.orderedAnswers = times(ORDER_THE_SEQUENCE_MAX_ANSWERS_COUNT, i => this.card.orderedAnswers[i] || '');
     },
     requiredOrderedAnswerIsMissing (index) {
-      return this.$v.card.orderedAnswers.$error &&
-        !this.$v.card.orderedAnswers.minLength &&
-        this.card.orderedAnswers.filter(a => !!a).length < this.orderedAnswersCountInDb &&
-        index < 2 &&
+      return this.$v.card.orderedAnswers.$error && !this.$v.card.orderedAnswers.minLength && index < 2 &&
         !this.card.orderedAnswers[index];
     },
     async updateOrderedAnswer (index) {

--- a/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
@@ -32,11 +32,6 @@ export default {
     'ni-input': Input,
   },
   mixins: [templateMixin, validationMixin],
-  data () {
-    return {
-      falsyAnswersCountInDb: 0,
-    };
-  },
   validations () {
     return {
       card: {
@@ -53,7 +48,6 @@ export default {
     },
   },
   async mounted () {
-    this.falsyAnswersCountInDb = this.card.falsyAnswers.length;
     this.initializeFalsyAnswers();
   },
   watch: {
@@ -70,7 +64,7 @@ export default {
     },
     requiredFalsyAnswerIsMissing (index) {
       return this.$v.card.falsyAnswers.$error && !this.$v.card.falsyAnswers.minLength && index === 0 &&
-        this.card.falsyAnswers.filter(a => !!a).length < this.falsyAnswersCountInDb && !this.card.falsyAnswers[index];
+        !this.card.falsyAnswers[index];
     },
     formatFalsyAnswersPayload () {
       return this.card.falsyAnswers.filter(a => !!a);
@@ -84,7 +78,6 @@ export default {
         await Cards.updateById(this.card._id, { falsyAnswers: this.formatFalsyAnswersPayload() });
 
         await this.refreshCard();
-        this.falsyAnswersCountInDb = this.card.falsyAnswers.length;
 
         NotifyPositive('Carte mise à jour.');
       } catch (e) {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : on enleve la comparaison avec le nbr de reponse en bd. Deux ptites coquilles fixées, le minimum de reponse dns un tableau et la regexp qui laissait passer les saut de ligne.
