### PR TITLE
COM-1585-fix - Fix updateCard

### DIFF
--- a/src/modules/vendor/mixins/templateMixin.js
+++ b/src/modules/vendor/mixins/templateMixin.js
@@ -43,7 +43,7 @@ export const templateMixin = {
           if (validation.$error) return NotifyWarning('Champ(s) invalide(s)');
         }
 
-        await Cards.updateById(this.card._id, set({}, path, value.trim()));
+        await Cards.updateById(this.card._id, set({}, path, typeof value === 'string' ? value.trim() : value));
 
         await this.refreshCard();
         NotifyPositive('Carte mise à jour.');


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : VENDOR

- Périmetre roles : ROF / admin

- Cas d'usage :
Sur la carte QuestionAnswer, lorsque je sélectionne 'sélection multiple', je reçois un message d'erreur de mise à jour de la carte. Cela venait du fait qu'on utilise updateCard pour mettre à jour la valeur de ce booléen et qu'on ajoutait '.trim()' à ce booléen.
