### PR TITLE
Com 1689 cookies

### DIFF
--- a/src/core/api/Users.js
+++ b/src/core/api/Users.js
@@ -19,6 +19,9 @@ export default {
     );
     return auth.data.data;
   },
+  async logOut () {
+    await axios.post(`${process.env.API_HOSTNAME}/users/logout`, null, { withCredentials: true });
+  },
   async list (params = null) {
     try {
       const usersRaw = await alenviAxios.get(`${process.env.API_HOSTNAME}/users`, { params });

--- a/src/core/api/Users.js
+++ b/src/core/api/Users.js
@@ -4,7 +4,11 @@ import { WEBAPP } from '@data/constants';
 
 export default {
   async refreshToken (data) {
-    const refreshToken = await axios.post(`${process.env.API_HOSTNAME}/users/refreshToken`, data);
+    const refreshToken = await axios.post(
+      `${process.env.API_HOSTNAME}/users/refreshToken`,
+      data,
+      { withCredentials: true }
+    );
     return refreshToken.data.data;
   },
   async authenticate (data) {

--- a/src/core/api/Users.js
+++ b/src/core/api/Users.js
@@ -4,23 +4,31 @@ import { WEBAPP } from '@data/constants';
 
 export default {
   async refreshToken (data) {
-    const refreshToken = await axios.post(
-      `${process.env.API_HOSTNAME}/users/refreshToken`,
-      data,
-      { withCredentials: true }
-    );
-    return refreshToken.data.data;
+    await axios.post(`${process.env.API_HOSTNAME}/users/refreshToken`, data, { withCredentials: true });
   },
   async authenticate (data) {
-    const auth = await axios.post(
-      `${process.env.API_HOSTNAME}/users/authenticate`,
-      data,
-      { withCredentials: true }
-    );
+    const auth = await axios.post(`${process.env.API_HOSTNAME}/users/authenticate`, data, { withCredentials: true });
     return auth.data.data;
   },
   async logOut () {
     await axios.post(`${process.env.API_HOSTNAME}/users/logout`, null, { withCredentials: true });
+  },
+  async forgotPassword (data) {
+    await axios.post(`${process.env.API_HOSTNAME}/users/forgot-password`, data);
+  },
+  async checkResetPasswordToken (resetToken) {
+    const check = await axios.get(
+      `${process.env.API_HOSTNAME}/users/check-reset-password/${resetToken}`,
+      { withCredentials: true }
+    );
+    return check.data.data;
+  },
+  async createPasswordToken (id, data) {
+    const passwordToken = await alenviAxios.put(`${process.env.API_HOSTNAME}/users/${id}/create-password-token`, data);
+    return passwordToken.data.data.passwordToken;
+  },
+  async updatePassword (userId, data) {
+    await alenviAxios.put(`${process.env.API_HOSTNAME}/users/${userId}/password`, data);
   },
   async list (params = null) {
     try {
@@ -66,10 +74,6 @@ export default {
     const newUser = await alenviAxios.post(`${process.env.API_HOSTNAME}/users`, { ...data, origin: WEBAPP });
     return newUser.data.data.user;
   },
-  async createPasswordToken (id, data) {
-    const passwordToken = await alenviAxios.put(`${process.env.API_HOSTNAME}/users/${id}/create-password-token`, data);
-    return passwordToken.data.data.passwordToken;
-  },
   async deleteById (id) {
     await alenviAxios.delete(`${process.env.API_HOSTNAME}/users/${id}`);
   },
@@ -77,29 +81,8 @@ export default {
     const updatedUser = await alenviAxios.put(`${process.env.API_HOSTNAME}/users/${userId}`, data);
     return updatedUser;
   },
-  async updatePassword (userId, data, token = null) {
-    let updatedUser;
-    if (token) {
-      updatedUser = await axios.put(
-        `${process.env.API_HOSTNAME}/users/${userId}/password`,
-        data,
-        { headers: { 'x-access-token': token } }
-      );
-    } else {
-      updatedUser = await alenviAxios.put(`${process.env.API_HOSTNAME}/users/${userId}/password`, data);
-    }
-    return updatedUser;
-  },
   async updateCertificates (userId, data) {
     await alenviAxios.put(`${process.env.API_HOSTNAME}/users/${userId}/certificates`, data);
-  },
-  async forgotPassword (data) {
-    const mailInfo = await axios.post(`${process.env.API_HOSTNAME}/users/forgot-password`, data);
-    return mailInfo.data.data.mailInfo;
-  },
-  async checkResetPasswordToken (resetToken) {
-    const check = await axios.get(`${process.env.API_HOSTNAME}/users/check-reset-password/${resetToken}`);
-    return check.data.data;
   },
   async createDriveFolder (userId) {
     await alenviAxios.post(`${process.env.API_HOSTNAME}/users/${userId}/drivefolder`);

--- a/src/core/api/Users.js
+++ b/src/core/api/Users.js
@@ -8,7 +8,11 @@ export default {
     return refreshToken.data.data;
   },
   async authenticate (data) {
-    const auth = await axios.post(`${process.env.API_HOSTNAME}/users/authenticate`, data);
+    const auth = await axios.post(
+      `${process.env.API_HOSTNAME}/users/authenticate`,
+      data,
+      { withCredentials: true }
+    );
     return auth.data.data;
   },
   async list (params = null) {

--- a/src/core/api/ressources/alenviAxios.js
+++ b/src/core/api/ressources/alenviAxios.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import qs from 'qs';
+import { refreshAlenviCookies } from '../../helpers/alenvi';
 
 const instance = axios.create({
   withCredentials: true,
@@ -8,6 +9,16 @@ const instance = axios.create({
 
 instance.interceptors.request.use(async config => config, err => Promise.reject(err));
 
-instance.interceptors.response.use(response => response, error => Promise.reject(error.response));
+instance.interceptors.response.use(
+  response => response,
+  async (error) => {
+    console.log(error.response);
+    if (error.response.status === 401) {
+      await refreshAlenviCookies();
+      return axios.request(error.config);
+    }
+    return Promise.reject(error.response);
+  }
+);
 
 export const alenviAxios = instance;

--- a/src/core/api/ressources/alenviAxios.js
+++ b/src/core/api/ressources/alenviAxios.js
@@ -1,21 +1,12 @@
 import axios from 'axios';
-import { Cookies } from 'quasar';
 import qs from 'qs';
-import { logOutAndRedirectToLogin } from 'src/router/redirect';
 
 const instance = axios.create({
   withCredentials: true,
   paramsSerializer: params => qs.stringify(params, { indices: false }),
 });
 
-instance.interceptors.request.use(async (config) => {
-  if (!Cookies.get('refresh_token')) {
-    logOutAndRedirectToLogin();
-    throw new Error('No refresh token');
-  }
-
-  return config;
-}, err => Promise.reject(err));
+instance.interceptors.request.use(async config => config, err => Promise.reject(err));
 
 instance.interceptors.response.use(response => response, error => Promise.reject(error.response));
 

--- a/src/core/api/ressources/alenviAxios.js
+++ b/src/core/api/ressources/alenviAxios.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import qs from 'qs';
-import { refreshAlenviCookies } from '../../helpers/alenvi';
+import { refreshAlenviCookies } from '@helpers/alenvi';
+import { logOutAndRedirectToLogin } from 'src/router/redirect';
 
 const instance = axios.create({
   withCredentials: true,
@@ -12,10 +13,11 @@ instance.interceptors.request.use(async config => config, err => Promise.reject(
 instance.interceptors.response.use(
   response => response,
   async (error) => {
-    console.log(error.response);
     if (error.response.status === 401) {
-      await refreshAlenviCookies();
-      return axios.request(error.config);
+      const refresh = await refreshAlenviCookies();
+
+      if (refresh) return axios.request(error.config);
+      return logOutAndRedirectToLogin();
     }
     return Promise.reject(error.response);
   }

--- a/src/core/api/ressources/alenviAxios.js
+++ b/src/core/api/ressources/alenviAxios.js
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { Cookies } from 'quasar';
 import qs from 'qs';
-import { refreshAlenviCookies } from '@helpers/alenvi';
 import { logOutAndRedirectToLogin } from 'src/router/redirect';
 
 const instance = axios.create({
+  withCredentials: true,
   paramsSerializer: params => qs.stringify(params, { indices: false }),
 });
 
@@ -14,16 +14,6 @@ instance.interceptors.request.use(async (config) => {
     throw new Error('No refresh token');
   }
 
-  if (!Cookies.get('alenvi_token')) {
-    const refresh = await refreshAlenviCookies();
-    if (!refresh) {
-      logOutAndRedirectToLogin();
-      throw new Error('No alenvi token');
-    }
-  }
-
-  // Headers for request only to API (alenvi)
-  config.headers.common['x-access-token'] = Cookies.get('alenvi_token');
   return config;
 }, err => Promise.reject(err));
 

--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -14,7 +14,7 @@
       </div>
     </div>
     <q-field borderless v-else :error="error" :error-message="errorMessage">
-      <q-uploader ref="uploader" flat :bordered="inModal" color="white" :label="label" :url="url" :headers="headers"
+      <q-uploader ref="uploader" flat :bordered="inModal" color="white" :label="label" :url="url" with-credentials
         text-color="black" @failed="failMsg" :form-fields="additionalFields" :max-file-size="maxFileSize"
         @uploaded="documentUploaded" auto-upload :accept="extensions" field-name="file" :multiple="multiple"
         @rejected="rejected" :disable="disable" @start="uploadStarted" @finish="uploadFinished" />
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import { Cookies, openURL } from 'quasar';
+import { openURL } from 'quasar';
 import get from 'lodash/get';
 import CustomImg from '@components/form/CustomImg';
 import { NotifyNegative } from '@components/popup/notify';
@@ -52,11 +52,6 @@ export default {
     label: { type: String, default: 'Pas de document' },
     cloudinaryStorage: { type: Boolean, default: false },
     maxFileSize: { type: Number, default: 1000 * 1000 },
-  },
-  data () {
-    return {
-      headers: [{ name: 'x-access-token', value: Cookies.get('alenvi_token') || '' }],
-    };
   },
   computed: {
     additionalFields () {

--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -6,7 +6,7 @@
     </div>
     <div v-if="document && imageSource" class="row justify-between" style="background: white">
       <div class="doc-thumbnail">
-        <ni-custom-img :cloudinary-storage="cloudinaryStorage" :image-source="imageSource" :alt="alt" />
+        <ni-custom-img :image-source="imageSource" :alt="alt" />
       </div>
       <div class="self-end doc-delete">
         <q-btn color="primary" round flat icon="delete" size="1rem" :disable="disable" @click.native="deleteDocument" />

--- a/src/core/helpers/alenvi.js
+++ b/src/core/helpers/alenvi.js
@@ -28,14 +28,12 @@ export const refreshAlenviCookies = async () => {
       const options = { path: '/', secure: process.env.NODE_ENV !== 'development', sameSite: 'Lax' };
 
       const expireDate = cookieExpirationDate();
-      Cookies.set('alenvi_token', newToken.token, { ...options, expires: expireDate });
       Cookies.set('refresh_token', newToken.refreshToken, { ...options, expires: 365 });
       Cookies.set('user_id', newToken.user._id, { ...options, expires: expireDate });
 
       return true;
     }
     const options = { path: '/' };
-    Cookies.remove('alenvi_token', options);
     Cookies.remove('user_id', options);
 
     return false;
@@ -43,7 +41,6 @@ export const refreshAlenviCookies = async () => {
     console.error(e);
     if (e.response.status === 404) {
       const options = { path: '/' };
-      Cookies.remove('alenvi_token', options);
       Cookies.remove('refresh_token', options);
       Cookies.remove('user_id', options);
     }

--- a/src/core/helpers/alenvi.js
+++ b/src/core/helpers/alenvi.js
@@ -1,12 +1,9 @@
 import { Cookies } from 'quasar';
 import User from '@api/Users';
 import store from 'src/store/index';
-import { logOutAndRedirectToLogin } from 'src/router/redirect';
 
 export const canNavigate = async () => {
   const { loggedUser } = store.state.main;
-  // eslint-disable-next-line no-console
-  console.log('nbonjour');
   if (!loggedUser && !Cookies.get('user_id')) await refreshAlenviCookies();
   if (!loggedUser) await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));
 
@@ -19,9 +16,6 @@ export const refreshAlenviCookies = async () => {
     return true;
   } catch (e) {
     console.error(e);
-    const options = { path: '/' };
-    Cookies.remove('refresh_token', options);
-    Cookies.remove('user_id', options);
-    logOutAndRedirectToLogin();
+    return false;
   }
 };

--- a/src/core/helpers/alenvi.js
+++ b/src/core/helpers/alenvi.js
@@ -28,7 +28,6 @@ export const refreshAlenviCookies = async () => {
       const options = { path: '/', secure: process.env.NODE_ENV !== 'development', sameSite: 'Lax' };
 
       const expireDate = cookieExpirationDate();
-      Cookies.set('refresh_token', newToken.refreshToken, { ...options, expires: 365 });
       Cookies.set('user_id', newToken.user._id, { ...options, expires: expireDate });
 
       return true;

--- a/src/core/helpers/alenvi.js
+++ b/src/core/helpers/alenvi.js
@@ -1,5 +1,5 @@
 import { Cookies } from 'quasar';
-import User from '@api/Users';
+import Users from '@api/Users';
 import store from 'src/store/index';
 
 export const canNavigate = async () => {
@@ -12,10 +12,22 @@ export const canNavigate = async () => {
 
 export const refreshAlenviCookies = async () => {
   try {
-    await User.refreshToken();
+    await Users.refreshToken();
     return true;
   } catch (e) {
     console.error(e);
     return false;
   }
+};
+
+export const isUserLogged = async () => {
+  const refresh = await refreshAlenviCookies();
+  if (!refresh) return false;
+
+  await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));
+  const loggedUser = store.getters['main/getLoggedUser'];
+  if (loggedUser) return true;
+
+  await Users.logOut();
+  return false;
 };

--- a/src/core/mixins/logInMixin.js
+++ b/src/core/mixins/logInMixin.js
@@ -18,9 +18,9 @@ export const logInMixin = {
       const options = { path: '/', secure: process.env.NODE_ENV !== 'development', sameSite: 'Lax' };
       const expireDate = cookieExpirationDate();
 
-      this.$q.cookies.set('alenvi_token', auth.token, { ...options, expires: expireDate });
       this.$q.cookies.set('refresh_token', auth.refreshToken, { ...options, expires: 365 });
       this.$q.cookies.set('user_id', auth.user._id, { ...options, expires: expireDate });
+
       await this.$store.dispatch('main/fetchLoggedUser', auth.user._id);
 
       if (!this.loggedUser) throw new Error('Error on login');

--- a/src/core/mixins/logInMixin.js
+++ b/src/core/mixins/logInMixin.js
@@ -1,6 +1,5 @@
 import { mapGetters, mapState } from 'vuex';
 import Users from '@api/Users';
-import { cookieExpirationDate } from '../helpers/alenvi';
 import { WEBAPP } from '../data/constants';
 
 export const logInMixin = {
@@ -14,11 +13,6 @@ export const logInMixin = {
   methods: {
     async logInUser (authenticationPayload) {
       const auth = await Users.authenticate({ ...authenticationPayload, origin: WEBAPP });
-
-      const options = { path: '/', secure: process.env.NODE_ENV !== 'development', sameSite: 'Lax' };
-      const expireDate = cookieExpirationDate();
-
-      this.$q.cookies.set('user_id', auth.user._id, { ...options, expires: expireDate });
 
       await this.$store.dispatch('main/fetchLoggedUser', auth.user._id);
 

--- a/src/core/mixins/logInMixin.js
+++ b/src/core/mixins/logInMixin.js
@@ -18,7 +18,6 @@ export const logInMixin = {
       const options = { path: '/', secure: process.env.NODE_ENV !== 'development', sameSite: 'Lax' };
       const expireDate = cookieExpirationDate();
 
-      this.$q.cookies.set('refresh_token', auth.refreshToken, { ...options, expires: 365 });
       this.$q.cookies.set('user_id', auth.user._id, { ...options, expires: expireDate });
 
       await this.$store.dispatch('main/fetchLoggedUser', auth.user._id);

--- a/src/core/pages/signin/Authenticate.vue
+++ b/src/core/pages/signin/Authenticate.vue
@@ -35,17 +35,14 @@
 
 <script>
 import get from 'lodash/get';
-import { Cookies } from 'quasar';
 import { required, email } from 'vuelidate/lib/validators';
-import Users from '@api/Users';
 import CompaniHeader from '@components/CompaniHeader';
 import Input from '@components/form/Input';
 import Button from '@components/Button';
 import { NotifyNegative } from '@components/popup/notify';
 import { AUXILIARY_ROLES, AUXILIARY_WITHOUT_COMPANY, REQUIRED_LABEL } from '@data/constants';
-import { refreshAlenviCookies } from '@helpers/alenvi';
+import { isUserLogged } from '@helpers/alenvi';
 import { logInMixin } from '@mixins/logInMixin';
-import store from 'src/store/index';
 
 export default {
   metaInfo: {
@@ -89,17 +86,9 @@ export default {
     },
   },
   async beforeRouteEnter (to, from, next) {
-    const refresh = await refreshAlenviCookies();
-    if (refresh) {
-      await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));
-
-      const loggedUser = store.getters['main/getLoggedUser'];
-      if (loggedUser) next({ path: '/' });
-      else {
-        await Users.logOut();
-        next();
-      }
-    } else next();
+    const isLogged = await isUserLogged();
+    if (isLogged) next({ path: '/' });
+    else next();
   },
   methods: {
     async submit () {

--- a/src/core/pages/signin/ForgotPassword.vue
+++ b/src/core/pages/signin/ForgotPassword.vue
@@ -23,6 +23,9 @@ import Users from '@api/Users';
 import CompaniHeader from '@components/CompaniHeader';
 import Input from '@components/form/Input';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
+import { refreshAlenviCookies } from '@helpers/alenvi';
+import { Cookies } from 'quasar';
+import store from 'src/store/index';
 
 export default {
   components: {
@@ -36,6 +39,19 @@ export default {
   },
   validations: {
     email: { email, required },
+  },
+  async beforeRouteEnter (to, from, next) {
+    const refresh = await refreshAlenviCookies();
+    if (refresh) {
+      await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));
+
+      const loggedUser = store.getters['main/getLoggedUser'];
+      if (loggedUser) next({ path: '/' });
+      else {
+        await Users.logOut();
+        next();
+      }
+    } else next();
   },
   methods: {
     async submit () {

--- a/src/core/pages/signin/ForgotPassword.vue
+++ b/src/core/pages/signin/ForgotPassword.vue
@@ -23,9 +23,7 @@ import Users from '@api/Users';
 import CompaniHeader from '@components/CompaniHeader';
 import Input from '@components/form/Input';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
-import { refreshAlenviCookies } from '@helpers/alenvi';
-import { Cookies } from 'quasar';
-import store from 'src/store/index';
+import { isUserLogged } from '@helpers/alenvi';
 
 export default {
   components: {
@@ -41,17 +39,9 @@ export default {
     email: { email, required },
   },
   async beforeRouteEnter (to, from, next) {
-    const refresh = await refreshAlenviCookies();
-    if (refresh) {
-      await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));
-
-      const loggedUser = store.getters['main/getLoggedUser'];
-      if (loggedUser) next({ path: '/' });
-      else {
-        await Users.logOut();
-        next();
-      }
-    } else next();
+    const isLogged = await isUserLogged();
+    if (isLogged) next({ path: '/' });
+    else next();
   },
   methods: {
     async submit () {

--- a/src/core/pages/signin/ResetPassword.vue
+++ b/src/core/pages/signin/ResetPassword.vue
@@ -38,7 +38,6 @@ export default {
     return {
       password: '',
       passwordConfirm: '',
-      token: null,
       userId: null,
       timeout: null,
       userEmail: '',
@@ -69,7 +68,6 @@ export default {
   },
   methods: {
     setData (checkToken) {
-      this.token = checkToken.token;
       this.userId = checkToken.user._id;
       this.userEmail = checkToken.user.email;
     },
@@ -83,7 +81,7 @@ export default {
     },
     async submit () {
       try {
-        await Users.updatePassword(this.userId, { local: { password: this.password }, isConfirmed: true }, this.token);
+        await Users.updatePassword(this.userId, { local: { password: this.password }, isConfirmed: true });
 
         NotifyPositive('Mot de passe changé. Connexion en cours...');
         this.timeout = setTimeout(() => this.logIn(), 2000);

--- a/src/core/pages/signin/ResetPassword.vue
+++ b/src/core/pages/signin/ResetPassword.vue
@@ -24,6 +24,7 @@ import CompaniHeader from '@components/CompaniHeader';
 import Input from '@components/form/Input';
 import Users from '@api/Users';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
+import { isUserLogged } from '@helpers/alenvi';
 import { passwordMixin } from '@mixins/passwordMixin';
 import { logInMixin } from '@mixins/logInMixin';
 import { logOutAndRedirectToLogin } from 'src/router/redirect';
@@ -45,6 +46,9 @@ export default {
   },
   async beforeRouteEnter (to, from, next) {
     try {
+      const isLogged = await isUserLogged();
+      if (isLogged) next({ path: '/' });
+
       if (to.params.token) {
         const checkToken = await Users.checkResetPasswordToken(to.params.token);
         next(vm => vm.setData(checkToken));

--- a/src/core/pages/signin/ResetPassword.vue
+++ b/src/core/pages/signin/ResetPassword.vue
@@ -47,7 +47,7 @@ export default {
   async beforeRouteEnter (to, from, next) {
     try {
       const isLogged = await isUserLogged();
-      if (isLogged) next({ path: '/' });
+      if (isLogged) return next({ path: '/' });
 
       if (to.params.token) {
         const checkToken = await Users.checkResetPasswordToken(to.params.token);

--- a/src/modules/client/components/contracts/ContractsCell.vue
+++ b/src/modules/client/components/contracts/ContractsCell.vue
@@ -25,9 +25,9 @@
                 </div>
                 <div v-else-if="!getContractLink(props.row) && displayUploader && !hasToBeSignedOnline(props.row)"
                   class="row justify-center table-actions">
-                  <q-uploader flat :url="docsUploadUrl(contract._id)" :headers="headers"
+                  <q-uploader flat :url="docsUploadUrl(contract._id)" with-credentials auto-upload @uploaded="refresh"
                     :form-fields="getFormFields(contract, props.row)" field-name="file" :accept="extensions"
-                    auto-upload @uploaded="refresh" @fail="failMsg" />
+                    @fail="failMsg" />
                 </div>
                 <div v-else-if="getContractLink(props.row)" class="row justify-center table-actions">
                   <q-btn flat round small color="primary" type="a" :href="getContractLink(props.row)" target="_blank"
@@ -81,7 +81,6 @@
 </template>
 
 <script>
-import { Cookies } from 'quasar';
 import orderBy from 'lodash/orderBy';
 import get from 'lodash/get';
 import esign from '@api/Esign';
@@ -151,9 +150,6 @@ export default {
     sortedContracts () {
       const { contracts } = this;
       return contracts.sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
-    },
-    headers () {
-      return [{ name: 'x-access-token', value: Cookies.get('alenvi_token') || '' }];
     },
   },
   methods: {

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -132,7 +132,7 @@
                 </template>
                 <template v-else-if="col.name === 'signedMandate'">
                   <div v-if="!props.row.drive || !getMandateLink(props.row)" class="row justify-center table-actions">
-                    <q-uploader flat :url="docsUploadUrl" :headers="headers" :form-fields="mandateFormFields(props.row)"
+                    <q-uploader flat :url="docsUploadUrl" with-credentials :form-fields="mandateFormFields(props.row)"
                       field-name="file" auto-upload :accept="extensions" @uploaded="refreshMandates"
                       @failed="failMsg" />
                   </div>
@@ -212,7 +212,7 @@
                 </template>
                 <template v-else-if="col.name === 'signedQuote'">
                   <div v-if="!props.row.drive || !getQuoteLink(props.row)" class="row justify-center table-actions">
-                    <q-uploader flat :url="docsUploadUrl" :headers="headers" :form-fields="quoteFormFields(props.row)"
+                    <q-uploader flat :url="docsUploadUrl" with-credentials :form-fields="quoteFormFields(props.row)"
                       field-name="file" :accept="extensions" auto-upload @uploaded="refreshQuotes"
                       @failed="failMsg" />
                   </div>
@@ -278,7 +278,6 @@
 </template>
 
 <script>
-import { Cookies } from 'quasar';
 import { mapState } from 'vuex';
 import { required, requiredIf } from 'vuelidate/lib/validators';
 import get from 'lodash/get';
@@ -458,9 +457,6 @@ export default {
 
       return `${process.env.API_HOSTNAME}/customers/${this.customer._id}/gdrive/${this.customer.driveFolder.driveId}`
         + '/upload';
-    },
-    headers () {
-      return [{ name: 'x-access-token', value: Cookies.get('alenvi_token') || '' }];
     },
     company () {
       return this.$store.getters['main/getCompany'];

--- a/src/modules/client/layouts/Layout.vue
+++ b/src/modules/client/layouts/Layout.vue
@@ -23,8 +23,7 @@
           <q-separator :key="`separator-${route.ref}`" />
           </template>
         </template>
-        <ni-side-menu-footer :label="footerLabel" :user-id="loggedUser._id" :interface-type="interfaceType"
-          @click="connectToBotMessenger" />
+        <ni-side-menu-footer :label="footerLabel" :user-id="loggedUser._id" :interface-type="interfaceType" />
       </q-list>
       <div :class="chevronContainerClasses">
         <q-btn :class="chevronClasses" dense round unelevated :icon="menuIcon" @click="isMini = !isMini" />
@@ -40,7 +39,6 @@
 </template>
 
 <script>
-import { Cookies } from 'quasar';
 import { layoutMixin } from '@mixins/layoutMixin';
 import { sideMenuMixin } from '@mixins/sideMenuMixin';
 import SideMenuFooter from '@components/menu/SideMenuFooter';
@@ -67,12 +65,6 @@ export default {
     footerLabel () {
       if (this.isCoach || this.isAuxiliary) return this.userFirstname;
       return this.loggedUser.identity.lastname;
-    },
-  },
-  methods: {
-    connectToBotMessenger () {
-      const token = Cookies.get('alenvi_token');
-      window.location.href = `${process.env.MESSENGER_LINK}?ref=${token}`;
     },
   },
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,11 +53,6 @@ Router.beforeEach(async (to, from, next) => {
       }
     }
   } else {
-    if (['/login', '/forgot-password'].includes(to.path) && Cookies.get('refresh_token') && Cookies.get('user_id')) {
-      await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));
-      const loggedUser = store.getters['main/getLoggedUser'];
-      if (loggedUser) next({ path: '/' });
-    }
     next();
   }
 });

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,7 @@ const Router = new VueRouter({
 
 Router.beforeEach(async (to, from, next) => {
   if (to.meta.cookies) {
-    if (!Cookies.get('alenvi_token') || !Cookies.get('user_id')) {
+    if (!Cookies.get('user_id')) {
       const refresh = await refreshAlenviCookies();
       if (refresh) {
         if (store.state.main.refreshState) await store.dispatch('main/fetchLoggedUser', Cookies.get('user_id'));

--- a/src/router/redirect.js
+++ b/src/router/redirect.js
@@ -1,11 +1,10 @@
+import { LocalStorage } from 'quasar';
 import router from 'src/router/index';
 import store from 'src/store/index';
-import { Cookies, LocalStorage } from 'quasar';
+import Users from 'src/core/api/Users';
 
-export const logOutAndRedirectToLogin = (params) => {
-  const options = { path: '/' };
-  Cookies.remove('refresh_token', options);
-  Cookies.remove('user_id', options);
+export const logOutAndRedirectToLogin = async (params) => {
+  await Users.logOut();
   LocalStorage.clear();
 
   store.dispatch('course/resetCourse');

--- a/src/router/redirect.js
+++ b/src/router/redirect.js
@@ -4,7 +4,6 @@ import { Cookies, LocalStorage } from 'quasar';
 
 export const logOutAndRedirectToLogin = (params) => {
   const options = { path: '/' };
-  Cookies.remove('alenvi_token', options);
   Cookies.remove('refresh_token', options);
   Cookies.remove('user_id', options);
   LocalStorage.clear();

--- a/test/cypress/integration/authenticate.spec.js
+++ b/test/cypress/integration/authenticate.spec.js
@@ -56,5 +56,5 @@ describe('Login page tests', () => {
       cy.getCookie('refresh_token').should('exist');
       cy.getCookie('user_id').should('exist');
     });
-  })
+  });
 });

--- a/test/cypress/integration/customer/agenda.spec.js
+++ b/test/cypress/integration/customer/agenda.spec.js
@@ -5,22 +5,24 @@ describe('customers agenda tests', () => {
     cy.visit('/customers/agenda');
   });
 
-  it('should display correctly the agenda page', function () {
+  it('should display correctly the agenda page', () => {
     cy.get('#q-app').click(500, 500);
     cy.get('[data-cy=customer-identity]').should('have.value', 'Romain BARDET');
 
     cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'day').week());
     cy.get('[data-cy=days-number]').eq(0).should(
       'contain',
-      Cypress.moment().subtract(1, 'day').startOf('week').add(1, 'day').format('DD')
+      Cypress.moment().subtract(1, 'day').startOf('week').add(1, 'day')
+        .format('DD')
     );
     cy.get('[data-cy=days-number]').eq(6).should(
       'contain',
-      Cypress.moment().subtract(1, 'day').endOf('week').add(1, 'day').format('DD')
+      Cypress.moment().subtract(1, 'day').endOf('week').add(1, 'day')
+        .format('DD')
     );
   });
 
-  it('should go through agenda and display events', function () {
+  it('should go through agenda and display events', () => {
     cy.get('#q-app').click(500, 500);
     cy.get('.event-intervention').should('have.length', 1);
     cy.get('[data-cy=event-title]').eq(0).should('contain', 'Auxiliary T.');

--- a/test/cypress/integration/customer/billing.spec.js
+++ b/test/cypress/integration/customer/billing.spec.js
@@ -31,10 +31,10 @@ describe('Customer billing tests', () => {
       expect($th.eq(12)).to.have.text('');
     });
 
-    cy.get('[data-cy=date-input] input').eq(0).clear()
-    cy.get('[data-cy=date-input] input').eq(0).type(Cypress.moment().subtract(4, 'M').format('DD/MM/YYYY'))
-    cy.get('[data-cy=date-input] input').eq(1).clear()
-    cy.get('[data-cy=date-input] input').eq(1).type(Cypress.moment().add(4, 'M').format('DD/MM/YYYY'))
+    cy.get('[data-cy=date-input] input').eq(0).clear();
+    cy.get('[data-cy=date-input] input').eq(0).type(Cypress.moment().subtract(4, 'M').format('DD/MM/YYYY'));
+    cy.get('[data-cy=date-input] input').eq(1).clear();
+    cy.get('[data-cy=date-input] input').eq(1).type(Cypress.moment().add(4, 'M').format('DD/MM/YYYY'));
     cy.get('[data-cy=start-period] td').and(($tds) => {
       expect($tds.eq(0)).to.have.text(Cypress.moment().subtract(4, 'M').format('DD/MM/YY'));
     });
@@ -58,8 +58,10 @@ describe('Customer billing tests', () => {
     cy.get('[data-cy=col-date]').eq(2).should('contain', oneMonthBefore.date(5).format('DD/MM/YYYY'));
 
     cy.get('[data-cy=col-document]').eq(0).should('contain', `Facture FACT-101${twoMonthBefore.format('MMYY')}00002`);
-    cy.get('[data-cy=col-document]').eq(1).should('contain', `Paiement REG-101${oneMonthBefore.format('MMYY')}00201 (Prélèvement)`);
-    cy.get('[data-cy=col-document]').eq(2).should('contain', `Remboursement REMB-101${oneMonthBefore.format('MMYY')}00201 (Virement)`);
+    cy.get('[data-cy=col-document]').eq(1)
+      .should('contain', `Paiement REG-101${oneMonthBefore.format('MMYY')}00201 (Prélèvement)`);
+    cy.get('[data-cy=col-document]').eq(2)
+      .should('contain', `Remboursement REMB-101${oneMonthBefore.format('MMYY')}00201 (Virement)`);
 
     cy.get('[data-cy=col-inclTaxes]').eq(0).should('contain', '-10,00\u00A0€');
     cy.get('[data-cy=col-inclTaxes]').eq(1).should('contain', '10,00\u00A0€');
@@ -86,11 +88,10 @@ describe('Customer billing tests', () => {
       expect($tds.eq(4)).to.have.text('');
     });
 
-    cy.get('[data-cy=link]').eq(0).then(($a) => {
-      const href = $a.prop('href');
-      expect(href).to.match(/^http(s)?:\/\/.*\/bills\/[0-9a-fA-F]{24}\/pdfs\?x-access-token=.*$/);
-      cy.request(href).its('status').should('equal', 200);
-    });
+    cy.server();
+    cy.route('GET', '/bills/*/pdfs').as('pdf');
+    cy.get('[data-cy=link]').eq(0).click().wait('@pdf')
+      .then((xhr) => { expect(xhr.status).to.equal(200); });
   });
 
   it('should display correctly tpp billing table', () => {
@@ -107,7 +108,8 @@ describe('Customer billing tests', () => {
     cy.get('[data-cy=col-date]').eq(4).should('contain', oneMonthBefore.date(5).format('DD/MM/YYYY'));
 
     cy.get('[data-cy=col-document]').eq(3).should('contain', `Facture FACT-101${twoMonthBefore.format('MMYY')}00001`);
-    cy.get('[data-cy=col-document]').eq(4).should('contain', `Paiement REG-101${oneMonthBefore.format('MMYY')}00202 (Prélèvement)`);
+    cy.get('[data-cy=col-document]').eq(4)
+      .should('contain', `Paiement REG-101${oneMonthBefore.format('MMYY')}00202 (Prélèvement)`);
 
     cy.get('[data-cy=col-inclTaxes]').eq(3).should('contain', '-20,00\u00A0€');
     cy.get('[data-cy=col-inclTaxes]').eq(4).should('contain', '20,00\u00A0€');
@@ -129,11 +131,10 @@ describe('Customer billing tests', () => {
       expect($tds.eq(9)).to.have.text('');
     });
 
-    cy.get('[data-cy=link]').eq(1).then(($a) => {
-      const href = $a.prop('href');
-      expect(href).to.match(/^http(s)?:\/\/.*\/bills\/[0-9a-fA-F]{24}\/pdfs\?x-access-token=.*$/);
-      cy.request(href).its('status').should('equal', 200);
-    });
+    cy.server();
+    cy.route('GET', '/bills/*/pdfs').as('pdf');
+    cy.get('[data-cy=link]').eq(1).click().wait('@pdf')
+      .then((xhr) => { expect(xhr.status).to.equal(200); });
   });
 
   it('should correctly display tax certificate table', () => {
@@ -142,10 +143,10 @@ describe('Customer billing tests', () => {
       expect($tds.eq(1)).to.have.text(Cypress.moment().subtract(1, 'y').endOf('y').format('DD/MM/YYYY'));
       expect($tds.eq(2)).to.contain('file_download');
     });
-    cy.get('[data-cy=link]').eq(2).then(($a) => {
-      const href = $a.prop('href');
-      expect(href).to.match(/^http(s)?:\/\/.*\/taxcertificates\/[0-9a-fA-F]{24}\/pdfs\?x-access-token=.*$/);
-      cy.request(href).its('status').should('equal', 200);
-    })
-  })
+
+    cy.server();
+    cy.route('GET', '/taxcertificates/*/pdfs').as('pdf');
+    cy.get('[data-cy=link]').eq(2).click().wait('@pdf')
+      .then((xhr) => { expect(xhr.status).to.equal(200); });
+  });
 });

--- a/test/cypress/integration/customer/subscription.spec.js
+++ b/test/cypress/integration/customer/subscription.spec.js
@@ -7,7 +7,7 @@ describe('customers subscription tests', () => {
     cy.visit('/customers/subscriptions');
   });
 
-  it('should display correctly the subscriptions part of the page', function () {
+  it('should display correctly the subscriptions part of the page', () => {
     cy.get('#q-app').click(500, 500);
     cy.get('[data-cy=subscriptions-table]').within(() => {
       cy.get('th').should('have.length', 6).and(($th) => {
@@ -20,14 +20,14 @@ describe('customers subscription tests', () => {
       });
     });
 
-    cy.get('[data-cy=col-service]').should('contain', 'Service 1')
-    cy.get('[data-cy=col-nature]').should('contain', 'Horaire')
-    cy.get('[data-cy=col-unitTTCRate]').should('contain', '12.00€')
-    cy.get('[data-cy=col-estimatedWeeklyVolume]').should('contain', '12h')
-    cy.get('[data-cy=col-weeklyRate]').should('contain', '144.00€')
+    cy.get('[data-cy=col-service]').should('contain', 'Service 1');
+    cy.get('[data-cy=col-nature]').should('contain', 'Horaire');
+    cy.get('[data-cy=col-unitTTCRate]').should('contain', '12.00€');
+    cy.get('[data-cy=col-estimatedWeeklyVolume]').should('contain', '12h');
+    cy.get('[data-cy=col-weeklyRate]').should('contain', '144.00€');
   });
 
-  it('should interact correctly with the subscriptions part of the page', function () {
+  it('should interact correctly with the subscriptions part of the page', () => {
     cy.get('#q-app').click(500, 500);
     cy.get('.q-checkbox__inner').should('have.class', 'q-checkbox__inner--falsy');
     cy.get('.q-checkbox').click();
@@ -37,7 +37,7 @@ describe('customers subscription tests', () => {
     cy.get('[data-cy=agreement]').should(
       'contain',
       `(Accepté le ${moment().format('DD/MM/YYYY')} par Helper TEST)`
-    )
+    );
 
     cy.get('[data-cy=show-subscription-history]').click();
     cy.get('[data-cy=subscriptions-history]').within(() => {
@@ -82,7 +82,7 @@ describe('customers subscription tests', () => {
     });
   });
 
-  it('should display correctly the payment part and open the modal for the mandate', function () {
+  it('should display correctly the payment part and open the modal for the mandate', () => {
     cy.get('#q-app').click(500, 500);
 
     cy.get('[data-cy=bank-account-owner]').should('have.value', 'David gaudu');

--- a/test/cypress/integration/ni/billing/toBill.spec.js
+++ b/test/cypress/integration/ni/billing/toBill.spec.js
@@ -24,15 +24,15 @@ describe('ToBill', () => {
       });
     });
 
-    cy.get('[data-cy=col-customer]').should('contain', 'ANDTHEQUEENS C.')
-    cy.get('[data-cy=col-client]').should('contain', 'ANDTHEQUEENS C.')
-    cy.get('[data-cy=col-startDate]').should('contain', '19/01/19')
-    cy.get('[data-cy=col-service]').should('contain', 'Service 2')
-    cy.get('[data-cy=col-hours]').should('contain', '5.00h')
-    cy.get('[data-cy=col-unitExclTaxes]').should('contain', '10,71')
-    cy.get('[data-cy=col-discount]').should('contain', '0,00')
-    cy.get('[data-cy=col-exclTaxes]').should('contain', '53,57')
-    cy.get('[data-cy=col-inclTaxes]').should('contain', '60,00')
+    cy.get('[data-cy=col-customer]').should('contain', 'ANDTHEQUEENS C.');
+    cy.get('[data-cy=col-client]').should('contain', 'ANDTHEQUEENS C.');
+    cy.get('[data-cy=col-startDate]').should('contain', '19/01/19');
+    cy.get('[data-cy=col-service]').should('contain', 'Service 2');
+    cy.get('[data-cy=col-hours]').should('contain', '5.00h');
+    cy.get('[data-cy=col-unitExclTaxes]').should('contain', '10,71');
+    cy.get('[data-cy=col-discount]').should('contain', '0,00');
+    cy.get('[data-cy=col-exclTaxes]').should('contain', '53,57');
+    cy.get('[data-cy=col-inclTaxes]').should('contain', '60,00');
 
     cy.get('[data-cy=bill-row]').should('have.length', 3);
 
@@ -56,7 +56,7 @@ describe('ToBill', () => {
     cy.get('[data-cy=date-input]  input').eq(1).clear().type('17/01/2019');
     cy.get('[data-cy=bill-row]').should('have.length', 1);
     cy.get('[data-cy=col-customer]').should('contain', 'AUFRAY H.');
-    cy.get('[data-cy=col-endDate]').should('contain', '17/01/19')
+    cy.get('[data-cy=col-endDate]').should('contain', '17/01/19');
     cy.get('[data-cy=col-selected-bill]').within(() => {
       cy.get('.q-checkbox__inner').should('have.class', 'q-checkbox__inner--falsy');
       cy.get('.q-checkbox').click();

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -1,10 +1,10 @@
-import './commands'
+import './commands';
 
-const resizeObserverLoopErrRe = /^ResizeObserver loop limit exceeded/
+const resizeObserverLoopErrRe = /^ResizeObserver loop limit exceeded/;
 
 Cypress.on('uncaught:exception', (err) => {
   if (resizeObserverLoopErrRe.test(err.message)) {
     // returning false here prevents Cypress from failing the test
-    return false
+    return false;
   }
-})
+});


### PR DESCRIPTION
Refonte de l'authentification :
- Cote WEBAPP : les cookies (`alenvi_token`, `refresh_token`, `user_id`) sont mis dans le state des réponses de l'api et enregistrer automatiquement dans le navigateur.
- Les 2 premiers ne sont plus accessible par du code JS (`httpOnly`) et sont automatiquement ajoutés aux requetes qui partent du front quand necessaire (`withCredentials` cote webapp)
- Il a donc fallu ajouter une route `logout` pour enlever les cookies lors de la déconnexion (on ne peut plus le faire directement en JS)

