### PR TITLE
CON-1621 - fix csv to match with table

### DIFF
--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -280,7 +280,7 @@ export const payMixin = {
           startDate ? this.$moment(startDate).format('DD/MM/YYYY') : '',
           endDate ? this.$moment(endDate).format('DD/MM/YYYY') : '',
           this.formatNumberForCSV(draftPay.contractHours),
-          this.formatHoursWithDiff(draftPay, 'hoursToWork'),
+          this.formatNumberForCSV(draftPay.hoursToWork - draftPay.diff.absencesHours),
           this.formatHoursWithDiff(draftPay, 'workedHours'),
           this.formatHoursWithDiff(draftPay, 'notSurchargedAndExempt'),
           this.formatHoursWithDiff(draftPay, 'surchargedAndExempt'),


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - non pertinent

- Périmetre interface : Client

- Périmetre roles : Admin / Coach

- Cas d'usage : 
Dans le tableau d ela paie mensuelle, colonne "Heures à travailler" on affichait `hoursToWork - diff.absencesHours` mais dans l'export on affichait `hoursToWork - diff.hoursToWork` (alors meme que diff.hoursToWork n'existe pas... )
