### PR TITLE
COM-1560 filtered to blended only in ProfileCourses

### DIFF
--- a/src/modules/vendor/components/learners/ProfileCourses.vue
+++ b/src/modules/vendor/components/learners/ProfileCourses.vue
@@ -9,7 +9,7 @@
 import { mapState } from 'vuex';
 import Courses from '@api/Courses';
 import TableList from '@components/table/TableList';
-import { FORTHCOMING, IN_PROGRESS, COMPLETED } from '@data/constants';
+import { FORTHCOMING, IN_PROGRESS, COMPLETED, BLENDED } from '@data/constants';
 import { userMixin } from '@mixins/userMixin';
 import { courseFiltersMixin } from '@mixins/courseFiltersMixin';
 import { courseTimelineMixin } from '@mixins/courseTimeline';
@@ -57,7 +57,7 @@ export default {
     },
   },
   async created () {
-    const courses = await Courses.list({ trainees: this.userProfile._id });
+    const courses = await Courses.list({ trainees: this.userProfile._id, format: BLENDED });
     this.courses = this.groupByCourses(courses);
   },
   methods: {


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : rof admin

- Cas d'usage : N'affiche plus les formations _eLearning_ sur la page profil d'un des stagiaires

(comme on ne peut pas encore inscrire un stagiaire à une formation _eLearning_, on peut vérifier que le filtre marche en remplaçant `BLENDED` par `STRICTLY_E_LEARNING` ) 
