### PR TITLE
Com 1691 put

### DIFF
--- a/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/MultipleChoiceQuestion.vue
@@ -6,8 +6,8 @@
     <div class="q-my-xl">
       <div v-for="(qcAnswer, i) in card.qcAnswers" :key="i" class="answers">
         <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qcAnswers[i].text" :required-field="i < 2"
-          @focus="saveTmp(`qcAnswers[${i}].text`)" @blur="updateAnswer(i)"
-          :error="answersError(i)" :error-message="answersErrorMsg(i)" :disable="disableEdition" />
+          @focus="saveTmp(`qcAnswers[${i}].text`)" @blur="updateQcmAnswer(i)" :error-message="answersErrorMsg(i)"
+          :error="$v.card.qcAnswers.$each[i].$error || requiredOneCorrectAnswer(i)" :disable="disableEdition" />
         <q-checkbox v-model="card.qcAnswers[i].correct" @input="updateCorrectAnswer(i)"
           :disable="!card.qcAnswers[i].text || disableEdition" />
       </div>
@@ -23,7 +23,8 @@ import { required, maxLength } from 'vuelidate/lib/validators';
 import Input from '@components/form/Input';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import { REQUIRED_LABEL, QUESTION_MAX_LENGTH, QC_ANSWER_MAX_LENGTH } from '@data/constants';
