### PR TITLE
COM-1711 add origin in authentication payload

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -430,3 +430,6 @@ export const ACCESS_OPTIONS = [
   { label: 'Libre accès', value: FREE_ACCESS },
   { label: 'Choisir une structure', value: RESTRICTED_ACCESS },
 ];
+
+// ORIGIN
+export const WEBAPP = 'webapp';

--- a/src/core/mixins/logInMixin.js
+++ b/src/core/mixins/logInMixin.js
@@ -2,6 +2,8 @@ import { mapGetters, mapState } from 'vuex';
 import Users from '@api/Users';
 import { cookieExpirationDate } from '../helpers/alenvi';
 
+const WEBAPP = 'webapp';
+
 export const logInMixin = {
   computed: {
     ...mapGetters({
@@ -12,7 +14,7 @@ export const logInMixin = {
   },
   methods: {
     async logInUser (authenticationPayload) {
-      const auth = await Users.authenticate(authenticationPayload);
+      const auth = await Users.authenticate({ ...authenticationPayload, origin: WEBAPP });
 
       const options = { path: '/', secure: process.env.NODE_ENV !== 'development', sameSite: 'Lax' };
       const expireDate = cookieExpirationDate();

--- a/src/core/mixins/logInMixin.js
+++ b/src/core/mixins/logInMixin.js
@@ -1,8 +1,7 @@
 import { mapGetters, mapState } from 'vuex';
 import Users from '@api/Users';
 import { cookieExpirationDate } from '../helpers/alenvi';
-
-const WEBAPP = 'webapp';
+import { WEBAPP } from '../data/constants';
 
 export const logInMixin = {
   computed: {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client/vendeur

- Périmetre roles : tous

- Cas d'usage : Lorsqu'un utilisateur se connecte on sait s'il se connecte sur la webapp ou sur le mobile. On conserve la premiere fois qu'il se connecte sur l'application mobile.
