### PR TITLE
COM-1689 - remove x-access-token from bills pdf url

### DIFF
--- a/src/core/api/Bills.js
+++ b/src/core/api/Bills.js
@@ -1,4 +1,3 @@
-import { Cookies } from 'quasar';
 import { alenviAxios } from '@api/ressources/alenviAxios';
 
 export default {
@@ -9,7 +8,10 @@ export default {
   async create (data) {
     return alenviAxios.post(`${process.env.API_HOSTNAME}/bills`, data);
   },
-  getPDFUrl (id) {
-    return `${process.env.API_HOSTNAME}/bills/${id}/pdfs?x-access-token=${Cookies.get('alenvi_token')}`;
+  async getPDF (id) {
+    return alenviAxios.get(
+      `${process.env.API_HOSTNAME}/bills/${id}/pdfs`,
+      { responseType: 'arraybuffer', headers: { Accept: 'application/pdf' } }
+    );
   },
 };

--- a/src/core/helpers/file.js
+++ b/src/core/helpers/file.js
@@ -26,5 +26,5 @@ export const downloadCsv = (data, fileName) => {
 
 export const generatePdfUrl = (pdf) => {
   const blob = new Blob([pdf.data], { type: 'application/pdf' });
-  return window.URL.createObjectURL(blob);
+  return URL.createObjectURL(blob);
 };

--- a/src/core/helpers/file.js
+++ b/src/core/helpers/file.js
@@ -23,3 +23,8 @@ export const downloadCsv = (data, fileName) => {
 
   return downloadFile({ data: csvContent }, fileName);
 };
+
+export const generatePdfUrl = (pdf) => {
+  const blob = new Blob([pdf.data], { type: 'application/pdf' });
+  return window.URL.createObjectURL(blob);
+};

--- a/src/core/pages/DisplayPdf.vue
+++ b/src/core/pages/DisplayPdf.vue
@@ -1,10 +1,10 @@
 <template>
   <div style="width: 100vw; height: 100vh">
     <object :data="blobUrl" :name="fileName" type="application/pdf" width="100%" height="100%" />
-    <big>
-      Votre navigateur ne peut pas charger l'aperçu, vous pouvez télécharger votre document en cliquant
-      <a :href="blobUrl" :download="fileName">ici</a>
-    </big>
+    <div class="info">
+      Si votre navigateur ne peut pas charger l'aperçu, vous pouvez télécharger votre document en
+      cliquant &nbsp;<a :href="blobUrl" :download="fileName">ici</a>
+    </div>
   </div>
 </template>
 
@@ -17,3 +17,9 @@ export default {
   },
 };
 </script>
+
+<style lang="stylus" scoped>
+.info
+  display: flex;
+  justify-content: center;
+</style>

--- a/src/core/pages/DisplayPdf.vue
+++ b/src/core/pages/DisplayPdf.vue
@@ -2,8 +2,8 @@
   <div style="width: 100vw; height: 100vh">
     <object :data="blobUrl" :name="fileName" type="application/pdf" width="100%" height="100%" />
     <div class="info">
-      Si votre navigateur ne peut pas charger l'aperçu, vous pouvez télécharger votre document en
-      cliquant &nbsp;<a :href="blobUrl" :download="fileName">ici</a>
+      Si votre navigateur ne peut pas charger l'aperçu, vous pouvez télécharger votre document&nbsp;
+      <a :href="blobUrl" :download="fileName">en cliquant ici </a>
     </div>
   </div>
 </template>
@@ -20,6 +20,5 @@ export default {
 
 <style lang="stylus" scoped>
 .info
-  display: flex;
-  justify-content: center;
+  text-align: center;
 </style>

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -20,7 +20,8 @@
                 data-cy="link">
                   Facture {{ props.row.number }}
               </a>
-              <div v-else @click="downloadBillPdf(props.row)" class="download" data-cy="link">
+              <div v-else @click="downloadBillPdf(props.row)" :class="{ 'download': canDownload(props.row) }"
+                data-cy="link">
                 Facture {{ props.row.number }}
               </div>
             </template>
@@ -193,7 +194,12 @@ export default {
     getBillUrl (bill) {
       return get(bill, 'driveFile.link');
     },
+    canDownload (bill) {
+      return bill.origin === COMPANI;
+    },
     async downloadBillPdf (bill) {
+      if (!this.canDownload(bill)) return;
+
       try {
         const pdf = await Bills.getPDF(bill._id);
 

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -15,14 +15,14 @@
           :data-label="col.label" :props="props">
           <template v-if="col.name === 'document'">
             <template v-if="props.row.type === BILL">
-              <template v-if="props.row.number">
-                <a data-cy="link" v-if="canDownloadBill(props.row)"
-                  :href="billUrl(props.row)" target="_blank" class="download">
+              <div v-if="!props.row.number">Facture tiers</div>
+              <a v-else-if="getBillUrl(props.row)" :href="getBillUrl(props.row)" target="_blank" class="download"
+                data-cy="link">
                   Facture {{ props.row.number }}
-                </a>
-                <div v-else>Facture {{ props.row.number }}</div>
-              </template>
-              <div v-else>Facture tiers</div>
+              </a>
+              <div v-else @click="downloadBillPdf(props.row)" class="download" data-cy="link">
+                Facture {{ props.row.number }}
+              </div>
             </template>
             <template v-else-if="props.row.type === CREDIT_NOTE">
               <a v-if="canDownloadCreditNote(props.row)" :href="creditNoteUrl(props.row)" target="_blank"
@@ -70,6 +70,7 @@ import Bills from '@api/Bills';
 import CreditNotes from '@api/CreditNotes';
 import SimpleTable from '@components/table/SimpleTable';
 import { formatPrice } from '@helpers/utils';
+import { generatePdfUrl } from '@helpers/file';
 import {
   CREDIT_NOTE,
   BILL,
@@ -189,20 +190,31 @@ export default {
     openEditionModal (payment) {
       this.$emit('open-edition-modal', payment);
     },
-    canDownloadBill (bill) {
-      return (bill.number && bill.origin === COMPANI) || (bill.driveFile && bill.driveFile.link);
+    getBillUrl (bill) {
+      return get(bill, 'driveFile.link');
+    },
+    async downloadBillPdf (bill) {
+      try {
+        const pdf = await Bills.getPDF(bill._id);
+
+        const windowRef = window.open();
+        const route = this.$router.resolve({
+          name: 'display file',
+          params: { fileName: bill.number },
+          query: { blobUrl: generatePdfUrl(pdf) },
+        });
+
+        windowRef.location = route.href;
+      } catch (e) {
+        console.error(e);
+      }
     },
     canDownloadCreditNote (creditNote) {
       return (creditNote.number && creditNote.origin === COMPANI) ||
         (creditNote.driveFile && creditNote.driveFile.link);
     },
-    billUrl (bill) {
-      return get(bill, 'driveFile.link') ? bill.driveFile.link : Bills.getPDFUrl(bill._id);
-    },
     creditNoteUrl (creditNote) {
-      return get(creditNote, 'driveFile.link')
-        ? creditNote.driveFile.link
-        : CreditNotes.getPDFUrl(creditNote._id);
+      return get(creditNote, 'driveFile.link') ? creditNote.driveFile.link : CreditNotes.getPDFUrl(creditNote._id);
     },
   },
 };

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -5,6 +5,12 @@ const routes = [
   { path: '/reset-password/:token', component: () => import('src/core/pages/signin/ResetPassword') },
   { path: '/403-pwd', component: () => import('src/core/pages/signin/403') },
   {
+    path: '/display/:fileName',
+    name: 'display file',
+    component: () => import('src/core/pages/DisplayPdf'),
+    props: route => ({ blobUrl: route.query.blobUrl, fileName: route.params.fileName }),
+  },
+  {
     path: '/docsigned',
     component: () => import('src/core/pages/DocumentSigned'),
     props: route => ({ signed: route.query.signed }),


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client

- Périmetre roles : Admin / Cocah / Aidant

- Cas d'usage : je peux charger mes factures depuis la page de facturation. l'appel se fait via alenviAxios et ne passe plus le `x-access-token` dans l'url

A tester sous chrome, firefox et safari :)
