### PR TITLE
COM_1587 disable sub if service is archived

### DIFF
--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -178,9 +178,8 @@ export default {
         ...this.newEvent,
         address: get(this.selectedCustomer, 'contact.primaryAddress', {}),
       };
-      if (this.customerSubscriptionsOptions.length === 1) {
-        payload.subscription = this.customerSubscriptionsOptions[0].value;
-      }
+      const cusSubNotArchived = this.customerSubscriptionsOptions.filter(sub => !sub.disable);
+      if (cusSubNotArchived.length === 1) payload.subscription = cusSubNotArchived[0].value;
       this.$emit('update:newEvent', payload);
     },
     toggleAddressSelect () {

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -141,7 +141,11 @@ export const planningModalMixin = {
       if (!this.selectedCustomer || !this.selectedCustomer.subscriptions ||
         this.selectedCustomer.subscriptions.length === 0) return [];
 
-      return this.selectedCustomer.subscriptions.map(sub => ({ label: get(sub, 'service.name'), value: sub._id }));
+      return this.selectedCustomer.subscriptions.map(sub => ({
+        label: get(sub, 'service.name') || '',
+        value: sub._id,
+        disable: get(sub, 'service.isArchived') || false,
+      }));
     },
     additionalValue () {
       return !this.selectedAuxiliary._id ? '' : `justificatif_absence_${this.selectedAuxiliary.identity.lastname}`;


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : aux/coach/admin

- Cas d'usage : Si un service est archive, je ne peux pas ajouter/modifier un evenement avec une souscription liée a ce service. 