### PR TITLE
Com 1560 - Fix courses count

### DIFF
--- a/src/modules/vendor/pages/ni/users/learners/LearnersDirectory.vue
+++ b/src/modules/vendor/pages/ni/users/learners/LearnersDirectory.vue
@@ -63,9 +63,9 @@ export default {
           style: 'min-width: 100px; width: 15%',
         },
         {
-          name: 'coursesCount',
+          name: 'blendedCoursesCount',
           label: 'Formations suivies',
-          field: 'coursesCount',
+          field: 'blendedCoursesCount',
           align: 'center',
           sortable: true,
           style: 'min-width: 110px; width: 15%',
@@ -102,7 +102,7 @@ export default {
           noDiacriticsName: removeDiacritics(formattedName),
         },
         company: user.company ? user.company.name : 'N/A',
-        coursesCount: user.coursesCount,
+        blendedCoursesCount: user.blendedCoursesCount,
       };
     },
     async getLearnerList () {


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Vendor

- Périmetre roles : apprenant / rof / admin

- Cas d'usage :
Sur la page répertoire apprenant, la colonne 'formation suivies' ne prends pas en compte les formation e_learning. Fait suite au changement du nom de variable dans le back de coursesCount
