### PR TITLE
Com 1691 - refacto qcm/qcu/questionAnswers

### DIFF
--- a/src/core/helpers/vuelidateCustomVal.js
+++ b/src/core/helpers/vuelidateCustomVal.js
@@ -137,6 +137,6 @@ export const minArrayLength = minLength => value => value.filter(a => !!a).lengt
 
 export const maxArrayLength = maxLength => value => value.filter(a => !!a).length <= maxLength;
 
-export const minLabelArrayLength = minLength => value => value.filter(a => !!a.label).length >= minLength;
+export const minTextArrayLength = minLength => value => value.filter(a => !!a.text).length >= minLength;
 
 export const minOneCorrectAnswer = value => value.filter(a => a.correct).length >= 1;

--- a/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
@@ -20,7 +20,6 @@
 <script>
 import get from 'lodash/get';
 import { required, maxLength } from 'vuelidate/lib/validators';
-import Cards from '@api/Cards';
 import Input from '@components/form/Input';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import { REQUIRED_LABEL, QUESTION_MAX_LENGTH, QC_ANSWER_MAX_LENGTH } from '@data/constants';
@@ -62,9 +61,6 @@ export default {
       return this.card.qcAnswers.filter(a => a.correct).length === 1 && this.card.qcAnswers[index].correct &&
         !this.card.qcAnswers[index].text;
     },
