### PR TITLE
COM-1606 new Romain's sketch

### DIFF
--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -64,7 +64,7 @@ export default {
   justify-content: space-between
   width: 312px
   @media screen and (max-width: 767px)
-    width: 212px
+    width: 100%
 
 .chart
   display: flex
@@ -77,14 +77,14 @@ export default {
   width: 56px
   height: 160px
   @media screen and (max-width: 767px)
-    width: 36px
+    width: 32px
 
 .chart-footer
   display: flex
   justify-content: space-between
   width: 312px
   @media screen and (max-width: 767px)
-    width: 212px
+    width: 100%
 
 .bar-fill
   position: absolute

--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -58,14 +58,14 @@ export default {
 
 .percentage
   text-align: center
-  @media screen and (max-width: 767px)
+  @media screen and (max-width: 420px)
     font-size: 12px
 
 .bar-container
   display: flex
   justify-content: space-between
   width: 312px
-  @media screen and (max-width: 767px)
+  @media screen and (max-width: 420px)
     width: 100%
 
 .chart
@@ -78,21 +78,21 @@ export default {
   background-color: $neutral-beige
   width: 56px
   height: 160px
-  @media screen and (max-width: 767px)
+  @media screen and (max-width: 420px)
     width: 32px
 
 .chart-footer
   display: flex
   justify-content: space-between
   width: 312px
-  @media screen and (max-width: 767px)
+  @media screen and (max-width: 420px)
     width: 100%
 
 .left-label
-  width: 40%
+  width: 30%
 
 .right-label
-  width: 40%
+  width: 30%
   text-align: right
 
 .bar-fill

--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -5,9 +5,9 @@
     <div class="chart">
       <div class="bar-container">
         <div v-for="(line, index) in lines" :key="index">
-          <div class="bar rounded-borders">
-            <div class="bar-fill rounded-borders" :style="`height: ${line.percentage * 100}%`" />
-            <div class="bar-label">{{ index + 1 }}</div>
+          <div class="bar">
+            <div class="bar-fill" :style="`height: ${line.percentage * 100}%`" />
+            <div class="q-mt-sm bar-label">{{ index + 1 }}</div>
           </div>
           <div class="percentage">{{ formatPercentage(line.percentage) }}</div>
         </div>
@@ -61,10 +61,10 @@ export default {
 
 .bar-container
   display: flex
-  justify-content: space-evenly
-  width: 50%
+  justify-content: space-between
+  width: 312px
   @media screen and (max-width: 767px)
-    width: 100%
+    width: 212px
 
 .chart
   display: flex
@@ -72,28 +72,30 @@ export default {
 
 .bar
   position: relative
+  border-radius: 8px
   background-color: $neutral-beige
-  width: 48px
-  height: 320px
+  width: 56px
+  height: 160px
   @media screen and (max-width: 767px)
-    width: 32px
+    width: 36px
 
 .chart-footer
   display: flex
   justify-content: space-between
-  width: 50%
+  width: 312px
   @media screen and (max-width: 767px)
-    width: 100%
+    width: 212px
 
 .bar-fill
   position: absolute
+  border-radius: 8px
   bottom: 0px
   background-color: $middle-beige
   width: 100%
 
 .bar-label
   position: absolute
-  font-size: 14px
+  font-size: 16px
   color: black
   text-align: center
   width: 100%

--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -13,8 +13,8 @@
         </div>
       </div>
       <div class="chart-footer">
-        <div>{{ this.card.label.left }}</div>
-        <div>{{ this.card.label.right }}</div>
+        <div class="left-label">{{ this.card.label.left }}</div>
+        <div class="right-label">{{ this.card.label.right }}</div>
       </div>
     </div>
   </q-card>
@@ -58,6 +58,8 @@ export default {
 
 .percentage
   text-align: center
+  @media screen and (max-width: 767px)
+    font-size: 12px
 
 .bar-container
   display: flex
@@ -85,6 +87,13 @@ export default {
   width: 312px
   @media screen and (max-width: 767px)
     width: 100%
+
+.left-label
+  width: 40%
+
+.right-label
+  width: 40%
+  text-align: right
 
 .bar-fill
   position: absolute


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : formateur

- Cas d'usage : maquette revue par Romain

INFO: je n'ai pas géré la taille de la zone de texte (cf point 4)

NOTE DE ROMAIN:
Est ce que c’est facile de régler la taille des rectangles, ainsi que l’espaces qui les sépare ? Si oui, peux-tu essayer de coller à la maquette que je viens de mettre à jour ? 
* largeur de 56px
* hauteur de 160px
* espace de 8px entre chaque rectangle
* la zone de texte pour les labels qui ne dépasse pas la moitié de la 2ème colonne (soit 56 + 8 + 56/2 = 92 px de largeur pour la zone texte)
* Rajouter une marge entre les chiffres “1, 2, 3, 4, 5” et le haut du rectangle de 8px
