### PR TITLE
COM-1494 call refresh if there is auxiliaries or sectors in filter

### DIFF
--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -134,7 +134,8 @@ export default {
 
       const range = this.$moment.range(this.startOfWeek, this.$moment(this.startOfWeek).add(6, 'd'));
       this.days = Array.from(range.by('days'));
-      if (this.auxiliaries && this.auxiliaries.length) await this.refresh();
+      if ((this.auxiliaries && this.auxiliaries.length) ||
+        (this.filteredSectors && this.filteredSectors.length)) await this.refresh();
     },
     // Filters
     initFilters () {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : vendeur

- Périmetre roles : coach/admin/auxiliaire

- Cas d'usage : sur le plannnig des groots, lorsque je vais sur la premeire semaine de septembre et que je reviens sur la semanie courante, je vois le planning qui s'affiche. 