-import { minTextArrayLength, minOneCorrectAnswer } from '@helpers/vuelidateCustomVal';
+import { minOneCorrectAnswer } from '@helpers/vuelidateCustomVal';
+import Cards from '@api/Cards';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
 
 export default {
@@ -40,10 +41,9 @@ export default {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
         qcAnswers: {
-          minLength: minTextArrayLength(2),
           minOneCorrectAnswer,
           $each: {
-            text: { maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
+            text: { required, maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
           },
         },
         explanation: { required },
@@ -51,9 +51,6 @@ export default {
     };
   },
   methods: {
-    requiredAnswerIsMissing (index) {
-      return index < 2 && !this.card.qcAnswers[index].text && this.$v.card.qcAnswers.$error;
-    },
     requiredOneCorrectAnswer (index) {
       return !this.$v.card.qcAnswers.minOneCorrectAnswer && !!this.card.qcAnswers[index].text;
     },
@@ -61,31 +58,31 @@ export default {
       return this.card.qcAnswers.filter(a => a.correct).length === 1 && this.card.qcAnswers[index].correct &&
         !this.card.qcAnswers[index].text;
     },
-    async updateAnswer (index) {
-      try {
-        if (this.tmpInput === get(this.card, `qcAnswers[${index}].text`)) return;
+    async updateQcmAnswer (index) {
+      this.$v.card.qcAnswers.$touch();
 
-        this.$v.card.qcAnswers.$touch();
-        if (this.requiredAnswerIsMissing(index) || this.$v.card.qcAnswers.$each[index].$error) {
-          return NotifyWarning('Champ(s) invalide(s)');
-        }
-        if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
-          return NotifyWarning('Une bonne réponse est nécessaire.');
-        }
-
-        await this.refreshCard();
-        NotifyPositive('Carte mise à jour.');
-      } catch (e) {
-        console.error(e);
-        NotifyNegative('Erreur lors de la mise à jour de la carte.');
+      if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
+        return NotifyWarning('Une bonne réponse est nécessaire.');
       }
+
+      await this.updateTextAnswer(index);
     },
     async updateCorrectAnswer (index) {
       try {
-        if (!this.card.qcAnswers[index].text || this.$v.card.qcAnswers.$each[index].$error) {
+        const editedAnswer = get(this.card, `qcAnswers[${index}]`);
+
+        this.$v.card.qcAnswers.$touch();
+
+        if (!editedAnswer.text || this.$v.card.qcAnswers.$each[index].$error) {
           return NotifyWarning('Champ(s) invalide(s)');
         }
+
         if (this.requiredOneCorrectAnswer(index)) return NotifyWarning('Une bonne réponse est nécessaire.');
+
+        await Cards.updateAnswer(
+          { cardId: this.card._id, answerId: editedAnswer._id },
+          { text: editedAnswer.text, correct: editedAnswer.correct }
+        );
 
         await this.refreshCard();
         NotifyPositive('Carte mise à jour.');
@@ -95,20 +92,11 @@ export default {
       }
     },
     answersErrorMsg (index) {
-      if (this.requiredAnswerIsMissing(index)) return REQUIRED_LABEL;
-      if (this.requiredOneCorrectAnswer(index) || this.removeSingleCorrectAnswer(index)) {
-        return 'Une bonne réponse est nécessaire.';
-      }
-      if (!this.$v.card.qcAnswers.$each[index].text.maxLength) {
-        return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
-      }
+      if (!this.$v.card.qcAnswers.$each[index].text.required) return REQUIRED_LABEL;
+      if (this.requiredOneCorrectAnswer(index)) return 'Une bonne réponse est nécessaire.';
+      if (!this.$v.card.qcAnswers.$each[index].text.maxLength) return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
+
       return '';
-    },
-    answersError (index) {
-      const exceedCharLength = this.$v.card.qcAnswers.$each[index].$error;
-      const missingField = this.requiredAnswerIsMissing(index) || this.requiredOneCorrectAnswer(index) ||
-        this.removeSingleCorrectAnswer(index);
-      return exceedCharLength || missingField;
     },
   },
 };

--- a/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
+++ b/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
@@ -8,7 +8,7 @@
     <div class="q-my-lg answers">
       <div v-for="(answer, i) in card.qcAnswers" :key="i" class="answers-container">
         <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qcAnswers[i].text" :disable="disableEdition"
-          @blur="updateQuestionAnswers(i)" @focus="saveTmp(`qcAnswers[${i}].text`)"
+          @blur="updateTextAnswer(i)" @focus="saveTmp(`qcAnswers[${i}].text`)"
           :error="$v.card.qcAnswers.$each[i].$error" class="answers-container-input" />
         <ni-button icon="delete" @click="deleteQuestionAnswer(i)" :disable="disableAnswerDeletion" />
       </div>
@@ -24,14 +24,13 @@ import { required, maxLength } from 'vuelidate/lib/validators';
 import Cards from '@api/Cards';
 import Input from '@components/form/Input';
 import Button from '@components/Button';
-import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
+import { NotifyNegative, NotifyPositive } from '@components/popup/notify';
 import {
   QUESTION_MAX_LENGTH,
   QUESTION_ANSWER_MAX_ANSWERS_COUNT,
   QUESTION_ANSWER_MIN_ANSWERS_COUNT,
   PUBLISHED,
 } from '@data/constants';
-import { minArrayLength, maxArrayLength } from '@helpers/vuelidateCustomVal';
 import { validationMixin } from '@mixins/validationMixin';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
 
@@ -50,9 +49,6 @@ export default {
       card: {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
         qcAnswers: {
-          required,
-          minLength: minArrayLength(QUESTION_ANSWER_MIN_ANSWERS_COUNT),
-          maxLength: maxArrayLength(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
           $each: { text: { required } },
         },
       },
@@ -69,25 +65,6 @@ export default {
     },
   },
   methods: {
-    async updateQuestionAnswers (index) {
-      try {
-        const editedAnswer = get(this.card, `qcAnswers[${index}]`);
-        if (this.tmpInput === editedAnswer.text) return;
-
-        this.$v.card.qcAnswers.$touch();
-        if (this.$v.card.qcAnswers.$each[index].$error) return NotifyWarning('Champ(s) invalide(s).');
-
-        await Cards.updateAnswer(
-          { cardId: this.card._id, answerId: editedAnswer._id }, { text: editedAnswer.text.trim() }
-        );
-
-        await this.refreshCard();
-        NotifyPositive('Carte mise à jour.');
-      } catch (e) {
-        console.error(e);
-        NotifyNegative('Erreur lors de la mise à jour de la carte.');
-      }
-    },
     async addAnswer () {
       try {
         await Cards.addAnswer(this.card._id);

--- a/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
+++ b/src/modules/vendor/components/programs/cards/templates/SingleChoiceQuestion.vue
@@ -8,9 +8,9 @@
       @blur="updateCard('qcuGoodAnswer')" :disable="disableEdition" />
     <div class="q-my-lg">
       <ni-input v-for="(answer, i) in card.qcAnswers" :key="i" :caption="`Mauvaise réponse ${i + 1}`"
-        v-model="card.qcAnswers[i].text" :required-field="i === 0" :error="qcuFalsyAnswerError(i)"
+        v-model="card.qcAnswers[i].text" :required-field="i === 0" :error="$v.card.qcAnswers.$each[i].$error"
         :error-message="qcuFalsyAnswerErrorMsg(i)" @focus="saveTmp(`qcAnswers[${i}].text`)"
-        @blur="updateFalsyAnswer(i)" :disable="disableEdition" />
+        @blur="updateTextAnswer(i)" :disable="disableEdition" />
     </div>
     <ni-input caption="Correction" v-model="card.explanation" required-field @focus="saveTmp('explanation')"
       @blur="updateCard('explanation')" :error="$v.card.explanation.$error" type="textarea" :disable="disableEdition" />
@@ -18,12 +18,9 @@
 </template>
 
 <script>
-import get from 'lodash/get';
 import { required, maxLength } from 'vuelidate/lib/validators';
 import Input from '@components/form/Input';
-import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import { REQUIRED_LABEL, QUESTION_MAX_LENGTH, QC_ANSWER_MAX_LENGTH } from '@data/constants';
-import { minTextArrayLength, minOneCorrectAnswer } from '@helpers/vuelidateCustomVal';
 import { validationMixin } from '@mixins/validationMixin';
 import { templateMixin } from 'src/modules/vendor/mixins/templateMixin';
 
@@ -42,10 +39,8 @@ export default {
         question: { required, maxLength: maxLength(QUESTION_MAX_LENGTH) },
         qcuGoodAnswer: { required, maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
         qcAnswers: {
-          minLength: minTextArrayLength(1),
-          minOneCorrectAnswer,
           $each: {
-            text: { maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
+            text: { required, maxLength: maxLength(QC_ANSWER_MAX_LENGTH) },
           },
         },
         explanation: { required },
@@ -55,39 +50,17 @@ export default {
   computed: {
     goodAnswerErrorMsg () {
       if (!this.$v.card.qcuGoodAnswer.required) return REQUIRED_LABEL;
-      if (!this.$v.card.qcuGoodAnswer.maxLength) {
-        return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
-      }
+      if (!this.$v.card.qcuGoodAnswer.maxLength) return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
+
       return '';
     },
   },
   methods: {
     qcuFalsyAnswerErrorMsg (index) {
-      if (!this.$v.card.qcAnswers.$each[index].text.maxLength) {
-        return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
-      }
+      if (!this.$v.card.qcAnswers.$each[index].text.required) return REQUIRED_LABEL;
+      if (!this.$v.card.qcAnswers.$each[index].text.maxLength) return `${QC_ANSWER_MAX_LENGTH} caractères maximum.`;
+
       return '';
-    },
-    qcuFalsyAnswerError (index) {
-      const exceedCharLength = this.$v.card.qcAnswers.$each[index].text.$error;
-      const missingField = this.$v.card.qcAnswers.$error &&
-        !this.$v.card.qcAnswers.minLength && index === 0 && !this.card.qcAnswers[index].text;
-
-      return exceedCharLength || missingField;
-    },
-    async updateFalsyAnswer (index) {
-      try {
-        if (this.tmpInput === get(this.card, `qcAnswers[${index}].text`)) return;
-
-        this.$v.card.qcAnswers.$touch();
-        if (this.qcuFalsyAnswerError(index)) return NotifyWarning('Champ(s) invalide(s)');
-
-        await this.refreshCard();
-        NotifyPositive('Carte mise à jour.');
-      } catch (e) {
-        console.error(e);
-        NotifyNegative('Erreur lors de la mise à jour de la carte.');
-      }
     },
   },
 };

--- a/src/modules/vendor/mixins/templateMixin.js
+++ b/src/modules/vendor/mixins/templateMixin.js
@@ -11,6 +11,9 @@ import {
   UPLOAD_IMAGE,
   UPLOAD_VIDEO,
   UPLOAD_AUDIO,
+  MULTIPLE_CHOICE_QUESTION,
+  SINGLE_CHOICE_QUESTION,
+  QUESTION_ANSWER,
 } from '../../../core/data/constants';
 
 export const templateMixin = {
@@ -89,6 +92,27 @@ export const templateMixin = {
         NotifyNegative('Erreur lors de la mise à jour de la carte.');
       }
     },
+    async updateTextAnswer (index) {
+      try {
+        const key = this.getAnswerKeyToUpdate(this.card.template);
+        const editedAnswer = get(this.card, `${key}[${index}]`);
+
+        if (this.tmpInput === editedAnswer.text) return;
+
+        get(this.$v, `card.${key}`).$touch();
+        if (get(this.$v, `card.${key}.$each[${index}].text.$error`)) return NotifyWarning('Champ(s) invalide(s).');
+
+        await Cards.updateAnswer(
+          { cardId: this.card._id, answerId: editedAnswer._id }, { text: editedAnswer.text.trim() }
+        );
+
+        await this.refreshCard();
+        NotifyPositive('Carte mise à jour.');
+      } catch (e) {
+        console.error(e);
+        NotifyNegative('Erreur lors de la mise à jour de la carte.');
+      }
+    },
     async refreshCard () {
       try {
         await this.$store.dispatch('program/fetchActivity', { activityId: this.activity._id });
@@ -127,6 +151,11 @@ export const templateMixin = {
         cancel: 'Annuler',
       }).onOk(() => this.deleteMedia(path))
         .onCancel(() => NotifyPositive('Suppression annulée.'));
+    },
+    getAnswerKeyToUpdate (template) {
+      if ([MULTIPLE_CHOICE_QUESTION, SINGLE_CHOICE_QUESTION, QUESTION_ANSWER].includes(template)) return 'qcAnswers';
+
+      return '';
     },
   },
 };

--- a/src/modules/vendor/mixins/templateMixin.js
+++ b/src/modules/vendor/mixins/templateMixin.js
@@ -99,7 +99,7 @@ export const templateMixin = {
 
         if (this.tmpInput === editedAnswer.text) return;
 
-        get(this.$v, `card.${key}`).$touch();
+        get(this.$v, `card.${key}.$each[${index}]`).$touch();
         if (get(this.$v, `card.${key}.$each[${index}].text.$error`)) return NotifyWarning('Champ(s) invalide(s).');
 
         await Cards.updateAnswer(


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - np

- Périmetre interface : vendor

- Périmetre roles : admin / rof

- Cas d'usage : 
Suite du changement sur qcAnswers. L'édition de réponse pour QCM et QCU passe désormais par la route updateQuestionAnswer.
Changement dans l'utilisation de QCM (vu avec Sophie) :
- désormais le texte et la box sont indépendants : on peut avoir une carte qcm sans réponse valide, la carte sera bien sûr  invalide mais réponses seront gardées en back.

Reste à faire :
la route post et delete pour ajouter de nouvelles réponses et les enlever


ATTENTION : le commit COM-1691 - use updateTextAnswer in MultipleChoiceQuestion, n'est pas à prendre en compte. C'était une des deux propositions pour QCM et j'ai vu avec Sophie pour valider la bonne solution (la 2ème donc)