### PR TITLE
Com 1578 - refacto surchargeCreationModal

### DIFF
--- a/src/modules/client/mixins/configMixin.js
+++ b/src/modules/client/mixins/configMixin.js
@@ -40,7 +40,7 @@ export const configMixin = {
         this.tmpInput = '';
       }
     },
-    nbrError (path, validations) {
+    nbrError (path, validations = this.$v) {
       if (get(validations, path).required === false) return REQUIRED_LABEL;
       if (get(validations, path).positiveNumber === false ||
       get(validations, path).numeric === false ||

--- a/src/modules/client/mixins/configMixin.js
+++ b/src/modules/client/mixins/configMixin.js
@@ -40,11 +40,11 @@ export const configMixin = {
         this.tmpInput = '';
       }
     },
-    nbrError (path) {
-      if (get(this.$v, path).required === false) return REQUIRED_LABEL;
-      if (get(this.$v, path).positiveNumber === false ||
-      get(this.$v, path).numeric === false ||
-      get(this.$v, path).maxValue === false) {
+    nbrError (path, validations) {
+      if (get(validations, path).required === false) return REQUIRED_LABEL;
+      if (get(validations, path).positiveNumber === false ||
+      get(validations, path).numeric === false ||
+      get(validations, path).maxValue === false) {
         return 'Nombre non valide';
       }
     },

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -120,7 +120,7 @@
 
     <!-- Surcharge creation modal -->
     <surcharge-creation-modal v-model="surchargeCreationModal" :new-surcharge="newSurcharge"
-      :$v="$v" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
+      :validations="$v" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
       :loading="loading" />
 
     <!-- Surcharge edition modal -->
@@ -132,22 +132,23 @@
         @blur="$v.editedSurcharge.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="editedSurcharge.saturday"
         :error="$v.editedSurcharge.saturday.$error" @blur="$v.editedSurcharge.saturday.$touch"
-        :error-message="nbrError('editedSurcharge.saturday')" />
+        :error-message="nbrError('editedSurcharge.saturday', $v)" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="editedSurcharge.sunday"
         :error="$v.editedSurcharge.sunday.$error" @blur="$v.editedSurcharge.sunday.$touch"
-        :error-message="nbrError('editedSurcharge.sunday')" />
+        :error-message="nbrError('editedSurcharge.sunday', $v)" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number"
         v-model="editedSurcharge.publicHoliday" :error="$v.editedSurcharge.publicHoliday.$error"
-        @blur="$v.editedSurcharge.publicHoliday.$touch" :error-message="nbrError('editedSurcharge.publicHoliday')" />
+        @blur="$v.editedSurcharge.publicHoliday.$touch"
+        :error-message="nbrError('editedSurcharge.publicHoliday', $v)" />
       <ni-input in-modal caption="Majoration 25 décembre" :error="$v.editedSurcharge.twentyFifthOfDecember.$error"
         v-model="editedSurcharge.twentyFifthOfDecember" @blur="$v.editedSurcharge.twentyFifthOfDecember.$touch"
-        :error-message="nbrError('editedSurcharge.twentyFifthOfDecember')" suffix="%" type="number" />
+        :error-message="nbrError('editedSurcharge.twentyFifthOfDecember', $v)" suffix="%" type="number" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="editedSurcharge.firstOfMay"
         :error="$v.editedSurcharge.firstOfMay.$error" @blur="$v.editedSurcharge.firstOfMay.$touch"
-        :error-message="nbrError('editedSurcharge.firstOfMay')" />
+        :error-message="nbrError('editedSurcharge.firstOfMay', $v)" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="editedSurcharge.evening"
         :error="$v.editedSurcharge.evening.$error" @blur="$v.editedSurcharge.evening.$touch"
-        :error-message="nbrError('editedSurcharge.evening')" first-of-may />
+        :error-message="nbrError('editedSurcharge.evening', $v)" first-of-may />
       <ni-time-input in-modal v-model="editedSurcharge.eveningStartTime" caption="Début soirée"
         :error="$v.editedSurcharge.eveningStartTime.$error" @blur="$v.editedSurcharge.eveningStartTime.$touch"
         :disable="!editedSurcharge.evening" :required-field="!!editedSurcharge.evening"
@@ -172,13 +173,13 @@
 
     <!-- Service creation modal -->
     <service-creation-modal v-model="serviceCreationModal" :new-service="newService" :validations="$v.newService"
-      :nature-options="natureOptions" :default-unit-amount-error="nbrError('newService.defaultUnitAmount')"
+      :nature-options="natureOptions" :default-unit-amount-error="nbrError('newService.defaultUnitAmount', $v)"
       :surcharges-options="surchargesOptions" @hide="resetCreationServiceData" @submit="createNewService"
       :loading="loading" />
 
     <!-- Service edition modal -->
     <service-edition-modal v-model="serviceEditionModal" :edited-service="editedService" :validations="$v.editedService"
-      :default-unit-amount-error="nbrError('newService.defaultUnitAmount')" :surcharges-options="surchargesOptions"
+      :default-unit-amount-error="nbrError('newService.defaultUnitAmount', $v)" :surcharges-options="surchargesOptions"
       :loading="loading" @hide="resetEditionServiceData" @submit="updateService" :min-start-date="minStartDate" />
 
     <!-- Service history modal -->
@@ -202,7 +203,7 @@
       <ni-input in-modal caption="Email" v-model.trim="newThirdPartyPayer.email" />
       <ni-input in-modal caption="Prix unitaire TTC par défaut" suffix="€" type="number"
         v-model="newThirdPartyPayer.unitTTCRate" :error="$v.newThirdPartyPayer.unitTTCRate.$error"
-        :error-message="nbrError('newThirdPartyPayer.unitTTCRate')" />
+        :error-message="nbrError('newThirdPartyPayer.unitTTCRate', $v)" />
       <ni-select in-modal v-model="newThirdPartyPayer.billingMode" :options="billingModeOptions" caption="Facturation"
         :filter="false" required-field :error="$v.newThirdPartyPayer.billingMode.$error"
         @blur="$v.newThirdPartyPayer.billingMode.$touch" />
@@ -227,7 +228,7 @@
       <ni-input in-modal caption="Email" v-model.trim="editedThirdPartyPayer.email" />
       <ni-input in-modal caption="Prix unitaire TTC par défaut" suffix="€" type="number"
         v-model="editedThirdPartyPayer.unitTTCRate" :error="$v.editedThirdPartyPayer.unitTTCRate.$error"
-        :error-message="nbrError('editedThirdPartyPayer.unitTTCRate')" />
+        :error-message="nbrError('editedThirdPartyPayer.unitTTCRate', $v)" />
       <ni-select in-modal v-model="editedThirdPartyPayer.billingMode" :options="billingModeOptions"
         caption="Facturation" :filter="false" required-field :error="$v.editedThirdPartyPayer.billingMode.$error"
         @blur="$v.editedThirdPartyPayer.billingMode.$touch" />

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -132,23 +132,23 @@
         @blur="$v.editedSurcharge.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="editedSurcharge.saturday"
         :error="$v.editedSurcharge.saturday.$error" @blur="$v.editedSurcharge.saturday.$touch"
-        :error-message="nbrError('editedSurcharge.saturday', $v)" />
+        :error-message="nbrError('editedSurcharge.saturday')" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="editedSurcharge.sunday"
         :error="$v.editedSurcharge.sunday.$error" @blur="$v.editedSurcharge.sunday.$touch"
-        :error-message="nbrError('editedSurcharge.sunday', $v)" />
+        :error-message="nbrError('editedSurcharge.sunday')" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number"
         v-model="editedSurcharge.publicHoliday" :error="$v.editedSurcharge.publicHoliday.$error"
         @blur="$v.editedSurcharge.publicHoliday.$touch"
-        :error-message="nbrError('editedSurcharge.publicHoliday', $v)" />
+        :error-message="nbrError('editedSurcharge.publicHoliday')" />
       <ni-input in-modal caption="Majoration 25 décembre" :error="$v.editedSurcharge.twentyFifthOfDecember.$error"
         v-model="editedSurcharge.twentyFifthOfDecember" @blur="$v.editedSurcharge.twentyFifthOfDecember.$touch"
-        :error-message="nbrError('editedSurcharge.twentyFifthOfDecember', $v)" suffix="%" type="number" />
+        :error-message="nbrError('editedSurcharge.twentyFifthOfDecember')" suffix="%" type="number" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="editedSurcharge.firstOfMay"
         :error="$v.editedSurcharge.firstOfMay.$error" @blur="$v.editedSurcharge.firstOfMay.$touch"
-        :error-message="nbrError('editedSurcharge.firstOfMay', $v)" />
+        :error-message="nbrError('editedSurcharge.firstOfMay')" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="editedSurcharge.evening"
         :error="$v.editedSurcharge.evening.$error" @blur="$v.editedSurcharge.evening.$touch"
-        :error-message="nbrError('editedSurcharge.evening', $v)" first-of-may />
+        :error-message="nbrError('editedSurcharge.evening')" first-of-may />
       <ni-time-input in-modal v-model="editedSurcharge.eveningStartTime" caption="Début soirée"
         :error="$v.editedSurcharge.eveningStartTime.$error" @blur="$v.editedSurcharge.eveningStartTime.$touch"
         :disable="!editedSurcharge.evening" :required-field="!!editedSurcharge.evening"
@@ -173,13 +173,13 @@
 
     <!-- Service creation modal -->
     <service-creation-modal v-model="serviceCreationModal" :new-service="newService" :validations="$v.newService"
-      :nature-options="natureOptions" :default-unit-amount-error="nbrError('newService.defaultUnitAmount', $v)"
+      :nature-options="natureOptions" :default-unit-amount-error="nbrError('newService.defaultUnitAmount')"
       :surcharges-options="surchargesOptions" @hide="resetCreationServiceData" @submit="createNewService"
       :loading="loading" />
 
     <!-- Service edition modal -->
     <service-edition-modal v-model="serviceEditionModal" :edited-service="editedService" :validations="$v.editedService"
-      :default-unit-amount-error="nbrError('newService.defaultUnitAmount', $v)" :surcharges-options="surchargesOptions"
+      :default-unit-amount-error="nbrError('newService.defaultUnitAmount')" :surcharges-options="surchargesOptions"
       :loading="loading" @hide="resetEditionServiceData" @submit="updateService" :min-start-date="minStartDate" />
 
     <!-- Service history modal -->
@@ -203,7 +203,7 @@
       <ni-input in-modal caption="Email" v-model.trim="newThirdPartyPayer.email" />
       <ni-input in-modal caption="Prix unitaire TTC par défaut" suffix="€" type="number"
         v-model="newThirdPartyPayer.unitTTCRate" :error="$v.newThirdPartyPayer.unitTTCRate.$error"
-        :error-message="nbrError('newThirdPartyPayer.unitTTCRate', $v)" />
+        :error-message="nbrError('newThirdPartyPayer.unitTTCRate')" />
       <ni-select in-modal v-model="newThirdPartyPayer.billingMode" :options="billingModeOptions" caption="Facturation"
         :filter="false" required-field :error="$v.newThirdPartyPayer.billingMode.$error"
         @blur="$v.newThirdPartyPayer.billingMode.$touch" />
@@ -228,7 +228,7 @@
       <ni-input in-modal caption="Email" v-model.trim="editedThirdPartyPayer.email" />
       <ni-input in-modal caption="Prix unitaire TTC par défaut" suffix="€" type="number"
         v-model="editedThirdPartyPayer.unitTTCRate" :error="$v.editedThirdPartyPayer.unitTTCRate.$error"
-        :error-message="nbrError('editedThirdPartyPayer.unitTTCRate', $v)" />
+        :error-message="nbrError('editedThirdPartyPayer.unitTTCRate')" />
       <ni-select in-modal v-model="editedThirdPartyPayer.billingMode" :options="billingModeOptions"
         caption="Facturation" :filter="false" required-field :error="$v.editedThirdPartyPayer.billingMode.$error"
         @blur="$v.editedThirdPartyPayer.billingMode.$touch" />

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -138,8 +138,7 @@
         :error-message="nbrError('editedSurcharge.sunday')" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number"
         v-model="editedSurcharge.publicHoliday" :error="$v.editedSurcharge.publicHoliday.$error"
-        @blur="$v.editedSurcharge.publicHoliday.$touch"
-        :error-message="nbrError('editedSurcharge.publicHoliday')" />
+        @blur="$v.editedSurcharge.publicHoliday.$touch" :error-message="nbrError('editedSurcharge.publicHoliday')" />
       <ni-input in-modal caption="Majoration 25 décembre" :error="$v.editedSurcharge.twentyFifthOfDecember.$error"
         v-model="editedSurcharge.twentyFifthOfDecember" @blur="$v.editedSurcharge.twentyFifthOfDecember.$touch"
         :error-message="nbrError('editedSurcharge.twentyFifthOfDecember')" suffix="%" type="number" />

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -120,7 +120,7 @@
 
     <!-- Surcharge creation modal -->
     <surcharge-creation-modal v-model="surchargeCreationModal" :new-surcharge="newSurcharge"
-      :validations="$v" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
+      :validation="$v.newSurcharge" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
       :loading="loading" />
 
     <!-- Surcharge edition modal -->

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -120,8 +120,8 @@
 
     <!-- Surcharge creation modal -->
     <surcharge-creation-modal v-model="surchargeCreationModal" :new-surcharge="newSurcharge"
-      :validations="$v.newSurcharge" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
-      :nbr-errors="nbrErrors" :loading="loading" />
+      :$v="$v" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
+      :loading="loading" />
 
     <!-- Surcharge edition modal -->
     <ni-modal v-model="surchargeEditionModal" @hide="resetEditionSurchargeData">
@@ -658,16 +658,6 @@ export default {
     },
   },
   computed: {
-    nbrErrors () {
-      return {
-        saturday: this.nbrError('newSurcharge.saturday'),
-        sunday: this.nbrError('newSurcharge.sunday'),
-        publicHoliday: this.nbrError('newSurcharge.publicHoliday'),
-        twentyFifthOfDecember: this.nbrError('newSurcharge.twentyFifthOfDecember'),
-        firstOfMay: this.nbrError('newSurcharge.firstOfMay'),
-        evening: this.nbrError('newSurcharge.evening'),
-      };
-    },
     docsUploadUrl () {
       return `${process.env.API_HOSTNAME}/companies/${this.company._id}/gdrive/${this.company.folderId}/upload`;
     },

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -120,7 +120,7 @@
 
     <!-- Surcharge creation modal -->
     <surcharge-creation-modal v-model="surchargeCreationModal" :new-surcharge="newSurcharge"
-      :validation="$v.newSurcharge" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
+      :validations="$v.newSurcharge" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
       :loading="loading" />
 
     <!-- Surcharge edition modal -->

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -119,49 +119,9 @@
     </div>
 
     <!-- Surcharge creation modal -->
-    <ni-modal v-model="surchargeCreationModal" @hide="resetCreationSurchargeData">
-      <template slot="title">
-        Créer un <span class="text-weight-bold">plan de majoration</span>
-      </template>
-      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="$v.newSurcharge.name.$error"
-        @blur="$v.newSurcharge.name.$touch" required-field />
-      <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
-        :error="$v.newSurcharge.saturday.$error" @blur="$v.newSurcharge.saturday.$touch"
-        :error-message="nbrError('newSurcharge.saturday')" />
-      <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
-        :error="$v.newSurcharge.sunday.$error" @blur="$v.newSurcharge.sunday.$touch"
-        :error-message="nbrError('newSurcharge.sunday')" />
-      <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
-        :error="$v.newSurcharge.publicHoliday.$error" @blur="$v.newSurcharge.publicHoliday.$touch"
-        :error-message="nbrError('newSurcharge.publicHoliday')" />
-      <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
-        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrError('newSurcharge.twentyFifthOfDecember')"
-        @blur="$v.newSurcharge.twentyFifthOfDecember.$touch" :error="$v.newSurcharge.twentyFifthOfDecember.$error" />
-      <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
-        :error="$v.newSurcharge.firstOfMay.$error" @blur="$v.newSurcharge.firstOfMay.$touch"
-        :error-message="nbrError('newSurcharge.firstOfMay')" />
-      <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
-        :error="$v.newSurcharge.evening.$error" @blur="$v.newSurcharge.evening.$touch"
-        :error-message="nbrError('newSurcharge.evening')" />
-      <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
-        :error="$v.newSurcharge.eveningStartTime.$error" @blur="$v.newSurcharge.eveningStartTime.$touch"
-        :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
-      <ni-time-input in-modal v-model="newSurcharge.eveningEndTime" caption="Fin soirée"
-        :error="$v.newSurcharge.eveningEndTime.$error" @blur="$v.newSurcharge.eveningEndTime.$touch"
-        :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
-      <ni-input in-modal caption="Majoration personnalisée" suffix="%" type="number" v-model="newSurcharge.custom"
-        :error="$v.newSurcharge.custom.$error" @blur="$v.newSurcharge.custom.$touch" />
-      <ni-time-input in-modal v-model="newSurcharge.customStartTime" caption="Début personnalisé"
-        :error="$v.newSurcharge.customStartTime.$error" @blur="$v.newSurcharge.customStartTime.$touch"
-        :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
-      <ni-time-input in-modal v-model="newSurcharge.customEndTime" caption="Fin personnalisée"
-        :error="$v.newSurcharge.customEndTime.$error" @blur="$v.newSurcharge.customEndTime.$touch"
-        :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
-      <template slot="footer">
-        <q-btn no-caps class="full-width modal-btn" label="Créer le plan de majoration" icon-right="add" color="primary"
-          :loading="loading" @click="createNewSurcharge" />
-      </template>
-    </ni-modal>
+    <surcharge-creation-modal v-model="surchargeCreationModal" :new-surcharge="newSurcharge"
+      :validations="$v.newSurcharge" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
+      :loading="loading" />
 
     <!-- Surcharge edition modal -->
     <ni-modal v-model="surchargeEditionModal" @hide="resetEditionSurchargeData">
@@ -312,6 +272,7 @@ import {
 } from '@data/constants';
 import ServiceCreationModal from 'src/modules/client/components/config/ServiceCreationModal';
 import ServiceEditionModal from 'src/modules/client/components/config/ServiceEditionModal';
+import SurchargeCreationModal from 'src/modules/client/pages/ni/config/SurchargeCreationModal';
 import { configMixin } from 'src/modules/client/mixins/configMixin';
 import { validationMixin } from '@mixins/validationMixin';
 import { tableMixin } from 'src/modules/client/mixins/tableMixin';
@@ -329,6 +290,7 @@ export default {
     'ni-responsive-table': ReponsiveTable,
     'service-creation-modal': ServiceCreationModal,
     'service-edition-modal': ServiceEditionModal,
+    'surcharge-creation-modal': SurchargeCreationModal,
   },
   mixins: [configMixin, validationMixin, tableMixin],
   watch: {

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -121,7 +121,7 @@
     <!-- Surcharge creation modal -->
     <surcharge-creation-modal v-model="surchargeCreationModal" :new-surcharge="newSurcharge"
       :validations="$v.newSurcharge" @hide="resetCreationSurchargeData" @submit="createNewSurcharge"
-      :loading="loading" />
+      :nbr-errors="nbrErrors" :loading="loading" />
 
     <!-- Surcharge edition modal -->
     <ni-modal v-model="surchargeEditionModal" @hide="resetEditionSurchargeData">
@@ -658,6 +658,16 @@ export default {
     },
   },
   computed: {
+    nbrErrors () {
+      return {
+        saturday: this.nbrError('newSurcharge.saturday'),
+        sunday: this.nbrError('newSurcharge.sunday'),
+        publicHoliday: this.nbrError('newSurcharge.publicHoliday'),
+        twentyFifthOfDecember: this.nbrError('newSurcharge.twentyFifthOfDecember'),
+        firstOfMay: this.nbrError('newSurcharge.firstOfMay'),
+        evening: this.nbrError('newSurcharge.evening'),
+      };
+    },
     docsUploadUrl () {
       return `${process.env.API_HOSTNAME}/companies/${this.company._id}/gdrive/${this.company.folderId}/upload`;
     },

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -35,7 +35,7 @@
         <p class="text-weight-bold">Contrats prestataires</p>
         <div class="row gutter-profile">
           <ni-input caption="Taux horaire brut par défaut" :error="$v.company.rhConfig.grossHourlyRate.$error"
-            :error-message="nbrError('company.rhConfig.grossHourlyRate', $v)" type="number"
+            :error-message="nbrError('company.rhConfig.grossHourlyRate')" type="number"
             v-model="company.rhConfig.grossHourlyRate" @focus="saveTmp('rhConfig.grossHourlyRate')" suffix="€"
             @blur="updateCompany('rhConfig.grossHourlyRate')" />
         </div>
@@ -44,7 +44,7 @@
         <p class="text-weight-bold">Remboursement frais</p>
         <div class="row gutter-profile">
           <ni-input caption="Montant des frais" :error="$v.company.rhConfig.phoneFeeAmount.$error" type="number"
-            :error-message="nbrError('company.rhConfig.phoneFeeAmount', $v)" v-model="company.rhConfig.phoneFeeAmount"
+            :error-message="nbrError('company.rhConfig.phoneFeeAmount')" v-model="company.rhConfig.phoneFeeAmount"
             @focus="saveTmp('rhConfig.phoneFeeAmount')" suffix="€" @blur="updateCompany('rhConfig.phoneFeeAmount')" />
         </div>
       </div>
@@ -52,7 +52,7 @@
         <p class="text-weight-bold">Taux kilométrique</p>
         <div class="row gutter-profile">
           <ni-input caption="Montant par kilomètre" :error="$v.company.rhConfig.amountPerKm.$error" type="number"
-            :error-message="nbrError('company.rhConfig.amountPerKm', $v)" v-model="company.rhConfig.amountPerKm"
+            :error-message="nbrError('company.rhConfig.amountPerKm')" v-model="company.rhConfig.amountPerKm"
             @focus="saveTmp('rhConfig.amountPerKm')" suffix="€" @blur="updateCompany('rhConfig.amountPerKm')" />
         </div>
       </div>
@@ -64,7 +64,7 @@
               <ni-input :caption="transportSub.department" v-model="company.rhConfig.transportSubs[index].price"
                 :error="$v.company.rhConfig.transportSubs.$each[index].$error" type="number" :key="index"
                 @focus="saveTmp(`rhConfig.transportSubs[${index}].price`)" suffix="€"
-                :error-message="nbrError(`company.rhConfig.transportSubs.$each[${index}].price`, $v)"
+                :error-message="nbrError(`company.rhConfig.transportSubs.$each[${index}].price`)"
                 @blur="updateCompanyTransportSubs(index)" />
             </template>
           </template>

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -35,7 +35,7 @@
         <p class="text-weight-bold">Contrats prestataires</p>
         <div class="row gutter-profile">
           <ni-input caption="Taux horaire brut par défaut" :error="$v.company.rhConfig.grossHourlyRate.$error"
-            :error-message="nbrError('company.rhConfig.grossHourlyRate')" type="number"
+            :error-message="nbrError('company.rhConfig.grossHourlyRate', $v)" type="number"
             v-model="company.rhConfig.grossHourlyRate" @focus="saveTmp('rhConfig.grossHourlyRate')" suffix="€"
             @blur="updateCompany('rhConfig.grossHourlyRate')" />
         </div>
@@ -44,7 +44,7 @@
         <p class="text-weight-bold">Remboursement frais</p>
         <div class="row gutter-profile">
           <ni-input caption="Montant des frais" :error="$v.company.rhConfig.phoneFeeAmount.$error" type="number"
-            :error-message="nbrError('company.rhConfig.phoneFeeAmount')" v-model="company.rhConfig.phoneFeeAmount"
+            :error-message="nbrError('company.rhConfig.phoneFeeAmount', $v)" v-model="company.rhConfig.phoneFeeAmount"
             @focus="saveTmp('rhConfig.phoneFeeAmount')" suffix="€" @blur="updateCompany('rhConfig.phoneFeeAmount')" />
         </div>
       </div>
@@ -52,7 +52,7 @@
         <p class="text-weight-bold">Taux kilométrique</p>
         <div class="row gutter-profile">
           <ni-input caption="Montant par kilomètre" :error="$v.company.rhConfig.amountPerKm.$error" type="number"
-            :error-message="nbrError('company.rhConfig.amountPerKm')" v-model="company.rhConfig.amountPerKm"
+            :error-message="nbrError('company.rhConfig.amountPerKm', $v)" v-model="company.rhConfig.amountPerKm"
             @focus="saveTmp('rhConfig.amountPerKm')" suffix="€" @blur="updateCompany('rhConfig.amountPerKm')" />
         </div>
       </div>
@@ -64,7 +64,7 @@
               <ni-input :caption="transportSub.department" v-model="company.rhConfig.transportSubs[index].price"
                 :error="$v.company.rhConfig.transportSubs.$each[index].$error" type="number" :key="index"
                 @focus="saveTmp(`rhConfig.transportSubs[${index}].price`)" suffix="€"
-                :error-message="nbrError(`company.rhConfig.transportSubs.$each[${index}].price`)"
+                :error-message="nbrError(`company.rhConfig.transportSubs.$each[${index}].price`, $v)"
                 @blur="updateCompanyTransportSubs(index)" />
             </template>
           </template>

--- a/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
+++ b/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
@@ -7,22 +7,22 @@
         @blur="validations.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
         :error="validations.saturday.$error" @blur="validations.saturday.$touch"
-        :error-message="nbrError('newSurcharge.saturday')" />
+        :error-message="nbrErrors.saturday" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
         :error="validations.sunday.$error" @blur="validations.sunday.$touch"
-        :error-message="nbrError('newSurcharge.sunday')" />
+        :error-message="nbrErrors.sunday" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
         :error="validations.publicHoliday.$error" @blur="validations.publicHoliday.$touch"
-        :error-message="nbrError('newSurcharge.publicHoliday')" />
+        :error-message="nbrErrors.publicHoliday" />
       <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
-        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrError('newSurcharge.twentyFifthOfDecember')"
+        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrErrors.twentyFifthOfDecember"
         @blur="validations.twentyFifthOfDecember.$touch" :error="validations.twentyFifthOfDecember.$error" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
         :error="validations.firstOfMay.$error" @blur="validations.firstOfMay.$touch"
-        :error-message="nbrError('newSurcharge.firstOfMay')" />
+        :error-message="nbrErrors.firstOfMay" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
         :error="validations.evening.$error" @blur="validations.evening.$touch"
-        :error-message="nbrError('newSurcharge.evening')" />
+        :error-message="nbrErrors.evening" />
       <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
         :error="validations.eveningStartTime.$error" @blur="validations.eveningStartTime.$touch"
         :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
@@ -48,6 +48,7 @@
 import Modal from '@components/modal/Modal';
 import Input from '@components/form/Input';
 import { configMixin } from 'src/modules/client/mixins/configMixin';
+import TimeInput from '@components/form/TimeInput';
 
 export default {
   name: 'SurchargeCreationModal',
@@ -57,10 +58,13 @@ export default {
     newSurcharge: { type: Object, default: () => ({}) },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
+    nbrErrors: { type: Object, default: () => ({}) },
   },
   components: {
     'ni-input': Input,
     'ni-modal': Modal,
+    'ni-time-input': TimeInput,
+
   },
   methods: {
     hide () {

--- a/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
+++ b/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
@@ -7,23 +7,23 @@
         @blur="validations.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
         :error="validations.saturday.$error" @blur="validations.saturday.$touch"
-        :error-message="nbrError('newSurcharge.saturday', validations)" />
+        :error-message="nbrError('saturday', validations)" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
         :error="validations.sunday.$error" @blur="validations.sunday.$touch"
-        :error-message="nbrError('newSurcharge.sunday', validations)" />
+        :error-message="nbrError('sunday', validations)" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
         :error="validations.publicHoliday.$error" @blur="validations.publicHoliday.$touch"
-        :error-message="nbrError('newSurcharge.publicHoliday', validations)" />
+        :error-message="nbrError('publicHoliday', validations)" />
       <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
         v-model="newSurcharge.twentyFifthOfDecember" :error="validations.twentyFifthOfDecember.$error"
-        :error-message="nbrError('newSurcharge.twentyFifthOfDecember', validations)"
+        :error-message="nbrError('twentyFifthOfDecember', validations)"
         @blur="validations.twentyFifthOfDecember.$touch" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
         :error="validations.firstOfMay.$error" @blur="validations.firstOfMay.$touch"
-        :error-message="nbrError('newSurcharge.firstOfMay', validations)" />
+        :error-message="nbrError('firstOfMay', validations)" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
         :error="validations.evening.$error" @blur="validations.evening.$touch"
-        :error-message="nbrError('newSurcharge.evening', validations)" />
+        :error-message="nbrError('evening', validations)" />
       <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
         :error="validations.eveningStartTime.$error" :disable="!newSurcharge.evening"
         @blur="validations.eveningStartTime.$touch" error-message="Heure invalide"
@@ -61,11 +61,6 @@ export default {
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
   },
-  data () {
-    return {
-      
-    }
-  }
   components: {
     'ni-input': Input,
     'ni-modal': Modal,

--- a/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
+++ b/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
@@ -3,39 +3,39 @@
       <template slot="title">
         Créer un <span class="text-weight-bold">plan de majoration</span>
       </template>
-      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="validations.name.$error"
-        @blur="validations.name.$touch" required-field />
+      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="$v.newSurcharge.name.$error"
+        @blur="$v.newSurcharge.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
-        :error="validations.saturday.$error" @blur="validations.saturday.$touch"
-        :error-message="nbrErrors.saturday" />
+        :error="$v.newSurcharge.saturday.$error" @blur="$v.newSurcharge.saturday.$touch"
+        :error-message="nbrError('newSurcharge.saturday')" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
-        :error="validations.sunday.$error" @blur="validations.sunday.$touch"
-        :error-message="nbrErrors.sunday" />
+        :error="$v.newSurcharge.sunday.$error" @blur="$v.newSurcharge.sunday.$touch"
+        :error-message="nbrError('newSurcharge.sunday')" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
-        :error="validations.publicHoliday.$error" @blur="validations.publicHoliday.$touch"
-        :error-message="nbrErrors.publicHoliday" />
+        :error="$v.newSurcharge.publicHoliday.$error" @blur="$v.newSurcharge.publicHoliday.$touch"
+        :error-message="nbrError('newSurcharge.publicHoliday')" />
       <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
-        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrErrors.twentyFifthOfDecember"
-        @blur="validations.twentyFifthOfDecember.$touch" :error="validations.twentyFifthOfDecember.$error" />
+        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrError('newSurcharge.twentyFifthOfDecember')"
+        @blur="$v.newSurcharge.twentyFifthOfDecember.$touch" :error="$v.newSurcharge.twentyFifthOfDecember.$error" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
-        :error="validations.firstOfMay.$error" @blur="validations.firstOfMay.$touch"
-        :error-message="nbrErrors.firstOfMay" />
+        :error="$v.newSurcharge.firstOfMay.$error" @blur="$v.newSurcharge.firstOfMay.$touch"
+        :error-message="nbrError('newSurcharge.firstOfMay')" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
-        :error="validations.evening.$error" @blur="validations.evening.$touch"
-        :error-message="nbrErrors.evening" />
+        :error="$v.newSurcharge.evening.$error" @blur="$v.newSurcharge.evening.$touch"
+        :error-message="nbrError('newSurcharge.evening')" />
       <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
-        :error="validations.eveningStartTime.$error" @blur="validations.eveningStartTime.$touch"
+        :error="$v.newSurcharge.eveningStartTime.$error" @blur="$v.newSurcharge.eveningStartTime.$touch"
         :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
       <ni-time-input in-modal v-model="newSurcharge.eveningEndTime" caption="Fin soirée"
-        :error="validations.eveningEndTime.$error" @blur="validations.eveningEndTime.$touch"
+        :error="$v.newSurcharge.eveningEndTime.$error" @blur="$v.newSurcharge.eveningEndTime.$touch"
         :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
       <ni-input in-modal caption="Majoration personnalisée" suffix="%" type="number" v-model="newSurcharge.custom"
-        :error="validations.custom.$error" @blur="validations.custom.$touch" />
+        :error="$v.newSurcharge.custom.$error" @blur="$v.newSurcharge.custom.$touch" />
       <ni-time-input in-modal v-model="newSurcharge.customStartTime" caption="Début personnalisé"
-        :error="validations.customStartTime.$error" @blur="validations.customStartTime.$touch"
+        :error="$v.newSurcharge.customStartTime.$error" @blur="$v.newSurcharge.customStartTime.$touch"
         :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
       <ni-time-input in-modal v-model="newSurcharge.customEndTime" caption="Fin personnalisée"
-        :error="validations.customEndTime.$error" @blur="validations.customEndTime.$touch"
+        :error="$v.newSurcharge.customEndTime.$error" @blur="$v.newSurcharge.customEndTime.$touch"
         :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
       <template slot="footer">
         <q-btn no-caps class="full-width modal-btn" label="Créer le plan de majoration" icon-right="add" color="primary"
@@ -56,9 +56,9 @@ export default {
   props: {
     value: { type: Boolean, default: false },
     newSurcharge: { type: Object, default: () => ({}) },
-    validations: { type: Object, default: () => ({}) },
+    // eslint-disable-next-line vue/prop-name-casing
+    $v: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
-    nbrErrors: { type: Object, default: () => ({}) },
   },
   components: {
     'ni-input': Input,

--- a/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
+++ b/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
@@ -3,41 +3,41 @@
       <template slot="title">
         Créer un <span class="text-weight-bold">plan de majoration</span>
       </template>
-      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="validations.newSurcharge.name.$error"
-        @blur="validations.newSurcharge.name.$touch" required-field />
+      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="validations.name.$error"
+        @blur="validations.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
-        :error="validations.newSurcharge.saturday.$error" @blur="validations.newSurcharge.saturday.$touch"
+        :error="validations.saturday.$error" @blur="validations.saturday.$touch"
         :error-message="nbrError('newSurcharge.saturday', validations)" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
-        :error="validations.newSurcharge.sunday.$error" @blur="validations.newSurcharge.sunday.$touch"
+        :error="validations.sunday.$error" @blur="validations.sunday.$touch"
         :error-message="nbrError('newSurcharge.sunday', validations)" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
-        :error="validations.newSurcharge.publicHoliday.$error" @blur="validations.newSurcharge.publicHoliday.$touch"
+        :error="validations.publicHoliday.$error" @blur="validations.publicHoliday.$touch"
         :error-message="nbrError('newSurcharge.publicHoliday', validations)" />
       <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
-        v-model="newSurcharge.twentyFifthOfDecember" :error="validations.newSurcharge.twentyFifthOfDecember.$error"
+        v-model="newSurcharge.twentyFifthOfDecember" :error="validations.twentyFifthOfDecember.$error"
         :error-message="nbrError('newSurcharge.twentyFifthOfDecember', validations)"
-        @blur="validations.newSurcharge.twentyFifthOfDecember.$touch" />
+        @blur="validations.twentyFifthOfDecember.$touch" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
-        :error="validations.newSurcharge.firstOfMay.$error" @blur="validations.newSurcharge.firstOfMay.$touch"
+        :error="validations.firstOfMay.$error" @blur="validations.firstOfMay.$touch"
         :error-message="nbrError('newSurcharge.firstOfMay', validations)" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
-        :error="validations.newSurcharge.evening.$error" @blur="validations.newSurcharge.evening.$touch"
+        :error="validations.evening.$error" @blur="validations.evening.$touch"
         :error-message="nbrError('newSurcharge.evening', validations)" />
       <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
-        :error="validations.newSurcharge.eveningStartTime.$error" :disable="!newSurcharge.evening"
-        @blur="validations.newSurcharge.eveningStartTime.$touch" error-message="Heure invalide"
+        :error="validations.eveningStartTime.$error" :disable="!newSurcharge.evening"
+        @blur="validations.eveningStartTime.$touch" error-message="Heure invalide"
         :required-field="!!newSurcharge.evening" />
       <ni-time-input in-modal v-model="newSurcharge.eveningEndTime" caption="Fin soirée"
-        :error="validations.newSurcharge.eveningEndTime.$error" @blur="validations.newSurcharge.eveningEndTime.$touch"
+        :error="validations.eveningEndTime.$error" @blur="validations.eveningEndTime.$touch"
         :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
       <ni-input in-modal caption="Majoration personnalisée" suffix="%" type="number" v-model="newSurcharge.custom"
-        :error="validations.newSurcharge.custom.$error" @blur="validations.newSurcharge.custom.$touch" />
+        :error="validations.custom.$error" @blur="validations.custom.$touch" />
       <ni-time-input in-modal v-model="newSurcharge.customStartTime" caption="Début personnalisé"
-        :error="validations.newSurcharge.customStartTime.$error" @blur="validations.newSurcharge.customStartTime.$touch"
+        :error="validations.customStartTime.$error" @blur="validations.customStartTime.$touch"
         :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
       <ni-time-input in-modal v-model="newSurcharge.customEndTime" caption="Fin personnalisée"
-        :error="validations.newSurcharge.customEndTime.$error" @blur="validations.newSurcharge.customEndTime.$touch"
+        :error="validations.customEndTime.$error" @blur="validations.customEndTime.$touch"
         :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
       <template slot="footer">
         <q-btn no-caps class="full-width modal-btn" label="Créer le plan de majoration" icon-right="add" color="primary"
@@ -61,6 +61,11 @@ export default {
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
   },
+  data () {
+    return {
+      
+    }
+  }
   components: {
     'ni-input': Input,
     'ni-modal': Modal,

--- a/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
+++ b/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
@@ -1,0 +1,77 @@
+<template>
+  <ni-modal :value="value" @hide="hide" @input="input">
+      <template slot="title">
+        Créer un <span class="text-weight-bold">plan de majoration</span>
+      </template>
+      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="validations.name.$error"
+        @blur="validations.name.$touch" required-field />
+      <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
+        :error="validations.saturday.$error" @blur="validations.saturday.$touch"
+        :error-message="nbrError('newSurcharge.saturday')" />
+      <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
+        :error="validations.sunday.$error" @blur="validations.sunday.$touch"
+        :error-message="nbrError('newSurcharge.sunday')" />
+      <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
+        :error="validations.publicHoliday.$error" @blur="validations.publicHoliday.$touch"
+        :error-message="nbrError('newSurcharge.publicHoliday')" />
+      <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
+        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrError('newSurcharge.twentyFifthOfDecember')"
+        @blur="validations.twentyFifthOfDecember.$touch" :error="validations.twentyFifthOfDecember.$error" />
+      <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
+        :error="validations.firstOfMay.$error" @blur="validations.firstOfMay.$touch"
+        :error-message="nbrError('newSurcharge.firstOfMay')" />
+      <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
+        :error="validations.evening.$error" @blur="validations.evening.$touch"
+        :error-message="nbrError('newSurcharge.evening')" />
+      <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
+        :error="validations.eveningStartTime.$error" @blur="validations.eveningStartTime.$touch"
+        :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
+      <ni-time-input in-modal v-model="newSurcharge.eveningEndTime" caption="Fin soirée"
+        :error="validations.eveningEndTime.$error" @blur="validations.eveningEndTime.$touch"
+        :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
+      <ni-input in-modal caption="Majoration personnalisée" suffix="%" type="number" v-model="newSurcharge.custom"
+        :error="validations.custom.$error" @blur="validations.custom.$touch" />
+      <ni-time-input in-modal v-model="newSurcharge.customStartTime" caption="Début personnalisé"
+        :error="validations.customStartTime.$error" @blur="validations.customStartTime.$touch"
+        :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
+      <ni-time-input in-modal v-model="newSurcharge.customEndTime" caption="Fin personnalisée"
+        :error="validations.customEndTime.$error" @blur="validations.customEndTime.$touch"
+        :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
+      <template slot="footer">
+        <q-btn no-caps class="full-width modal-btn" label="Créer le plan de majoration" icon-right="add" color="primary"
+          :loading="loading" @click="submit" />
+      </template>
+    </ni-modal>
+</template>
+
+<script>
+import Modal from '@components/modal/Modal';
+import Input from '@components/form/Input';
+import { configMixin } from 'src/modules/client/mixins/configMixin';
+
+export default {
+  name: 'SurchargeCreationModal',
+  mixins: [configMixin],
+  props: {
+    value: { type: Boolean, default: false },
+    newSurcharge: { type: Object, default: () => ({}) },
+    validations: { type: Object, default: () => ({}) },
+    loading: { type: Boolean, default: false },
+  },
+  components: {
+    'ni-input': Input,
+    'ni-modal': Modal,
+  },
+  methods: {
+    hide () {
+      this.$emit('hide');
+    },
+    input (event) {
+      this.$emit('input', event);
+    },
+    submit () {
+      this.$emit('submit');
+    },
+  },
+};
+</script>

--- a/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
+++ b/src/modules/client/pages/ni/config/SurchargeCreationModal.vue
@@ -3,39 +3,41 @@
       <template slot="title">
         Créer un <span class="text-weight-bold">plan de majoration</span>
       </template>
-      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="$v.newSurcharge.name.$error"
-        @blur="$v.newSurcharge.name.$touch" required-field />
+      <ni-input in-modal caption="Nom" v-model="newSurcharge.name" :error="validations.newSurcharge.name.$error"
+        @blur="validations.newSurcharge.name.$touch" required-field />
       <ni-input in-modal caption="Majoration samedi" suffix="%" type="number" v-model="newSurcharge.saturday"
-        :error="$v.newSurcharge.saturday.$error" @blur="$v.newSurcharge.saturday.$touch"
-        :error-message="nbrError('newSurcharge.saturday')" />
+        :error="validations.newSurcharge.saturday.$error" @blur="validations.newSurcharge.saturday.$touch"
+        :error-message="nbrError('newSurcharge.saturday', validations)" />
       <ni-input in-modal caption="Majoration dimanche" suffix="%" type="number" v-model="newSurcharge.sunday"
-        :error="$v.newSurcharge.sunday.$error" @blur="$v.newSurcharge.sunday.$touch"
-        :error-message="nbrError('newSurcharge.sunday')" />
+        :error="validations.newSurcharge.sunday.$error" @blur="validations.newSurcharge.sunday.$touch"
+        :error-message="nbrError('newSurcharge.sunday', validations)" />
       <ni-input in-modal caption="Majoration jour férié" suffix="%" type="number" v-model="newSurcharge.publicHoliday"
-        :error="$v.newSurcharge.publicHoliday.$error" @blur="$v.newSurcharge.publicHoliday.$touch"
-        :error-message="nbrError('newSurcharge.publicHoliday')" />
+        :error="validations.newSurcharge.publicHoliday.$error" @blur="validations.newSurcharge.publicHoliday.$touch"
+        :error-message="nbrError('newSurcharge.publicHoliday', validations)" />
       <ni-input in-modal caption="Majoration 25 décembre" suffix="%" type="number"
-        v-model="newSurcharge.twentyFifthOfDecember" :error-message="nbrError('newSurcharge.twentyFifthOfDecember')"
-        @blur="$v.newSurcharge.twentyFifthOfDecember.$touch" :error="$v.newSurcharge.twentyFifthOfDecember.$error" />
+        v-model="newSurcharge.twentyFifthOfDecember" :error="validations.newSurcharge.twentyFifthOfDecember.$error"
+        :error-message="nbrError('newSurcharge.twentyFifthOfDecember', validations)"
+        @blur="validations.newSurcharge.twentyFifthOfDecember.$touch" />
       <ni-input in-modal caption="Majoration 1er mai" suffix="%" type="number" v-model="newSurcharge.firstOfMay"
-        :error="$v.newSurcharge.firstOfMay.$error" @blur="$v.newSurcharge.firstOfMay.$touch"
-        :error-message="nbrError('newSurcharge.firstOfMay')" />
+        :error="validations.newSurcharge.firstOfMay.$error" @blur="validations.newSurcharge.firstOfMay.$touch"
+        :error-message="nbrError('newSurcharge.firstOfMay', validations)" />
       <ni-input in-modal caption="Majoration soirée" suffix="%" type="number" v-model="newSurcharge.evening"
-        :error="$v.newSurcharge.evening.$error" @blur="$v.newSurcharge.evening.$touch"
-        :error-message="nbrError('newSurcharge.evening')" />
+        :error="validations.newSurcharge.evening.$error" @blur="validations.newSurcharge.evening.$touch"
+        :error-message="nbrError('newSurcharge.evening', validations)" />
       <ni-time-input in-modal v-model="newSurcharge.eveningStartTime" caption="Début soirée"
-        :error="$v.newSurcharge.eveningStartTime.$error" @blur="$v.newSurcharge.eveningStartTime.$touch"
-        :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
+        :error="validations.newSurcharge.eveningStartTime.$error" :disable="!newSurcharge.evening"
+        @blur="validations.newSurcharge.eveningStartTime.$touch" error-message="Heure invalide"
+        :required-field="!!newSurcharge.evening" />
       <ni-time-input in-modal v-model="newSurcharge.eveningEndTime" caption="Fin soirée"
-        :error="$v.newSurcharge.eveningEndTime.$error" @blur="$v.newSurcharge.eveningEndTime.$touch"
+        :error="validations.newSurcharge.eveningEndTime.$error" @blur="validations.newSurcharge.eveningEndTime.$touch"
         :disable="!newSurcharge.evening" :required-field="!!newSurcharge.evening" error-message="Heure invalide" />
       <ni-input in-modal caption="Majoration personnalisée" suffix="%" type="number" v-model="newSurcharge.custom"
-        :error="$v.newSurcharge.custom.$error" @blur="$v.newSurcharge.custom.$touch" />
+        :error="validations.newSurcharge.custom.$error" @blur="validations.newSurcharge.custom.$touch" />
       <ni-time-input in-modal v-model="newSurcharge.customStartTime" caption="Début personnalisé"
-        :error="$v.newSurcharge.customStartTime.$error" @blur="$v.newSurcharge.customStartTime.$touch"
+        :error="validations.newSurcharge.customStartTime.$error" @blur="validations.newSurcharge.customStartTime.$touch"
         :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
       <ni-time-input in-modal v-model="newSurcharge.customEndTime" caption="Fin personnalisée"
-        :error="$v.newSurcharge.customEndTime.$error" @blur="$v.newSurcharge.customEndTime.$touch"
+        :error="validations.newSurcharge.customEndTime.$error" @blur="validations.newSurcharge.customEndTime.$touch"
         :disable="!newSurcharge.custom" :required-field="!!newSurcharge.custom" error-message="Heure invalide" />
       <template slot="footer">
         <q-btn no-caps class="full-width modal-btn" label="Créer le plan de majoration" icon-right="add" color="primary"
@@ -56,8 +58,7 @@ export default {
   props: {
     value: { type: Boolean, default: false },
     newSurcharge: { type: Object, default: () => ({}) },
-    // eslint-disable-next-line vue/prop-name-casing
-    $v: { type: Object, default: () => ({}) },
+    validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
   },
   components: {


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile

- Périmètre interface : client

- Périmètre rôles : admin

- Cas d'usage : dans configuration bénéficiaire, j'ajoute une nouvelle majoration

l'affichage des erreurs pour les `numberInputs` se fait depuis la _configMixin_ : la fonction `nbrError` accède au `$v` de l'objet courant, or ici cela ne peut pas fonctionnner car `$v` est toujours remplacé par `validations` dans nos composants. J'ai donc remis `$v` comme prop mais on perd un peu en cohérence

qu'en pensez vous?