### PR TITLE
COM-1460 disable steps drag and drop if subprogram is published

### DIFF
--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -13,7 +13,7 @@
         @blur="updateSubProgramName(index)" :error="$v.program.subPrograms.$each[index].name.$error"
         :disable="isPublished(subProgram)" />
       <draggable @end="dropStep(subProgram._id)" v-model="subProgram.steps"
-        ghost-class="ghost" :disabled="$q.platform.is.mobile">
+        ghost-class="ghost" :disabled="$q.platform.is.mobile || isPublished(subProgram)">
         <q-card v-for="(step, stepIndex) of subProgram.steps" :key="stepIndex" flat class="step">
           <q-card-section class="step-head cursor-pointer row" @click="showActivities(step._id)" :id="step._id">
             <q-item-section side><q-icon :name="getStepTypeIcon(step.type)" size="sm" color="black" /></q-item-section>


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : le drag and drop des etapes est desactive si le sous programme est publié
