### PR TITLE
COM-1549 - change otherFees to phoneFees

### DIFF
--- a/src/modules/client/mixins/configMixin.js
+++ b/src/modules/client/mixins/configMixin.js
@@ -42,10 +42,11 @@ export const configMixin = {
     },
     nbrError (path) {
       if (get(this.$v, path).required === false) return REQUIRED_LABEL;
-      if (get(this.$v, path).positiveNumber === false || get(this.$v, path).numeric === false) {
+      if (get(this.$v, path).positiveNumber === false ||
+      get(this.$v, path).numeric === false ||
+      get(this.$v, path).maxValue === false) {
         return 'Nombre non valide';
       }
-      if (get(this.$v, path).maxValue === false) return 'Le montant doit être inférieur à 999';
     },
     // Documents
     async deleteDocument (driveId, type, key) {

--- a/src/modules/client/mixins/configMixin.js
+++ b/src/modules/client/mixins/configMixin.js
@@ -45,6 +45,7 @@ export const configMixin = {
       if (get(this.$v, path).positiveNumber === false || get(this.$v, path).numeric === false) {
         return 'Nombre non valide';
       }
+      if (get(this.$v, path).maxValue === false) return 'Le montant doit être inférieur à 999';
     },
     // Documents
     async deleteDocument (driveId, type, key) {

--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -169,7 +169,7 @@ export const payMixin = {
         },
         {
           name: 'phoneFees',
-          label: 'Frais téléphonique',
+          label: 'Frais tel',
           align: 'center',
           field: 'phoneFees',
           format: formatPrice,
@@ -267,7 +267,7 @@ export const payMixin = {
         'Heures comp à payer',
         'Mutuelle',
         'Transport',
-        'Frais téléphonique',
+        'Frais tel',
         'Prime',
       ]];
 

--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -169,7 +169,7 @@ export const payMixin = {
         },
         {
           name: 'phoneFees',
-          label: 'Frais tel',
+          label: 'Frais tél',
           align: 'center',
           field: 'phoneFees',
           format: formatPrice,
@@ -267,7 +267,7 @@ export const payMixin = {
         'Heures comp à payer',
         'Mutuelle',
         'Transport',
-        'Frais tel',
+        'Frais téléphoniques',
         'Prime',
       ]];
 

--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -168,10 +168,10 @@ export const payMixin = {
           format: formatPrice,
         },
         {
-          name: 'otherFees',
-          label: 'Autres frais',
+          name: 'phoneFees',
+          label: 'Frais téléphonique',
           align: 'center',
-          field: 'otherFees',
+          field: 'phoneFees',
           format: formatPrice,
         },
         {
@@ -267,7 +267,7 @@ export const payMixin = {
         'Heures comp à payer',
         'Mutuelle',
         'Transport',
-        'Autres frais',
+        'Frais téléphonique',
         'Prime',
       ]];
 
@@ -295,7 +295,7 @@ export const payMixin = {
           this.formatNumberForCSV(draftPay.additionalHours),
           draftPay.mutual ? 'Oui' : 'Non',
           this.formatNumberForCSV(draftPay.transport),
-          this.formatNumberForCSV(draftPay.otherFees),
+          this.formatNumberForCSV(draftPay.phoneFees),
           this.formatNumberForCSV(draftPay.bonus),
         ]);
       }

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -43,9 +43,9 @@
       <div class="q-mb-xl">
         <p class="text-weight-bold">Remboursement frais</p>
         <div class="row gutter-profile">
-          <ni-input caption="Montant des frais" :error="$v.company.rhConfig.feeAmount.$error"
-            :error-message="nbrError('company.rhConfig.feeAmount')" type="number" v-model="company.rhConfig.feeAmount"
-            @focus="saveTmp('rhConfig.feeAmount')" suffix="€" @blur="updateCompany('rhConfig.feeAmount')" />
+          <ni-input caption="Montant des frais" :error="$v.company.rhConfig.phoneFeeAmount.$error" type="number"
+            :error-message="nbrError('company.rhConfig.phoneFeeAmount')" v-model="company.rhConfig.phoneFeeAmount"
+            @focus="saveTmp('rhConfig.phoneFeeAmount')" suffix="€" @blur="updateCompany('rhConfig.phoneFeeAmount')" />
         </div>
       </div>
       <div class="q-mb-xl">
@@ -282,7 +282,7 @@ export default {
       company: {
         rhConfig: {
           grossHourlyRate: { required, positiveNumber, maxValue: maxValue(999) },
-          feeAmount: { required, positiveNumber, maxValue: maxValue(999) },
+          phoneFeeAmount: { required, positiveNumber, maxValue: maxValue(999) },
           amountPerKm: { required, positiveNumber, maxValue: maxValue(999) },
           transportSubs: { $each: { price: { required, positiveNumber, maxValue: maxValue(999) } } },
         },

--- a/src/modules/client/pages/ni/pay/ToPay.vue
+++ b/src/modules/client/pages/ni/pay/ToPay.vue
@@ -155,7 +155,7 @@ export default {
         { label: 'Compteur', value: 'hoursCounter' },
         { label: 'Mutuelle', value: 'mutual' },
         { label: 'Transport', value: 'transport' },
-        { label: 'Frais téléphonique', value: 'phoneFees' },
+        { label: 'Frais tel', value: 'phoneFees' },
       ],
       sortOption: 'auxiliary',
     };

--- a/src/modules/client/pages/ni/pay/ToPay.vue
+++ b/src/modules/client/pages/ni/pay/ToPay.vue
@@ -155,7 +155,7 @@ export default {
         { label: 'Compteur', value: 'hoursCounter' },
         { label: 'Mutuelle', value: 'mutual' },
         { label: 'Transport', value: 'transport' },
-        { label: 'Frais tel', value: 'phoneFees' },
+        { label: 'Frais téléphoniques', value: 'phoneFees' },
       ],
       sortOption: 'auxiliary',
     };

--- a/src/modules/client/pages/ni/pay/ToPay.vue
+++ b/src/modules/client/pages/ni/pay/ToPay.vue
@@ -137,7 +137,7 @@ export default {
         'additionalHours',
         'mutual',
         'transport',
-        'otherFees',
+        'phoneFees',
         'bonus',
       ],
       surchargeDetailModal: false,
@@ -155,7 +155,7 @@ export default {
         { label: 'Compteur', value: 'hoursCounter' },
         { label: 'Mutuelle', value: 'mutual' },
         { label: 'Transport', value: 'transport' },
-        { label: 'Autres frais', value: 'otherFees' },
+        { label: 'Frais téléphonique', value: 'phoneFees' },
       ],
       sortOption: 'auxiliary',
     };


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : CLIENT

- Périmetre roles : admin

- Cas d'usage : 
Dans les paies (stc et paie mensuelle), le champ 'autre frais' est devenu 'frais téléphonique'. Si l'auxiliaire à un justificatif de téléphone, les frais sont calculés, sinon ils sont de 0.
