### PR TITLE
Com 1628 - Upload Image, Video and Audio

### DIFF
--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -17,7 +17,7 @@
       <q-uploader ref="uploader" flat :bordered="inModal" color="white" :label="label" :url="url" :headers="headers"
         text-color="black" @failed="failMsg" :form-fields="additionalFields" :max-file-size="maxFileSize"
         @uploaded="documentUploaded" auto-upload :accept="extensions" field-name="file" :multiple="multiple"
-        @rejected="rejected" :disable="disable" />
+        @rejected="rejected" :disable="disable" @start="uploadStarted" @finish="uploadFinished" />
     </q-field>
   </div>
 </template>
@@ -72,6 +72,12 @@ export default {
     },
   },
   methods: {
+    uploadStarted () {
+      this.$emit('start');
+    },
+    uploadFinished () {
+      this.$emit('finish');
+    },
     deleteDocument () {
       this.$emit('delete');
     },

--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -395,3 +395,13 @@ export const SLOT_DELETION = 'slot_deletion';
 export const SLOT_EDITION = 'slot_edition';
 export const TRAINEE_ADDITION = 'trainee_addition';
 export const TRAINEE_DELETION = 'trainee_deletion';
+
+// MEDIA UPLOAD
+export const UPLOAD_IMAGE = 'image';
+export const UPLOAD_VIDEO = 'video';
+export const UPLOAD_AUDIO = 'audio';
+export const UPLOAD_EXTENSION_OPTIONS = [
+  { label: 'Image', value: UPLOAD_IMAGE },
+  { label: 'Video', value: UPLOAD_VIDEO },
+  { label: 'Audio', value: UPLOAD_AUDIO },
+];

--- a/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
+++ b/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
@@ -2,11 +2,12 @@
   <div>
     <ni-input caption="Texte" v-model="card.text" required-field @focus="saveTmp('text')"
       @blur="updateCard('text')" :error="$v.card.text.$error" type="textarea" :disable="disableEdition" />
-    <ni-option-group v-model="selectedExtension" type="radio" :options="extensionOptions" inline />
+    <ni-option-group v-model="card.media.type" type="radio" :options="extensionOptions" inline
+      @input="updateMediaType" :disable="isUploading || !!card.media.publicId" />
     <ni-file-uploader class="file-uploader" caption="Média" path="media" alt="media" :entity="card" name="media"
       @uploaded="mediaUploaded()" @delete="validateMediaDeletion()" :error="$v.card.media.$error"
       :extensions="extensions" cloudinary-storage :additional-value="imageFileName" required-field
-      :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize"
+      :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize" @start="start" @finish="finish"
       :disable="disableEdition || [UPLOAD_VIDEO, UPLOAD_AUDIO].includes(selectedExtension)" />
   </div>
 </template>
@@ -36,6 +37,7 @@ export default {
       extensionOptions: UPLOAD_EXTENSION_OPTIONS,
       UPLOAD_VIDEO,
       UPLOAD_AUDIO,
+      isUploading: false,
     };
   },
   computed: {
@@ -54,6 +56,18 @@ export default {
     return {
       card: { text: { required }, media: { publicId: required, link: required } },
     };
+  },
+  methods: {
+    updateMediaType () {
+      this.selectedExtension = this.card.media.type;
+      this.updateCard('media.type');
+    },
+    start () {
+      this.isUploading = true;
+    },
+    finish () {
+      this.isUploading = false;
+    },
   },
 };
 </script>

--- a/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
+++ b/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
@@ -2,11 +2,10 @@
   <div>
     <ni-input caption="Texte" v-model="card.text" required-field @focus="saveTmp('text')"
       @blur="updateCard('text')" :error="$v.card.text.$error" type="textarea" :disable="disableEdition" />
-    <ni-option-group :display-caption="true" v-model="selectedExtension" type="radio" :options="extensionOptions"
-      inline />
+    <ni-option-group v-model="selectedExtension" type="radio" :options="extensionOptions" inline />
     <ni-file-uploader class="file-uploader" caption="Média" path="media" alt="media" :entity="card" name="media"
       @uploaded="mediaUploaded()" @delete="validateMediaDeletion()" :error="$v.card.media.$error"
-      :extensions="imageExtensions" cloudinary-storage :additional-value="imageFileName" required-field
+      :extensions="extensions" cloudinary-storage :additional-value="imageFileName" required-field
       :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize" :disable="disableEdition" />
   </div>
 </template>
@@ -17,7 +16,7 @@ import Input from '@components/form/Input';
 import FileUploader from '@components/form/FileUploader';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
 import OptionGroup from '@components/form/OptionGroup';
