### PR TITLE
Com 1708

### DIFF
--- a/src/modules/vendor/components/programs/ProgramCreationModal.vue
+++ b/src/modules/vendor/components/programs/ProgramCreationModal.vue
@@ -3,10 +3,10 @@
     <template slot="title">
       Créer un nouveau <span class="text-weight-bold">programme</span>
     </template>
-    <ni-input in-modal :value="name" @input="update($event, 'name')" :error="validations.name.$error"
+    <ni-input in-modal :value="newProgram.name" @input="update($event, 'name')" :error="validations.name.$error"
       @blur="validations.name.$touch" required-field caption="Nom" />
-    <ni-select in-modal :value="category" @input="update($event, 'category')" :error="validations.category.$error"
-        @blur="validations.category.$touch" required-field caption="Catégorie" :options="categoryOptions" />
+    <ni-select in-modal :value="newProgram.category" @input="update($event, 'category')" :options="categoryOptions"
+      :error="validations.category.$error" @blur="validations.category.$touch" required-field caption="Catégorie" />
     <template slot="footer">
       <q-btn no-caps class="full-width modal-btn" label="Créer le programme" color="primary" :loading="loading"
         icon-right="add" @click="submit" />
@@ -27,8 +27,7 @@ export default {
     value: { type: Boolean, default: false },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
-    name: { type: String, default: '' },
-    category: { type: String, default: '' },
+    newProgram: { type: Object, default: () => ({}) },
   },
   data () {
     return {
@@ -60,7 +59,7 @@ export default {
       this.$emit('submit');
     },
     update (event, prop) {
-      this.$emit(`update:${prop}`, event.trim());
+      this.$emit('update:newProgram', { ...this.newProgram, [prop]: event.trim() });
     },
   },
 };

--- a/src/modules/vendor/components/programs/ProgramCreationModal.vue
+++ b/src/modules/vendor/components/programs/ProgramCreationModal.vue
@@ -3,7 +3,7 @@
     <template slot="title">
       Créer un nouveau <span class="text-weight-bold">programme</span>
     </template>
-    <ni-input in-modal :value="newProgram.name" @input="update($event, 'name')" :error="validations.name.$error"
+    <ni-input in-modal :value="newProgram.name" @input="update($event.trim(), 'name')" :error="validations.name.$error"
       @blur="validations.name.$touch" required-field caption="Nom" />
     <ni-select in-modal :value="newProgram.category" @input="update($event, 'category')" :options="categoryOptions"
       :error="validations.category.$error" @blur="validations.category.$touch" required-field caption="Catégorie" />
@@ -59,7 +59,7 @@ export default {
       this.$emit('submit');
     },
     update (event, prop) {
-      this.$emit('update:newProgram', { ...this.newProgram, [prop]: event.trim() });
+      this.$emit('update:newProgram', { ...this.newProgram, [prop]: event });
     },
   },
 };

--- a/src/modules/vendor/components/programs/ProgramCreationModal.vue
+++ b/src/modules/vendor/components/programs/ProgramCreationModal.vue
@@ -3,9 +3,9 @@
     <template slot="title">
       Créer un nouveau <span class="text-weight-bold">programme</span>
     </template>
-    <ni-input in-modal v-model.trim="newProgram.name" :error="validations.name.$error"
+    <ni-input in-modal :value="name" @input="update($event, 'name')" :error="validations.name.$error"
       @blur="validations.name.$touch" required-field caption="Nom" />
-    <ni-select in-modal v-model.trim="newProgram.category" :error="validations.category.$error"
+    <ni-select in-modal :value="category" @input="update($event, 'category')" :error="validations.category.$error"
         @blur="validations.category.$touch" required-field caption="Catégorie" :options="categoryOptions" />
     <template slot="footer">
       <q-btn no-caps class="full-width modal-btn" label="Créer le programme" color="primary" :loading="loading"
@@ -25,9 +25,10 @@ export default {
   name: 'ProgramCreationModal',
   props: {
     value: { type: Boolean, default: false },
-    newProgram: { type: Object, default: () => ({}) },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
+    name: { type: String, default: '' },
+    category: { type: String, default: '' },
   },
   data () {
     return {
@@ -57,6 +58,9 @@ export default {
     },
     submit () {
       this.$emit('submit');
+    },
+    update (event, prop) {
+      this.$emit(`update:${prop}`, event.trim());
     },
   },
 };

--- a/src/modules/vendor/pages/ni/config/ProgramsDirectory.vue
+++ b/src/modules/vendor/pages/ni/config/ProgramsDirectory.vue
@@ -8,8 +8,7 @@
       @click="programCreationModal = true" :disable="tableLoading" />
 
     <program-creation-modal v-model="programCreationModal" @hide="resetCreationModal" @submit="createProgram"
-      :validations="$v.newProgram" :loading="modalLoading" :name.sync="newProgram.name"
-      :category.sync="newProgram.category" />
+      :validations="$v.newProgram" :loading="modalLoading" :new-program.sync="newProgram" />
   </q-page>
 </template>
 

--- a/src/modules/vendor/pages/ni/config/ProgramsDirectory.vue
+++ b/src/modules/vendor/pages/ni/config/ProgramsDirectory.vue
@@ -8,7 +8,8 @@
       @click="programCreationModal = true" :disable="tableLoading" />
 
     <program-creation-modal v-model="programCreationModal" @hide="resetCreationModal" @submit="createProgram"
-      :new-program="newProgram" :validations="$v.newProgram" :loading="modalLoading" />
+      :validations="$v.newProgram" :loading="modalLoading" :name.sync="newProgram.name"
+      :category.sync="newProgram.category" />
   </q-page>
 </template>
 


### PR DESCRIPTION
Afin d'éviter la mauvaise pratique 'no-mutating-props' (https://eslint.vuejs.org/rules/no-mutating-props.html), il faut changer la façon dont on modifie les props données par le parent.
Ex : Pour changer le nom d'un program dans ProgramCreation, on passait la props 'newProgram' puis dans le v-model de l'input 'newProgram.name'. On vient donc directement modifier la props 'newProgram', ce qu'on éviter.

3 solutions possibles : 
- dupliquer l'information : en ayant une data 'name' puis en envoyant cette data au parent -> pas creusée car la duplication d'information n'est pas une bonne pratique et très couteuse en code (c'est long et pas beau)
( https://medium.com/javascript-in-plain-english/avoid-mutating-a-prop-directly-7b127b9bca5b
https://michaelnthiessen.com/avoid-mutating-prop-directly/ )

- v.sync : conseillée par quasiment tous les docs consultés. J'ai proposé deux solutions se basant sur sync dans cette PR : une qu'on retrouve dans les différents articles, une autre que j'ai crée en me basant sur la façon dont v.sync fonctionne mais que je n'ai pas trouvé sur internet.
https://vuejs.org/v2/guide/components-custom-events.html#sync-Modifier
https://medium.com/front-end-weekly/vues-v-model-directive-vs-sync-modifier-d1f83957c57c
https://levelup.gitconnected.com/introduction-to-vue-js-custom-events-9bc752922902

- $set : je ne l'ai trouvé que sur une réponse d'un stackoverflow. Elle a l'air fonctionnelle mais moins élégante et surtout moins adaptée à notre façon actuelle de gérer les props. Je ne l'ai donc pas testé mais je vous la mets au cas où elle vous plairait plus que v.sync.
https://stackoverflow.com/questions/59436985/making-dynamically-set-object-values-reactive-in-vuejs-data-v-bind-sync-for