-    formatAnswersPayload () {
-      return { qcAnswers: this.card.qcAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
-    },
     async updateAnswer (index) {
       try {
         if (this.tmpInput === get(this.card, `qcAnswers[${index}].text`)) return;
@@ -76,8 +72,6 @@ export default {
         if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
           return NotifyWarning('Une bonne réponse est nécessaire.');
         }
-
-        await Cards.updateById(this.card._id, this.formatAnswersPayload());
 
         await this.refreshCard();
         NotifyPositive('Carte mise à jour.');
@@ -92,8 +86,6 @@ export default {
           return NotifyWarning('Champ(s) invalide(s)');
         }
         if (this.requiredOneCorrectAnswer(index)) return NotifyWarning('Une bonne réponse est nécessaire.');
-
-        await Cards.updateById(this.card._id, this.formatAnswersPayload());
 
         await this.refreshCard();
         NotifyPositive('Carte mise à jour.');

--- a/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
@@ -4,12 +4,12 @@
       @blur="updateCard('question')" :error="$v.card.question.$error" :error-message="questionErrorMsg"
       type="textarea" :disable="disableEdition" />
     <div class="q-my-xl">
-      <div v-for="(qAnswer, i) in card.qAnswers" :key="i" class="answers">
-        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qAnswers[i].text" :required-field="i < 2"
-          @focus="saveTmp(`qAnswers[${i}].text`)" @blur="updateAnswer(i)"
+      <div v-for="(qcAnswer, i) in card.qcAnswers" :key="i" class="answers">
+        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qcAnswers[i].text" :required-field="i < 2"
+          @focus="saveTmp(`qcAnswers[${i}].text`)" @blur="updateAnswer(i)"
           :error="answersError(i)" :error-message="answersErrorMsg(i)" :disable="disableEdition" />
-        <q-checkbox v-model="card.qAnswers[i].correct" @input="updateCorrectAnswer(i)"
-          :disable="!card.qAnswers[i].text || disableEdition" />
+        <q-checkbox v-model="card.qcAnswers[i].correct" @input="updateCorrectAnswer(i)"
+          :disable="!card.qcAnswers[i].text || disableEdition" />
       </div>
     </div>
     <ni-input caption="Correction" v-model="card.explanation" required-field @focus="saveTmp('explanation')"
@@ -40,7 +40,7 @@ export default {
     return {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
-        qAnswers: {
+        qcAnswers: {
           minLength: minTextArrayLength(2),
           minOneCorrectAnswer,
           $each: {
@@ -53,24 +53,24 @@ export default {
   },
   methods: {
     requiredAnswerIsMissing (index) {
-      return index < 2 && !this.card.qAnswers[index].text && this.$v.card.qAnswers.$error;
+      return index < 2 && !this.card.qcAnswers[index].text && this.$v.card.qcAnswers.$error;
     },
     requiredOneCorrectAnswer (index) {
-      return !this.$v.card.qAnswers.minOneCorrectAnswer && !!this.card.qAnswers[index].text;
+      return !this.$v.card.qcAnswers.minOneCorrectAnswer && !!this.card.qcAnswers[index].text;
     },
     removeSingleCorrectAnswer (index) {
-      return this.card.qAnswers.filter(a => a.correct).length === 1 && this.card.qAnswers[index].correct &&
-        !this.card.qAnswers[index].text;
+      return this.card.qcAnswers.filter(a => a.correct).length === 1 && this.card.qcAnswers[index].correct &&
+        !this.card.qcAnswers[index].text;
     },
     formatAnswersPayload () {
-      return { qAnswers: this.card.qAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
+      return { qcAnswers: this.card.qcAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
     },
     async updateAnswer (index) {
       try {
-        if (this.tmpInput === get(this.card, `qAnswers[${index}].text`)) return;
+        if (this.tmpInput === get(this.card, `qcAnswers[${index}].text`)) return;
 
-        this.$v.card.qAnswers.$touch();
-        if (this.requiredAnswerIsMissing(index) || this.$v.card.qAnswers.$each[index].$error) {
+        this.$v.card.qcAnswers.$touch();
+        if (this.requiredAnswerIsMissing(index) || this.$v.card.qcAnswers.$each[index].$error) {
           return NotifyWarning('Champ(s) invalide(s)');
         }
         if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
@@ -88,7 +88,7 @@ export default {
     },
     async updateCorrectAnswer (index) {
       try {
-        if (!this.card.qAnswers[index].text || this.$v.card.qAnswers.$each[index].$error) {
+        if (!this.card.qcAnswers[index].text || this.$v.card.qcAnswers.$each[index].$error) {
           return NotifyWarning('Champ(s) invalide(s)');
         }
         if (this.requiredOneCorrectAnswer(index)) return NotifyWarning('Une bonne réponse est nécessaire.');
@@ -107,13 +107,13 @@ export default {
       if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
         return 'Une bonne réponse est nécessaire.';
       }
-      if (!this.$v.card.qAnswers.$each[index].text.maxLength) {
+      if (!this.$v.card.qcAnswers.$each[index].text.maxLength) {
         return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
       }
       return '';
     },
     answersError (index) {
-      const exceedCharLength = this.$v.card.qAnswers.$each[index].$error;
+      const exceedCharLength = this.$v.card.qcAnswers.$each[index].$error;
       const missingField = this.requiredAnswerIsMissing(index) || this.requiredOneCorrectAnswer(index) ||
         this.removeSingleCorrectAnswer(index);
       return exceedCharLength || missingField;

--- a/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
@@ -1,15 +1,15 @@
 <template>
-  <div v-if="answersInitialized">
+  <div>
     <ni-input caption="Question" v-model="card.question" required-field @focus="saveTmp('question')"
       @blur="updateCard('question')" :error="$v.card.question.$error" :error-message="questionErrorMsg"
       type="textarea" :disable="disableEdition" />
     <div class="q-my-xl">
-      <div v-for="(qcmAnswers, i) in card.qcmAnswers" :key="i" class="answers">
-        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qcmAnswers[i].label" :required-field="i < 2"
-          @focus="saveTmp(`qcmAnswers[${i}].label`)" @blur="updateQcmAnswer(i)"
+      <div v-for="(qAnswer, i) in card.qAnswers" :key="i" class="answers">
+        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qAnswers[i].text" :required-field="i < 2"
+          @focus="saveTmp(`qAnswers[${i}].text`)" @blur="updateAnswer(i)"
           :error="answersError(i)" :error-message="answersErrorMsg(i)" :disable="disableEdition" />
-        <q-checkbox v-model="card.qcmAnswers[i].correct" @input="updateCorrectAnswer(i)"
-          :disable="!card.qcmAnswers[i].label || disableEdition" />
+        <q-checkbox v-model="card.qAnswers[i].correct" @input="updateCorrectAnswer(i)"
+          :disable="!card.qAnswers[i].text || disableEdition" />
       </div>
     </div>
     <ni-input caption="Correction" v-model="card.explanation" required-field @focus="saveTmp('explanation')"
@@ -18,15 +18,13 @@
 </template>
 
 <script>
-import times from 'lodash/times';
 import get from 'lodash/get';
 import { required, maxLength } from 'vuelidate/lib/validators';
 import Cards from '@api/Cards';
 import Input from '@components/form/Input';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
-import { MULTIPLE_CHOICE_QUESTION_MAX_ANSWERS_COUNT, REQUIRED_LABEL, QUESTION_MAX_LENGTH,
-  QC_ANSWER_MAX_LENGTH } from '@data/constants';
-import { minLabelArrayLength, minOneCorrectAnswer } from '@helpers/vuelidateCustomVal';
+import { REQUIRED_LABEL, QUESTION_MAX_LENGTH, QC_ANSWER_MAX_LENGTH } from '@data/constants';
+import { minTextArrayLength, minOneCorrectAnswer } from '@helpers/vuelidateCustomVal';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
 
 export default {
@@ -42,54 +40,37 @@ export default {
     return {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
-        qcmAnswers: {
-          minLength: minLabelArrayLength(2),
+        qAnswers: {
+          minLength: minTextArrayLength(2),
           minOneCorrectAnswer,
           $each: {
-            label: { maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
+            text: { maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
           },
         },
         explanation: { required },
       },
     };
   },
-  computed: {
-    answersInitialized () {
-      return this.card.qcmAnswers.length === MULTIPLE_CHOICE_QUESTION_MAX_ANSWERS_COUNT;
-    },
-  },
-  watch: {
-    card: {
-      handler: 'initializeAnswers',
-      immediate: true,
-    },
-  },
   methods: {
-    initializeAnswers () {
-      this.card.qcmAnswers = times(
-        MULTIPLE_CHOICE_QUESTION_MAX_ANSWERS_COUNT,
-        i => this.card.qcmAnswers[i] || ({ label: '', correct: false })
-      );
-    },
     requiredAnswerIsMissing (index) {
-      return index < 2 && !this.card.qcmAnswers[index].label && this.$v.card.qcmAnswers.$error;
+      return index < 2 && !this.card.qAnswers[index].text && this.$v.card.qAnswers.$error;
     },
     requiredOneCorrectAnswer (index) {
-      return !this.$v.card.qcmAnswers.minOneCorrectAnswer && !!this.card.qcmAnswers[index].label;
+      return !this.$v.card.qAnswers.minOneCorrectAnswer && !!this.card.qAnswers[index].text;
     },
     removeSingleCorrectAnswer (index) {
-      return this.card.qcmAnswers.filter(a => a.correct).length === 1 && this.card.qcmAnswers[index].correct &&
-        !this.card.qcmAnswers[index].label;
+      return this.card.qAnswers.filter(a => a.correct).length === 1 && this.card.qAnswers[index].correct &&
+        !this.card.qAnswers[index].text;
     },
     formatAnswersPayload () {
-      return { qcmAnswers: this.card.qcmAnswers.filter(a => !!a.label).map(a => ({ ...a, label: a.label.trim() })) };
+      return { qAnswers: this.card.qAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
     },
-    async updateQcmAnswer (index) {
+    async updateAnswer (index) {
       try {
-        if (this.tmpInput === get(this.card, `qcmAnswers[${index}].label`)) return;
+        if (this.tmpInput === get(this.card, `qAnswers[${index}].text`)) return;
 
-        this.$v.card.qcmAnswers.$touch();
-        if (this.requiredAnswerIsMissing(index) || this.$v.card.qcmAnswers.$each[index].$error) {
+        this.$v.card.qAnswers.$touch();
+        if (this.requiredAnswerIsMissing(index) || this.$v.card.qAnswers.$each[index].$error) {
           return NotifyWarning('Champ(s) invalide(s)');
         }
         if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
@@ -107,7 +88,7 @@ export default {
     },
     async updateCorrectAnswer (index) {
       try {
-        if (!this.card.qcmAnswers[index].label || this.$v.card.qcmAnswers.$each[index].$error) {
+        if (!this.card.qAnswers[index].text || this.$v.card.qAnswers.$each[index].$error) {
           return NotifyWarning('Champ(s) invalide(s)');
         }
         if (this.requiredOneCorrectAnswer(index)) return NotifyWarning('Une bonne réponse est nécessaire.');
@@ -126,13 +107,13 @@ export default {
       if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
         return 'Une bonne réponse est nécessaire.';
       }
-      if (!this.$v.card.qcmAnswers.$each[index].label.maxLength) {
+      if (!this.$v.card.qAnswers.$each[index].text.maxLength) {
         return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
       }
       return '';
     },
     answersError (index) {
-      const exceedCharLength = this.$v.card.qcmAnswers.$each[index].$error;
+      const exceedCharLength = this.$v.card.qAnswers.$each[index].$error;
       const missingField = this.requiredAnswerIsMissing(index) || this.requiredOneCorrectAnswer(index) ||
         this.removeSingleCorrectAnswer(index);
       return exceedCharLength || missingField;

--- a/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
+++ b/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
@@ -6,10 +6,10 @@
     <q-checkbox v-model="card.isQuestionAnswerMultipleChoiced" @input="updateCard('isQuestionAnswerMultipleChoiced')"
       size="sm" :disable="disableEdition" label="Sélection multiple" />
     <div class="q-my-lg answers">
-      <div v-for="(answer, i) in card.questionAnswers" :key="i" class="answers-container">
-        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.questionAnswers[i].text" :disable="disableEdition"
-          @blur="updateQuestionAnswers(i)" @focus="saveTmp(`questionAnswers[${i}].text`)"
-          :error="$v.card.questionAnswers.$each[i].$error" class="answers-container-input" />
+      <div v-for="(answer, i) in card.qAnswers" :key="i" class="answers-container">
+        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qAnswers[i].text" :disable="disableEdition"
+          @blur="updateQuestionAnswers(i)" @focus="saveTmp(`qAnswers[${i}].text`)"
+          :error="$v.card.qAnswers.$each[i].$error" class="answers-container-input" />
         <ni-button icon="delete" @click="deleteQuestionAnswer(i)" :disable="disableAnswerDeletion" />
       </div>
       <ni-button class="add-button" icon="add" label="Ajouter une réponse" color="primary" @click="addAnswer"
@@ -49,7 +49,7 @@ export default {
     return {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
-        questionAnswers: {
+        qAnswers: {
           required,
           minLength: minArrayLength(QUESTION_ANSWER_MIN_ANSWERS_COUNT),
           maxLength: maxArrayLength(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
@@ -60,22 +60,22 @@ export default {
   },
   computed: {
     disableAnswerCreation () {
-      return this.card.questionAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT ||
+      return this.card.qAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT ||
         this.disableEdition || this.activity.status === PUBLISHED;
     },
     disableAnswerDeletion () {
-      return this.card.questionAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT ||
+      return this.card.qAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT ||
         this.disableEdition || this.activity.status === PUBLISHED;
     },
   },
   methods: {
     async updateQuestionAnswers (index) {
       try {
-        const editedAnswer = get(this.card, `questionAnswers[${index}]`);
+        const editedAnswer = get(this.card, `qAnswers[${index}]`);
         if (this.tmpInput === editedAnswer.text) return;
 
-        this.$v.card.questionAnswers.$touch();
-        if (this.$v.card.questionAnswers.$each[index].$error) return NotifyWarning('Champ(s) invalide(s).');
+        this.$v.card.qAnswers.$touch();
+        if (this.$v.card.qAnswers.$each[index].$error) return NotifyWarning('Champ(s) invalide(s).');
 
         await Cards.updateAnswer(
           { cardId: this.card._id, answerId: editedAnswer._id }, { text: editedAnswer.text.trim() }
@@ -101,7 +101,7 @@ export default {
     },
     async deleteQuestionAnswer (index) {
       try {
-        const answerId = get(this.card, `questionAnswers[${index}]._id`);
+        const answerId = get(this.card, `qAnswers[${index}]._id`);
         if (!answerId) return;
         await Cards.deleteAnswer({ cardId: this.card._id, answerId });
 

--- a/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
+++ b/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
@@ -6,10 +6,10 @@
     <q-checkbox v-model="card.isQuestionAnswerMultipleChoiced" @input="updateCard('isQuestionAnswerMultipleChoiced')"
       size="sm" :disable="disableEdition" label="Sélection multiple" />
     <div class="q-my-lg answers">
-      <div v-for="(answer, i) in card.qAnswers" :key="i" class="answers-container">
-        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qAnswers[i].text" :disable="disableEdition"
-          @blur="updateQuestionAnswers(i)" @focus="saveTmp(`qAnswers[${i}].text`)"
-          :error="$v.card.qAnswers.$each[i].$error" class="answers-container-input" />
+      <div v-for="(answer, i) in card.qcAnswers" :key="i" class="answers-container">
+        <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qcAnswers[i].text" :disable="disableEdition"
+          @blur="updateQuestionAnswers(i)" @focus="saveTmp(`qcAnswers[${i}].text`)"
+          :error="$v.card.qcAnswers.$each[i].$error" class="answers-container-input" />
         <ni-button icon="delete" @click="deleteQuestionAnswer(i)" :disable="disableAnswerDeletion" />
       </div>
       <ni-button class="add-button" icon="add" label="Ajouter une réponse" color="primary" @click="addAnswer"
@@ -49,7 +49,7 @@ export default {
     return {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
-        qAnswers: {
+        qcAnswers: {
           required,
           minLength: minArrayLength(QUESTION_ANSWER_MIN_ANSWERS_COUNT),
           maxLength: maxArrayLength(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
@@ -60,22 +60,22 @@ export default {
   },
   computed: {
     disableAnswerCreation () {
-      return this.card.qAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT ||
+      return this.card.qcAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT ||
         this.disableEdition || this.activity.status === PUBLISHED;
     },
     disableAnswerDeletion () {
-      return this.card.qAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT ||
+      return this.card.qcAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT ||
         this.disableEdition || this.activity.status === PUBLISHED;
     },
   },
   methods: {
     async updateQuestionAnswers (index) {
       try {
-        const editedAnswer = get(this.card, `qAnswers[${index}]`);
+        const editedAnswer = get(this.card, `qcAnswers[${index}]`);
         if (this.tmpInput === editedAnswer.text) return;
 
-        this.$v.card.qAnswers.$touch();
-        if (this.$v.card.qAnswers.$each[index].$error) return NotifyWarning('Champ(s) invalide(s).');
+        this.$v.card.qcAnswers.$touch();
+        if (this.$v.card.qcAnswers.$each[index].$error) return NotifyWarning('Champ(s) invalide(s).');
 
         await Cards.updateAnswer(
           { cardId: this.card._id, answerId: editedAnswer._id }, { text: editedAnswer.text.trim() }
@@ -101,7 +101,7 @@ export default {
     },
     async deleteQuestionAnswer (index) {
       try {
-        const answerId = get(this.card, `qAnswers[${index}]._id`);
+        const answerId = get(this.card, `qcAnswers[${index}]._id`);
         if (!answerId) return;
         await Cards.deleteAnswer({ cardId: this.card._id, answerId });
 

--- a/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
@@ -7,9 +7,9 @@
       @focus="saveTmp('qcuGoodAnswer')" :error="$v.card.qcuGoodAnswer.$error" :error-message="goodAnswerErrorMsg"
       @blur="updateCard('qcuGoodAnswer')" :disable="disableEdition" />
     <div class="q-my-lg">
-      <ni-input v-for="(answer, i) in card.qAnswers" :key="i" :caption="`Mauvaise réponse ${i + 1}`"
-        v-model="card.qAnswers[i].text" :required-field="i === 0" :error="qcuFalsyAnswerError(i)"
-        :error-message="qcuFalsyAnswerErrorMsg(i)" @focus="saveTmp(`qAnswers[${i}].text`)"
+      <ni-input v-for="(answer, i) in card.qcAnswers" :key="i" :caption="`Mauvaise réponse ${i + 1}`"
+        v-model="card.qcAnswers[i].text" :required-field="i === 0" :error="qcuFalsyAnswerError(i)"
+        :error-message="qcuFalsyAnswerErrorMsg(i)" @focus="saveTmp(`qcAnswers[${i}].text`)"
         @blur="updateFalsyAnswer(i)" :disable="disableEdition" />
     </div>
     <ni-input caption="Correction" v-model="card.explanation" required-field @focus="saveTmp('explanation')"
@@ -42,7 +42,7 @@ export default {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
         qcuGoodAnswer: { required, maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
-        qAnswers: {
+        qcAnswers: {
           minLength: minTextArrayLength(1),
           minOneCorrectAnswer,
           $each: {
@@ -64,26 +64,26 @@ export default {
   },
   methods: {
     qcuFalsyAnswerErrorMsg (index) {
-      if (!this.$v.card.qAnswers.$each[index].text.maxLength) {
+      if (!this.$v.card.qcAnswers.$each[index].text.maxLength) {
         return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
       }
       return '';
     },
     qcuFalsyAnswerError (index) {
-      const exceedCharLength = this.$v.card.qAnswers.$each[index].text.$error;
-      const missingField = this.$v.card.qAnswers.$error &&
-        !this.$v.card.qAnswers.minLength && index === 0 && !this.card.qAnswers[index].text;
+      const exceedCharLength = this.$v.card.qcAnswers.$each[index].text.$error;
+      const missingField = this.$v.card.qcAnswers.$error &&
+        !this.$v.card.qcAnswers.minLength && index === 0 && !this.card.qcAnswers[index].text;
 
       return exceedCharLength || missingField;
     },
     formatQcuFalsyAnswersPayload () {
-      return { qAnswers: this.card.qAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
+      return { qcAnswers: this.card.qcAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
     },
     async updateFalsyAnswer (index) {
       try {
-        if (this.tmpInput === get(this.card, `qAnswers[${index}].text`)) return;
+        if (this.tmpInput === get(this.card, `qcAnswers[${index}].text`)) return;
 
-        this.$v.card.qAnswers.$touch();
+        this.$v.card.qcAnswers.$touch();
         if (this.qcuFalsyAnswerError(index)) return NotifyWarning('Champ(s) invalide(s)');
 
         await Cards.updateById(this.card._id, this.formatQcuFalsyAnswersPayload());

--- a/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="qcuFalsyAnswersInitialized">
+  <div>
     <ni-input caption="Question" v-model="card.question" required-field @focus="saveTmp('question')"
       @blur="updateCard('question')" :error="$v.card.question.$error" :error-message="questionErrorMsg"
       type="textarea" :disable="disableEdition" />
@@ -7,9 +7,9 @@
       @focus="saveTmp('qcuGoodAnswer')" :error="$v.card.qcuGoodAnswer.$error" :error-message="goodAnswerErrorMsg"
       @blur="updateCard('qcuGoodAnswer')" :disable="disableEdition" />
     <div class="q-my-lg">
-      <ni-input v-for="(answer, i) in card.qcuFalsyAnswers" :key="i" :caption="`Mauvaise réponse ${i + 1}`"
-        v-model="card.qcuFalsyAnswers[i]" :required-field="i === 0" :error="qcuFalsyAnswerError(i)"
-        :error-message="qcuFalsyAnswerErrorMsg(i)" @focus="saveTmp(`qcuFalsyAnswers[${i}]`)"
+      <ni-input v-for="(answer, i) in card.qAnswers" :key="i" :caption="`Mauvaise réponse ${i + 1}`"
+        v-model="card.qAnswers[i].text" :required-field="i === 0" :error="qcuFalsyAnswerError(i)"
+        :error-message="qcuFalsyAnswerErrorMsg(i)" @focus="saveTmp(`qAnswers[${i}].text`)"
         @blur="updateFalsyAnswer(i)" :disable="disableEdition" />
     </div>
     <ni-input caption="Correction" v-model="card.explanation" required-field @focus="saveTmp('explanation')"
@@ -18,15 +18,13 @@
 </template>
 
 <script>
-import times from 'lodash/times';
 import get from 'lodash/get';
 import { required, maxLength } from 'vuelidate/lib/validators';
 import Cards from '@api/Cards';
 import Input from '@components/form/Input';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
-import { SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT, REQUIRED_LABEL, QUESTION_MAX_LENGTH,
-  QC_ANSWER_MAX_LENGTH } from '@data/constants';
-import { minArrayLength } from '@helpers/vuelidateCustomVal';
+import { REQUIRED_LABEL, QUESTION_MAX_LENGTH, QC_ANSWER_MAX_LENGTH } from '@data/constants';
+import { minTextArrayLength, minOneCorrectAnswer } from '@helpers/vuelidateCustomVal';
 import { validationMixin } from '@mixins/validationMixin';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
 
@@ -44,19 +42,18 @@ export default {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
         qcuGoodAnswer: { required, maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
-        qcuFalsyAnswers: {
-          required,
-          minLength: minArrayLength(1),
-          $each: { maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
+        qAnswers: {
+          minLength: minTextArrayLength(1),
+          minOneCorrectAnswer,
+          $each: {
+            text: { maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
+          },
         },
         explanation: { required },
       },
     };
   },
   computed: {
-    qcuFalsyAnswersInitialized () {
-      return this.card.qcuFalsyAnswers.length === SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT;
-    },
     goodAnswerErrorMsg () {
       if (!this.$v.card.qcuGoodAnswer.required) return REQUIRED_LABEL;
       if (!this.$v.card.qcuGoodAnswer.maxLength) {
@@ -65,43 +62,31 @@ export default {
       return '';
     },
   },
-  watch: {
-    card: {
-      handler: 'initializeQcuFalsyAnswers',
-      immediate: true,
-    },
-  },
   methods: {
     qcuFalsyAnswerErrorMsg (index) {
-      if (!this.$v.card.qcuFalsyAnswers.$each[index].maxLength) {
+      if (!this.$v.card.qAnswers.$each[index].text.maxLength) {
         return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
       }
       return '';
     },
-    initializeQcuFalsyAnswers () {
-      this.card.qcuFalsyAnswers = times(
-        SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT,
-        i => this.card.qcuFalsyAnswers[i] || ''
-      );
-    },
     qcuFalsyAnswerError (index) {
-      const exceedCharLength = this.$v.card.qcuFalsyAnswers.$each[index].$error;
-      const missingField = this.$v.card.qcuFalsyAnswers.$error &&
-        !this.$v.card.qcuFalsyAnswers.minLength && index === 0 && !this.card.qcuFalsyAnswers[index];
+      const exceedCharLength = this.$v.card.qAnswers.$each[index].text.$error;
+      const missingField = this.$v.card.qAnswers.$error &&
+        !this.$v.card.qAnswers.minLength && index === 0 && !this.card.qAnswers[index].text;
 
       return exceedCharLength || missingField;
     },
     formatQcuFalsyAnswersPayload () {
-      return this.card.qcuFalsyAnswers.filter(a => !!a).map(a => a.trim());
+      return { qAnswers: this.card.qAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
     },
     async updateFalsyAnswer (index) {
       try {
-        if (this.tmpInput === get(this.card, `qcuFalsyAnswers[${index}]`)) return;
+        if (this.tmpInput === get(this.card, `qAnswers[${index}].text`)) return;
 
-        this.$v.card.qcuFalsyAnswers.$touch();
+        this.$v.card.qAnswers.$touch();
         if (this.qcuFalsyAnswerError(index)) return NotifyWarning('Champ(s) invalide(s)');
 
-        await Cards.updateById(this.card._id, { qcuFalsyAnswers: this.formatQcuFalsyAnswersPayload() });
+        await Cards.updateById(this.card._id, this.formatQcuFalsyAnswersPayload());
 
         await this.refreshCard();
         NotifyPositive('Carte mise à jour.');

--- a/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
@@ -20,7 +20,6 @@
 <script>
 import get from 'lodash/get';
 import { required, maxLength } from 'vuelidate/lib/validators';
-import Cards from '@api/Cards';
 import Input from '@components/form/Input';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import { REQUIRED_LABEL, QUESTION_MAX_LENGTH, QC_ANSWER_MAX_LENGTH } from '@data/constants';
@@ -76,17 +75,12 @@ export default {
 
       return exceedCharLength || missingField;
     },
-    formatQcuFalsyAnswersPayload () {
-      return { qcAnswers: this.card.qcAnswers.filter(a => !!a.text).map(a => ({ ...a, text: a.text.trim() })) };
-    },
     async updateFalsyAnswer (index) {
       try {
         if (this.tmpInput === get(this.card, `qcAnswers[${index}].text`)) return;
 
         this.$v.card.qcAnswers.$touch();
         if (this.qcuFalsyAnswerError(index)) return NotifyWarning('Champ(s) invalide(s)');
-
-        await Cards.updateById(this.card._id, this.formatQcuFalsyAnswersPayload());
 
         await this.refreshCard();
         NotifyPositive('Carte mise à jour.');


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - np

- Périmetre interface : vendor

- Périmetre roles : admin / rof

- Cas d'usage : 
qcuFalsyAnswers, qcmAnswers et questionAnswers sont fondus en un seul champ qAnswers.
L'utilisation des qcm et des qcu se fera sous la même forme que question answer :
- ajout des champs answer en plus via un bouton
- passage par les routes /{_id}/answers (POST, PUT, DELETE)

Dans cette PR :
- uniquement la refonte en un seul champ
- le fait que qcm et qcu ne soit plus comme avant est voulu (préparation à l'ajout de réponse par bouton)