-import { UPLOAD_IMAGE, UPLOAD_EXTENSION_OPTIONS } from '@data/constants';
+import { UPLOAD_IMAGE, UPLOAD_VIDEO, UPLOAD_AUDIO, UPLOAD_EXTENSION_OPTIONS } from '@data/constants';
 
 export default {
   name: 'TextMedia',
@@ -35,6 +34,18 @@ export default {
       selectedExtension: UPLOAD_IMAGE,
       extensionOptions: UPLOAD_EXTENSION_OPTIONS,
     };
+  },
+  computed: {
+    extensions () {
+      switch (this.selectedExtension) {
+        case UPLOAD_VIDEO:
+          return this.videoExtensions;
+        case UPLOAD_AUDIO:
+          return this.audioExtensions;
+        default:
+          return this.imageExtensions;
+      }
+    },
   },
   validations () {
     return {

--- a/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
+++ b/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
@@ -2,9 +2,11 @@
   <div>
     <ni-input caption="Texte" v-model="card.text" required-field @focus="saveTmp('text')"
       @blur="updateCard('text')" :error="$v.card.text.$error" type="textarea" :disable="disableEdition" />
+    <ni-option-group :display-caption="true" v-model="selectedExtension" type="radio" :options="extensionOptions"
+      inline />
     <ni-file-uploader class="file-uploader" caption="Média" path="media" alt="media" :entity="card" name="media"
       @uploaded="mediaUploaded()" @delete="validateMediaDeletion()" :error="$v.card.media.$error"
-      :extensions="extensions" cloudinary-storage :additional-value="imageFileName" required-field
+      :extensions="imageExtensions" cloudinary-storage :additional-value="imageFileName" required-field
       :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize" :disable="disableEdition" />
   </div>
 </template>
@@ -14,17 +16,26 @@ import { required } from 'vuelidate/lib/validators';
 import Input from '@components/form/Input';
 import FileUploader from '@components/form/FileUploader';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
+import OptionGroup from '@components/form/OptionGroup';
+import { UPLOAD_IMAGE, UPLOAD_EXTENSION_OPTIONS } from '@data/constants';
 
 export default {
-  name: 'TitleTextMedia',
+  name: 'TextMedia',
   props: {
     disableEdition: { type: Boolean, default: false },
   },
   components: {
     'ni-input': Input,
     'ni-file-uploader': FileUploader,
+    'ni-option-group': OptionGroup,
   },
   mixins: [templateMixin],
+  data () {
+    return {
+      selectedExtension: UPLOAD_IMAGE,
+      extensionOptions: UPLOAD_EXTENSION_OPTIONS,
+    };
+  },
   validations () {
     return {
       card: { text: { required }, media: { publicId: required, link: required } },

--- a/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
+++ b/src/modules/vendor/components/programs/cards/templates/TextMedia.vue
@@ -6,7 +6,8 @@
     <ni-file-uploader class="file-uploader" caption="Média" path="media" alt="media" :entity="card" name="media"
       @uploaded="mediaUploaded()" @delete="validateMediaDeletion()" :error="$v.card.media.$error"
       :extensions="extensions" cloudinary-storage :additional-value="imageFileName" required-field
-      :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize" :disable="disableEdition" />
+      :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize"
+      :disable="disableEdition || [UPLOAD_VIDEO, UPLOAD_AUDIO].includes(selectedExtension)" />
   </div>
 </template>
 
@@ -33,6 +34,8 @@ export default {
     return {
       selectedExtension: UPLOAD_IMAGE,
       extensionOptions: UPLOAD_EXTENSION_OPTIONS,
+      UPLOAD_VIDEO,
+      UPLOAD_AUDIO,
     };
   },
   computed: {

--- a/src/modules/vendor/components/programs/cards/templates/TitleTextMedia.vue
+++ b/src/modules/vendor/components/programs/cards/templates/TitleTextMedia.vue
@@ -6,7 +6,7 @@
       @blur="updateCard('text')" :error="$v.card.text.$error" type="textarea" :disable="disableEdition" />
     <ni-file-uploader class="file-uploader" caption="Média" path="media" alt="media" :entity="card" name="media"
       @uploaded="mediaUploaded()" @delete="validateMediaDeletion()" :error="$v.card.media.$error"
-      :extensions="extensions" cloudinary-storage :additional-value="imageFileName" required-field
+      :extensions="imageExtensions" cloudinary-storage :additional-value="imageFileName" required-field
       :url="mediaUploadUrl" label="Pas de média" :max-file-size="maxFileSize" :disable="disableEdition" />
   </div>
 </template>

--- a/src/modules/vendor/mixins/templateMixin.js
+++ b/src/modules/vendor/mixins/templateMixin.js
@@ -10,7 +10,9 @@ export const templateMixin = {
   data () {
     return {
       tmpInput: '',
-      extensions: 'image/jpg, image/jpeg, image/png',
+      imageExtensions: 'image/jpg, image/jpeg, image/png',
+      videoExtensions: 'video/mp4, video/m4v, video/avi',
+      audioExtensions: 'audio/mp3',
       maxFileSize: 2000000,
     };
   },

--- a/src/modules/vendor/mixins/templateMixin.js
+++ b/src/modules/vendor/mixins/templateMixin.js
@@ -20,7 +20,7 @@ export const templateMixin = {
       return this.card.title ? this.card.title.replace(/ /g, '_') : this.activity.name.replace(/ /g, '_');
     },
     mediaUploadUrl () {
-      return `${process.env.API_HOSTNAME}/cards/${this.card._id}/cloudinary/upload`;
+      return `${process.env.API_HOSTNAME}/cards/${this.card._id}/upload`;
     },
     questionErrorMsg () {
       if (!this.$v.card.question.required) return REQUIRED_LABEL;


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendor

- Périmetre roles : rof / admin

- Cas d'usage :
Sur une carte TitleMedia, je peux sélectionner l'input que je souhaite (image, video ou audio).

Ce qu'il manque sur cette PR :
- La gestion de l'upload par GCS (google cloud)