### PR TITLE
COM-1597 hide modal on submit for sector creation and edition modal

### DIFF
--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -707,7 +707,7 @@ export default {
         const payload = this.getSurchargePayload(this.newSurcharge);
         await Surcharges.create(payload);
         NotifyPositive('Plan de majoration créé.');
-        this.resetCreationSurchargeData();
+        this.surchargeCreationModal = false;
         await this.refreshSurcharges();
       } catch (e) {
         console.error(e);
@@ -767,7 +767,7 @@ export default {
         delete payload.company;
         await Surcharges.updateById(surchargeId, payload);
         NotifyPositive('Plan de majoration modifié.');
-        this.resetEditionSurchargeData();
+        this.surchargeEditionModal = false;
         await this.refreshSurcharges();
       } catch (e) {
         console.error(e);
@@ -837,7 +837,7 @@ export default {
         await Services.create(payload);
 
         NotifyPositive('Service créé.');
-        this.resetCreationServiceData();
+        this.serviceCreationModal = false;
         await this.refreshServices();
       } catch (e) {
         console.error(e);
@@ -891,7 +891,7 @@ export default {
         await Services.updateById(this.editedService._id, payload);
 
         NotifyPositive('Service modifié');
-        this.resetEditionServiceData();
+        this.serviceEditionModal = false;
         await this.refreshServices();
       } catch (e) {
         console.error(e);

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -394,6 +394,7 @@ export default {
         this.loading = true;
         await Sectors.create(this.newSector);
         NotifyPositive('Équipe créée.');
+        this.sectorCreationModal = false;
         this.resetCreationSectorData();
         await this.getSectors();
       } catch (e) {
@@ -422,6 +423,7 @@ export default {
         this.loading = true;
         await Sectors.updateById(this.editedSector._id, { name: this.editedSector.name });
         NotifyPositive('Équipe modifiée.');
+        this.sectorEditionModal = false;
         this.resetEditionSectorData();
         await this.getSectors();
       } catch (e) {

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -395,7 +395,6 @@ export default {
         await Sectors.create(this.newSector);
         NotifyPositive('Équipe créée.');
         this.sectorCreationModal = false;
-        this.resetCreationSectorData();
         await this.getSectors();
       } catch (e) {
         console.error(e);
@@ -424,7 +423,6 @@ export default {
         await Sectors.updateById(this.editedSector._id, { name: this.editedSector.name });
         NotifyPositive('Équipe modifiée.');
         this.sectorEditionModal = false;
-        this.resetEditionSectorData();
         await this.getSectors();
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : sur la page rh config, lorsque je valide l'ajout ou la modification d'une equipe, la modale se ferme
