### PR TITLE
Com 1737 design system grey palette

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -15,6 +15,7 @@ module.exports = function (ctx) {
     ],
     css: [
       'app.styl',
+      'colors.styl',
     ],
     extras: [
       'material-icons',

--- a/src/core/components/Banner.vue
+++ b/src/core/components/Banner.vue
@@ -16,7 +16,7 @@ export default {
   data () {
     const interfaceType = /\/ad\//.test(this.$router.currentRoute.path) ? VENDOR : CLIENT;
     return {
-      backgroundClass: interfaceType === CLIENT ? 'grey-background' : 'beige-background',
+      backgroundClass: interfaceType === CLIENT ? 'bg-grey-300' : 'beige-background',
     };
   },
 };

--- a/src/core/components/ProfileTabs.vue
+++ b/src/core/components/ProfileTabs.vue
@@ -44,7 +44,7 @@ export default {
       & > .q-tab__indicator
         color: $primary
     /deep/.q-tab__indicator
-      color: $middle-grey
+      color: $grey-300
       opacity: 1
     & /deep/.q-tab-panels
       background-color: inherit
@@ -73,7 +73,7 @@ export default {
             max-width: 33%
           & .q-tab__content
             & .q-tab__label
-              color: $dark-grey
+              color: $grey-800
               font-size: 24px
             & .q-tab__alert
               background: $secondary

--- a/src/core/components/courses/CourseCell.vue
+++ b/src/core/components/courses/CourseCell.vue
@@ -160,7 +160,7 @@ export default {
     display: flex;
     flex-wrap: wrap;
     font-size: 12px;
-    color: $grey;
+    color: $grey-400;
   .item-section-container
     display: flex;
   .q-item__section--side

--- a/src/core/components/courses/CourseContainer.vue
+++ b/src/core/components/courses/CourseContainer.vue
@@ -24,7 +24,7 @@ export default {
 
     return {
       interfaceType,
-      backgroundClass: interfaceType === CLIENT ? 'grey-background' : 'beige-background',
+      backgroundClass: interfaceType === CLIENT ? 'bg-grey-300' : 'beige-background',
     };
   },
   computed: {

--- a/src/core/components/courses/OpenQuestionChart.vue
+++ b/src/core/components/courses/OpenQuestionChart.vue
@@ -28,7 +28,7 @@ export default {
 .card
   padding: 16px 32px
 .subtitle
-  color: $dark-grey
+  color: $grey-800
   font-size: 14px
 .answer-container
   border-radius: 3px !important

--- a/src/core/components/courses/QuestionAnswerChart.vue
+++ b/src/core/components/courses/QuestionAnswerChart.vue
@@ -48,7 +48,7 @@ export default {
   padding: 16px 32px
 
 .subtitle
-  color: $dark-grey
+  color: $grey-800
   font-size: 14px
 
 .percentage

--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -53,7 +53,7 @@ export default {
   padding: 16px 32px
 
 .subtitle
-  color: $dark-grey
+  color: $grey-800
   font-size: 14px
 
 .percentage

--- a/src/core/components/form/DateInput.vue
+++ b/src/core/components/form/DateInput.vue
@@ -8,7 +8,7 @@
       :disable="disable" :class="{ 'borders': inModal }" :error-message="errorMessage" @blur="blur" ref="dateInput"
       @focus="focus">
       <template #append>
-        <q-icon name="event" class="cursor-pointer" @click="focus">
+        <q-icon name="event" class="cursor-pointer" @click="focus" color="grey-800">
           <q-menu ref="qDateMenu" anchor="bottom right" self="top right">
             <q-date minimal :value="date" @input="select" :options="dateOptions" :disable="disable" />
           </q-menu>

--- a/src/core/components/form/DateInput.vue
+++ b/src/core/components/form/DateInput.vue
@@ -81,7 +81,7 @@ export default {
 <style lang="stylus" scoped>
   .borders
     /deep/ .q-field__control
-      border: 1px solid $middle-grey
+      border: 1px solid $grey-300
 
   .q-input
     /deep/ .q-field__control

--- a/src/core/components/form/DateInput.vue
+++ b/src/core/components/form/DateInput.vue
@@ -8,7 +8,7 @@
       :disable="disable" :class="{ 'borders': inModal }" :error-message="errorMessage" @blur="blur" ref="dateInput"
       @focus="focus">
       <template #append>
-        <q-icon name="event" class="cursor-pointer" @click="focus" color="grey-800">
+        <q-icon name="event" class="cursor-pointer" @click="focus" color="grey-600">
           <q-menu ref="qDateMenu" anchor="bottom right" self="top right">
             <q-date minimal :value="date" @input="select" :options="dateOptions" :disable="disable" />
           </q-menu>

--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -52,7 +52,7 @@ export default {
 
 <style lang="stylus" scoped>
   .borders
-    border: 1px solid $middle-grey
+    border: 1px solid $grey-300
 
   /deep/ .q-field__append
     .text-negative

--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -51,9 +51,6 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-  .borders
-    border: 1px solid $grey-300
-
   /deep/ .q-field__append
     .text-negative
       display: none

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -110,7 +110,7 @@ export default {
 <style lang="stylus" scoped>
   .datetime-container
     width: 100%
-    border: 1px solid $middle-grey;
+    border: 1px solid $grey-300
     border-radius: 3px;
     @media screen and (min-width: 768px)
       flex-wrap: nowrap;

--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -123,7 +123,7 @@ export default {
       height: 38px
       margin: 0
       .q-btn__content
-        color: $grey
+        color: $grey-400
     .q-btn
       margin: 0
       padding: 0

--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -115,7 +115,7 @@ export default {
   /deep/ .q-uploader
     width: 100%
     &--bordered
-      border: 1px solid #d0d0d0
+      border: 1px solid $grey-300
     .q-uploader__list
       display: none
     .q-uploader__header-content

--- a/src/core/components/form/Input.vue
+++ b/src/core/components/form/Input.vue
@@ -124,7 +124,7 @@ export default {
       width: 100%
       font-size: 0
     &.borders
-      border: 1px solid $middle-grey
+      border: 1px solid $grey-300
   .file-error
     color: $secondary
     line-height: 1

--- a/src/core/components/table/LargeTable.vue
+++ b/src/core/components/table/LargeTable.vue
@@ -18,7 +18,7 @@
         <ni-pagination :props="props" :pagination.sync="pagination" :data="data" />
       </template>
       <template #no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm grey-text">
+        <div v-show="!loading" class="full-width row q-gutter-sm text-grey-800">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/ResponsiveTable.vue
+++ b/src/core/components/table/ResponsiveTable.vue
@@ -22,7 +22,7 @@
         </slot>
       </template>
       <template #no-data>
-        <div class="full-width row grey-text justify-center">
+        <div class="full-width row text-grey-800 justify-center">
           <span class="text-italic q-pb-sm" style="font-size: 0.8rem">{{ noDataLabel }}</span>
           <q-separator />
         </div>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -20,7 +20,7 @@
         <slot name="bottom-row" :props="props" />
       </template>
       <template #no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm grey-text">
+        <div v-show="!loading" class="full-width row q-gutter-sm text-grey-800">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/TableList.vue
+++ b/src/core/components/table/TableList.vue
@@ -15,7 +15,7 @@
         </q-tr>
       </template>
       <template #no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm grey-text">
+        <div v-show="!loading" class="full-width row q-gutter-sm text-grey-800">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -31,7 +31,7 @@ div h4:only-child
   margin-bottom: 0
 
 .client-background
-  background: $neutral-grey
+  background: $grey-100
 
 .vendor-background
   background: $neutral-beige

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -82,19 +82,19 @@ div h4:only-child
 
 .avatar
   border-radius: 50%
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 1px 1px rgba(0,0,0,0.14), 0 2px 1px -1px rgba(0,0,0,0.12);
-  vertical-align: middle;
+  width: 50px
+  height: 50px
+  border-radius: 50%
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 1px 1px rgba(0,0,0,0.14), 0 2px 1px -1px rgba(0,0,0,0.12)
+  vertical-align: middle
   @media screen and (max-width: 1023px)
     height: 30px
     width: 30px
 
 .grey-background
-  background-color: $middle-grey
+  background-color: $grey-300
 .beige-background
   background-color: $middle-beige
 
 .grey-text
-  color: $dark-grey;
+  color: $grey-800

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -91,10 +91,6 @@ div h4:only-child
     height: 30px
     width: 30px
 
-.grey-background
-  background-color: $grey-300
 .beige-background
   background-color: $middle-beige
 
-.grey-text
-  color: $grey-800

--- a/src/css/chip.styl
+++ b/src/css/chip.styl
@@ -31,7 +31,7 @@
   .avatar
     z-index: 2
     box-shadow: none
-    border: 1px solid #979797
+    border: 1px solid $grey-600
     @media (min-width: 1024px)
       width: 2.5rem
       height: 2.5rem

--- a/src/css/chip.styl
+++ b/src/css/chip.styl
@@ -8,7 +8,7 @@
       left: 50%
       transform: translate(-50%, -50%)
   .q-chip
-    background: $dark-grey
+    background: $grey-800
     width: 100%
     padding: 0 10px
     justify-content: flex-end

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -1,4 +1,12 @@
-// <ni-button color="gray-xxx" ... />
+// colors can be used as quasar color <ni-button color="grey-xxx" ... />
+
+// default grey is grey-400
+.text-grey {
+  color: $grey;
+}
+.bg-grey {
+  background: $grey;
+}
 
 .text-grey-800 {
   color: $dark-grey;

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -2,37 +2,37 @@
 
 // over-riding default grey in quasar colors as grey-400
 .text-grey {
-  color: $grey;
+  color: $grey-400
 }
 .bg-grey {
-  background: $grey;
+  background: $grey-400
 }
 
 // adding our 4 shades of grey in quasar colors as grey-XXX
 .text-grey-800 {
-  color: $grey-800;
+  color: $grey-800
 }
 .bg-grey-800 {
-  background: $grey-800;
+  background: $grey-800
 }
 
 .text-grey-400 {
-  color: $grey;
+  color: $grey-400
 }
 .bg-grey-400 {
-  background: $grey;
+  background: $grey-400
 }
 
 .text-grey-300 {
-  color: $grey-300;
+  color: $grey-300
 }
 .bg-grey-300 {
-  background: $grey-300;
+  background: $grey-300
 }
 
 .text-grey-100 {
-  color: $light-grey;
+  color: $light-grey
 }
 .bg-grey-100 {
-  background: $light-grey;
+  background: $light-grey
 }

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -1,6 +1,4 @@
-// colors can be used as quasar colors <ni-button color="grey-xxx" ... />
-
-// over-riding default grey in quasar colors as grey-400
+// over-riding default grey color as grey-400
 .text-grey {
   color: $grey-400
 }
@@ -8,19 +6,12 @@
   background: $grey-400
 }
 
-// adding our 4 shades of grey in quasar colors as grey-XXX
+// adding our other shades of grey in quasar color palette
 .text-grey-800 {
   color: $grey-800
 }
 .bg-grey-800 {
   background: $grey-800
-}
-
-.text-grey-400 {
-  color: $grey-400
-}
-.bg-grey-400 {
-  background: $grey-400
 }
 
 .text-grey-300 {
@@ -31,8 +22,8 @@
 }
 
 .text-grey-100 {
-  color: $light-grey
+  color: $grey-100
 }
 .bg-grey-100 {
-  background: $light-grey
+  background: $grey-100
 }

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -1,0 +1,29 @@
+// <ni-button color="gray-xxx" ... />
+
+.text-grey-800 {
+  color: $dark-grey;
+}
+.bg-grey-800 {
+  background: $dark-grey;
+}
+
+.text-grey-400 {
+  color: $grey;
+}
+.bg-grey-400 {
+  background: $grey;
+}
+
+.text-grey-300 {
+  color: $middle-grey;
+}
+.bg-grey-300 {
+  background: $middle-grey;
+}
+
+.text-grey-100 {
+  color: $light-grey;
+}
+.bg-grey-100 {
+  background: $light-grey;
+}

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -14,6 +14,13 @@
   background: $grey-800
 }
 
+.text-grey-600 {
+  color: $grey-600
+}
+.bg-grey-600 {
+  background: $grey-600
+}
+
 .text-grey-300 {
   color: $grey-300
 }

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -1,6 +1,6 @@
-// colors can be used as quasar color <ni-button color="grey-xxx" ... />
+// colors can be used as quasar colors <ni-button color="grey-xxx" ... />
 
-// default grey is grey-400
+// over-riding default grey in quasar colors as grey-400
 .text-grey {
   color: $grey;
 }
@@ -8,6 +8,7 @@
   background: $grey;
 }
 
+// adding our 4 shades of grey in quasar colors as grey-XXX
 .text-grey-800 {
   color: $dark-grey;
 }

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -10,10 +10,10 @@
 
 // adding our 4 shades of grey in quasar colors as grey-XXX
 .text-grey-800 {
-  color: $dark-grey;
+  color: $grey-800;
 }
 .bg-grey-800 {
-  background: $dark-grey;
+  background: $grey-800;
 }
 
 .text-grey-400 {
@@ -24,10 +24,10 @@
 }
 
 .text-grey-300 {
-  color: $middle-grey;
+  color: $grey-300;
 }
 .bg-grey-300 {
-  background: $middle-grey;
+  background: $grey-300;
 }
 
 .text-grey-100 {

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -29,14 +29,14 @@
             line-height: 20px
           & .q-item__section--side
             padding: 0
-            color: $grey-800
+            color: $grey-600
           & .q-item__section--avatar
             min-width: 24px
           & .q-item__label
             font-size: 1rem
       & .q-item
         & .q-item__section--side
-          color: $grey-800
+          color: $grey-600
         & .q-item__section--avatar
           min-width: 38px
 

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -51,7 +51,7 @@
         & .sidemenu-footer-user
           font-size: 11px
           font-weight: bold
-          color: #A3A3A3
+          color: $grey
         & .sidemenu-footer-icons
           margin-right: 10px
           display: flex

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -29,14 +29,14 @@
             line-height: 20px
           & .q-item__section--side
             padding: 0
-            color: $dark-grey
+            color: $grey-800
           & .q-item__section--avatar
             min-width: 24px
           & .q-item__label
             font-size: 1rem
       & .q-item
         & .q-item__section--side
-          color: $dark-grey
+          color: $grey-800
         & .q-item__section--avatar
           min-width: 38px
 

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -46,7 +46,7 @@
         align-items: flex-end
         & .q-item
           min-height: 40px
-          border-top: 1px solid $light-grey
+          border-top: 1px solid $grey-100
           padding: 6px 2px 0px 16px
         & .sidemenu-footer-user
           font-size: 11px

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -51,7 +51,7 @@
         & .sidemenu-footer-user
           font-size: 11px
           font-weight: bold
-          color: $grey
+          color: $grey-400
         & .sidemenu-footer-icons
           margin-right: 10px
           display: flex

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -29,14 +29,14 @@
             line-height: 20px
           & .q-item__section--side
             padding: 0
-            color: #737373
+            color: $dark-grey
           & .q-item__section--avatar
             min-width: 24px
           & .q-item__label
             font-size: 1rem
       & .q-item
         & .q-item__section--side
-          color: #737373
+          color: $dark-grey
         & .q-item__section--avatar
           min-width: 38px
 
@@ -46,7 +46,7 @@
         align-items: flex-end
         & .q-item
           min-height: 40px
-          border-top: 1px solid #e0e0e0
+          border-top: 1px solid $light-grey
           padding: 6px 2px 0px 16px
         & .sidemenu-footer-user
           font-size: 11px

--- a/src/css/history.styl
+++ b/src/css/history.styl
@@ -18,11 +18,11 @@
       flex: 1;
   &-info
     font-weight: bold;
-    color: #2E2E2E
+    color: $dark-grey
     white-space: pre-line
   &-details
     font-size: 12px;
-    color: $dark-grey;  
+    color: $dark-grey;
     margin: 3px 0 5px;
     white-space: pre-line
   &-signature

--- a/src/css/history.styl
+++ b/src/css/history.styl
@@ -8,7 +8,7 @@
     display: block
     margin: auto
     width: 95%
-    border-bottom: 1px solid $neutral-grey
+    border-bottom: 1px solid $grey-100
   &-cell
     margin: 2px 10px 0 2px
     padding: 5px

--- a/src/css/history.styl
+++ b/src/css/history.styl
@@ -10,28 +10,28 @@
     width: 95%
     border-bottom: 1px solid $neutral-grey
   &-cell
-    margin: 2px 10px 0 2px;
-    padding: 5px;
+    margin: 2px 10px 0 2px
+    padding: 5px
   &-title
-    display: flex;
+    display: flex
     &-text
       flex: 1;
   &-info
-    font-weight: bold;
-    color: $dark-grey
+    font-weight: bold
+    color: $grey-800
     white-space: pre-line
   &-details
-    font-size: 12px;
-    color: $dark-grey;
-    margin: 3px 0 5px;
+    font-size: 12px
+    color: $grey-800
+    margin: 3px 0 5px
     white-space: pre-line
   &-signature
-    color: $dark-grey
+    color: $grey-800
     font-size: 12px
     font-style: italic
     display: flex
     align-items: center
-    margin: 2px 0 3px;
+    margin: 2px 0 3px
     div
       margin-left: 5px
   &-avatar
@@ -52,4 +52,4 @@
   &-type
     color: $primary
   &-button
-    height: 20px;
+    height: 20px

--- a/src/css/input.styl
+++ b/src/css/input.styl
@@ -33,7 +33,7 @@
 
 .borders
   .q-field__control
-    border: 1px solid $middle-grey
+    border: 1px solid $grey-300
     border-radius: 3px
 
 .q-input

--- a/src/css/planning.styl
+++ b/src/css/planning.styl
@@ -29,12 +29,12 @@
   &-internal_hour
     background: $light-purple
   &-absence
-    background: $neutral-grey
+    background: $grey-100
   &-unavailability
     background: repeating-linear-gradient(
       45deg,
-      $neutral-grey,
-      $neutral-grey 3px,
+      $grey-100,
+      $grey-100 3px,
       $white 3px,
       $white 7px
     )
@@ -115,7 +115,7 @@
     font-size: 1.2em
     position: -webkit-sticky
     position: sticky
-    background-color: $neutral-grey
+    background-color: $grey-100
     top: 0
     left: 0
     right: 0

--- a/src/css/planning.styl
+++ b/src/css/planning.styl
@@ -74,7 +74,7 @@
         align-items: center;
     &-name
       font-size: 1.125rem
-      color: $grey
+      color: $grey-400
     &-number
       font-size: 1.5rem
       font-weight: 600

--- a/src/css/planning.styl
+++ b/src/css/planning.styl
@@ -115,7 +115,7 @@
     font-size: 1.2em;
     position: -webkit-sticky;
     position: sticky;
-    background-color: #eee;
+    background-color: $neutral-grey;
     top: 0;
     left: 0;
     right: 0;
@@ -172,7 +172,7 @@
     font-size: 12px;
   @media (max-width: 420px)
     font-size: 10px;
-  
+
 .customer-info
   .q-icon
     display: none;

--- a/src/css/planning.styl
+++ b/src/css/planning.styl
@@ -6,19 +6,19 @@
   margin-top: 6px
   &-container
     overflow: hidden
-    height: 100%;
-    width: stretch;
-    position: relative;
+    height: 100%
+    width: stretch
+    position: relative
   &-title
     font-size: 0.875rem
     font-weight: 600
   &-subtitle
-    display: flex;
-    flex-direction: row;
+    display: flex
+    flex-direction: row
     width: 100%
-    justify-content: space-between;
+    justify-content: space-between
     font-size: 0.6875rem
-    color: $dark-grey
+    color: $grey-800
   &-billed
     position: absolute;
     right: 0;
@@ -55,15 +55,15 @@
   border-style: hidden;
 
   td
-    border-left: 1px solid $middle-grey;
-    border-right: 1px solid $middle-grey;
+    border-left: 1px solid $grey-300
+    border-right: 1px solid $grey-300
     padding: 0px 5px 5px 5px;
   tr:not(:first-child)
     td:before
       content: '';
       display: block;
       width: 98%;
-      border-bottom: 1px solid $middle-grey;
+      border-bottom: 1px solid $grey-300
 
   .days
     &-header
@@ -92,115 +92,115 @@
     background: white;
     padding: 0 5px;
     th
-      background-color: white;
-      position: -webkit-sticky;
-      position: sticky;
-      z-index: 10;
+      background-color: white
+      position: -webkit-sticky
+      position: sticky
+      z-index: 10
       &:not(:first-child):before
-        content: '';
-        position: absolute;
+        content: ''
+        position: absolute
         left: 0;
         bottom: 0;
         top: 6px;
-        border-right: 1px solid $middle-grey;
+        border-right: 1px solid $grey-300;
     .bottom-border
       &:after
-        content: '';
-        position: absolute;
-        left: 6px;
-        right: 6px;
-        bottom: 0;
-        border-bottom: 1px solid $middle-grey;
+        content: ''
+        position: absolute
+        left: 6px
+        right: 6px
+        bottom: 0
+        border-bottom: 1px solid $grey-300;
   &-header
-    font-size: 1.2em;
-    position: -webkit-sticky;
-    position: sticky;
-    background-color: $neutral-grey;
-    top: 0;
-    left: 0;
-    right: 0;
-    width: 100%;
-    padding: 20px 20px 15px;
-    z-index: 10;
+    font-size: 1.2em
+    position: -webkit-sticky
+    position: sticky
+    background-color: $neutral-grey
+    top: 0
+    left: 0
+    right: 0
+    width: 100%
+    padding: 20px 20px 15px
+    z-index: 10
     @media screen and (max-width: 767px)
-      padding: 15px 10px 10px;
+      padding: 15px 10px 10px
   &-month
-    display: flex;
+    display: flex
     @media screen and (min-width: 768px)
-      justify-content: center;
+      justify-content: center
     @media screen and (max-width: 767px)
-      width: 60%;
+      width: 60%
     .q-icon
-      font-size: 0.8em;
-      margin: 5px;
+      font-size: 0.8em
+      margin: 5px
   &-search
-    display: flex;
-    align-items: center;
+    display: flex
+    align-items: center
     @media screen and (max-width: 767px)
-      margin-bottom: 10px;
+      margin-bottom: 10px
   &-actions
     display: flex
     justify-content: center
   &-navigation-actions
-    display: flex;
-    align-items: center;
-    flex-wrap: nowrap;
+    display: flex
+    align-items: center
+    flex-wrap: nowrap
     @media screen and (min-width: 768px)
       .q-btn
         margin: 0 5px
     @media screen and (max-width: 767px)
-      justify-content: space-around;
+      justify-content: space-around
       .q-btn
         width: 30px
     div:first-child
       flex-grow: 1
   &-view
-    padding: 4px;
+    padding: 4px
   &-hour
-    position: absolute;
-    color: $middle-grey;
-    font-size: 12px;
-    bottom: -3px;
+    position: absolute
+    color: $grey-300
+    font-size: 12px
+    bottom: -3px
 
 .person-name
   display: flex
   flex-direction: row
   align-items: center
-  font-weight: 600;
-  font-size: 14px;
+  font-weight: 600
+  font-size: 14px
   @media (min-width: 421px) and (max-width: 1023px)
-    font-size: 12px;
+    font-size: 12px
   @media (max-width: 420px)
-    font-size: 10px;
+    font-size: 10px
 
 .customer-info
   .q-icon
-    display: none;
+    display: none
   .q-btn
-    margin-left: auto;
+    margin-left: auto
     .q-icon
-      display: flex !important;
+      display: flex !important
 
 .customer
   &-info
-    background: $middle-grey;
-    padding: 5px 25px;
+    background: $grey-300
+    padding: 5px 25px
     & .q-if-inverted
-      background: $middle-grey !important;
-      border: none;
+      background: $grey-300 !important
+      border: none
   &-address
     margin-right: 6px
 
 .person-inner-cell
-    margin-top: 4px;
+    margin-top: 4px
 
 .holiday
-  background-color: $primary;
-  color: $white;
-  font-size: 12px;
-  border-radius: 5px;
-  width: 20px;
-  margin-top: 10px;
+  background-color: $primary
+  color: $white
+  font-size: 12px
+  border-radius: 5px
+  width: 20px
+  margin-top: 10px
   @media (min-width: 768px)
-    margin-top: 0px;
-    margin-left: 10px;
+    margin-top: 0px
+    margin-left: 10px

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -5,7 +5,6 @@ $primary-dark = #A63A77
 // Background
 $neutral-grey = #EEE
 $neutral-beige = #FFEDDA
-
 $middle-beige = #EBD2B8
 
 // Notify
@@ -19,7 +18,6 @@ $middle-grey = #D0D0D0
 $light-grey = #EEEEEE
 
 $white = #FFFFFF
-$blue = #0084ff
 $secondary = #F29400
 $accent = #0F9319
 $light-purple = #E6C6D6

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -3,7 +3,6 @@ $primary-light = #FFECF6
 $primary-dark = #A63A77
 
 // Background
-$neutral-grey = #EEE
 $neutral-beige = #FFEDDA
 $middle-beige = #EBD2B8
 

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -15,7 +15,7 @@ $warning = #F2C037
 $grey-800 = #4E4E4E
 $grey-400 = #9B9B9B
 $grey-300 = #D0D0D0
-$light-grey = #EEEEEE
+$grey-100 = #EEEEEE
 
 $white = #FFFFFF
 $secondary = #F29400

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -12,9 +12,9 @@ $positive = #21BA45
 $negative = #DB2828
 $warning = #F2C037
 
-$dark-grey = #4E4E4E
+$grey-800 = #4E4E4E
 $grey = #9B9B9B
-$middle-grey = #D0D0D0
+$grey-300 = #D0D0D0
 $light-grey = #EEEEEE
 
 $white = #FFFFFF

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -13,7 +13,7 @@ $negative = #DB2828
 $warning = #F2C037
 
 $grey-800 = #4E4E4E
-$grey = #9B9B9B
+$grey-400 = #9B9B9B
 $grey-300 = #D0D0D0
 $light-grey = #EEEEEE
 

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -13,6 +13,7 @@ $negative = #DB2828
 $warning = #F2C037
 
 $grey-800 = #4E4E4E
+$grey-600 = #737373
 $grey-400 = #9B9B9B
 $grey-300 = #D0D0D0
 $grey-100 = #EEEEEE

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -13,7 +13,7 @@
         margin: 0 5px
         cursor: pointer
         font-size: 21px
-      &:after 
+      &:after
         background: inherit
     & tr
       &.selected
@@ -147,7 +147,7 @@
 
     .thirdPartyPayer
     .email
-      word-break: break-all      
+      word-break: break-all
 
   @media screen and (min-width: 768px)
     .q-table__middle
@@ -178,7 +178,7 @@
           cursor: pointer
           background: $white !important
           box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.2)
-          border: 1px solid $middle-grey
+          border: 1px solid $grey-300
     td
       font-weight: 400
       border: none

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -170,7 +170,7 @@
       &:hover
         background: $white
       .avatar
-        border: 1px solid $grey
+        border: 1px solid $grey-400
         width: 30px
         height: 30px
       &:not(.q-tr--no-hover)

--- a/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
+++ b/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
@@ -188,7 +188,7 @@ export default {
   .avatar
     width: 59px
     height: 59px
-    border: 1px solid $grey
+    border: 1px solid $grey-400
 
   .send-message-link
     color: $primary

--- a/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
+++ b/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
@@ -188,7 +188,7 @@ export default {
   .avatar
     width: 59px
     height: 59px
-    border: 1px solid #979797
+    border: 1px solid $grey
 
   .send-message-link
     color: $primary

--- a/src/modules/client/components/customers/billing/PaymentCreationModal.vue
+++ b/src/modules/client/components/customers/billing/PaymentCreationModal.vue
@@ -87,19 +87,19 @@ export default {
 
 <style lang="stylus" scoped>
   .modal-subtitle
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 16px;
+    display: flex
+    justify-content: space-between
+    margin-bottom: 16px
     .q-btn-toggle
-      margin-bottom: 0;
-      cursor: default;
-      width: 100%;
+      margin-bottom: 0
+      cursor: default
+      width: 100%
     & /deep/ .q-btn-toggle
-      border: none;
-      box-shadow: none;
+      border: none
+      box-shadow: none
       & .q-btn-item
         width: 50%
-        border-radius: 20px;
-        margin: 5px;
-        background-color: $middle-grey;
+        border-radius: 20px
+        margin: 5px
+        background-color: $grey-300
 </style>

--- a/src/modules/client/components/pay/PaySurchargeDetailsModal.vue
+++ b/src/modules/client/components/pay/PaySurchargeDetailsModal.vue
@@ -74,14 +74,14 @@ export default {
 
 <style lang="stylus" scoped>
   .surcharge-line
-    display: flex;
-    flex-direction: row;
+    display: flex
+    flex-direction: row
     width: 100%;
-    border: 1px solid $middle-grey;
+    border: 1px solid $grey-300
     &:not(:nth-child(2)) // first-child is title
-      border-top: none;
+      border-top: none
 
   .surcharge-type
     width: 60%
-    border-right: 1px solid $middle-grey;
+    border-right: 1px solid $grey-300
 </style>

--- a/src/modules/client/components/planning/Agenda.vue
+++ b/src/modules/client/components/planning/Agenda.vue
@@ -148,8 +148,8 @@ export default {
           180deg,
           $white,
           $white 13.1%,
-          $neutral-grey,
-          $neutral-grey 13.3%
+          $grey-100,
+          $grey-100 13.3%
         )
         height: 100%
         position: relative

--- a/src/modules/client/components/planning/Agenda.vue
+++ b/src/modules/client/components/planning/Agenda.vue
@@ -136,12 +136,12 @@ export default {
   .agenda-table
     th
       @media screen and (min-width: 768px)
-        top: 85px;
+        top: 85px
       @media screen and (max-width: 767px)
-        top: 100px;
+        top: 100px
     td
-      padding: 0px;
-      height: 100%;
+      padding: 0px
+      height: 100%
 
       .planning-background
         background: repeating-linear-gradient(
@@ -151,47 +151,47 @@ export default {
           $neutral-grey,
           $neutral-grey 13.3%
         )
-        height: 100%;
-        position: relative;
-        margin-top: 2px;
-        display: list-item;
-        list-style: none;
+        height: 100%
+        position: relative
+        margin-top: 2px
+        display: list-item
+        list-style: none
 
       .event
-        position: absolute;
-        left: 3px;
-        right: 3px;
-        margin: 0;
-        border: 1px solid $white;
-        overflow: hidden;
-        padding-top: 0;
-        padding-bottom: 0;
+        position: absolute
+        left: 3px
+        right: 3px
+        margin: 0
+        border: 1px solid $white
+        overflow: hidden
+        padding-top: 0
+        padding-bottom: 0
         &-container
-          height: auto;
+          height: auto
 
       .planning-hour
-        position: absolute;
-        color: $middle-grey;
-        background-color: $white;
-        font-size: 12px;
+        position: absolute
+        color: $grey-300
+        background-color: $white
+        font-size: 12px
         padding: 0 5px
 
       .event-number
-        border-radius: 50%;
-        width: 16px;
-        height: 16px;
-        border: 1px solid $primary;
-        text-align: center;
-        background-color: white;
-        position: absolute;
-        bottom: 0;
-        right: 0;
+        border-radius: 50%
+        width: 16px
+        height: 16px
+        border: 1px solid $primary
+        text-align: center
+        background-color: white
+        position: absolute
+        bottom: 0
+        right: 0
         &-label
-          line-height: 1;
-          color: $primary;
-          font-size: 14px;
+          line-height: 1
+          color: $primary
+          font-size: 14px
 
 thead
-  vertical-align: baseline;
+  vertical-align: baseline
 
 </style>

--- a/src/modules/client/components/planning/AuxiliaryIndicators.vue
+++ b/src/modules/client/components/planning/AuxiliaryIndicators.vue
@@ -95,23 +95,23 @@ export default {
 
 <style lang="stylus" scoped>
   .indicators-container
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    flex-grow: 1
+    display: flex
+    flex-direction: column
+    justify-content: space-between
 
   .indicator
     display: flex;
-    border-top: 1px solid $middle-grey
-    border-left: 1px solid $middle-grey
-    border-right: 1px solid $middle-grey
+    border-top: 1px solid $grey-300
+    border-left: 1px solid $grey-300
+    border-right: 1px solid $grey-300
     .indicator-title
       padding: 5px
     .indicator-hours
       padding: 5px
-      border-left:  1px solid $middle-grey
+      border-left:  1px solid $grey-300
     &:last-child
-      border-bottom: 1px solid $middle-grey
+      border-bottom: 1px solid $grey-300
 
   .highlight
     color: $primary
@@ -129,6 +129,6 @@ export default {
     border-left: 5px solid $primary !important
 
   .quality-indicators-item
-    border-top: 1px solid $middle-grey
+    border-top: 1px solid $grey-300
     padding: 10px 0
 </style>

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -197,14 +197,14 @@ export default {
   /deep/ .q-btn-toggle
     width: 100%
     @media screen and (max-width: 767px)
-      display: inline-flex;
-      flex-wrap: wrap;
+      display: inline-flex
+      flex-wrap: wrap
     & .q-btn-item
-      width: 24%;
-      border-radius: 20px;
-      margin: 5px;
-      background-color: $middle-grey;
+      width: 24%
+      border-radius: 20px
+      margin: 5px
+      background-color: $grey-300
       @media screen and (max-width: 767px)
-        width: 45%;
+        width: 45%
 
 </style>

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -200,7 +200,7 @@ export default {
         width: 100%
 
   .light-checkbox
-    color: $grey
+    color: $grey-400
     font-size: 14px
 
 </style>

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -331,7 +331,7 @@ export default {
       .line
         width: 1px;
         height: 100%;
-        background: $neutral-grey;
+        background: $grey-100;
         margin: 0;
         position: absolute;
         z-index: -1;

--- a/src/modules/client/components/planning/PlanningNavigation.vue
+++ b/src/modules/client/components/planning/PlanningNavigation.vue
@@ -9,7 +9,7 @@
       <div data-cy="week-number" class="week-number"><span>{{ weekNumber }}</span></div>
     </div>
     <div class="planning-navigation-actions col-6">
-      <div>
+      <div class="text-grey-800">
         <q-btn data-cy="planning_before" icon="chevron_left" dense flat round @click="goToPreviousWeek()" />
         <q-btn data-cy="planning_after" icon="chevron_right" dense flat round @click="goToNextWeek()" />
         <q-btn data-cy="planning_today" icon="today" dense flat round @click="goToToday" />

--- a/src/modules/client/layouts/Layout.vue
+++ b/src/modules/client/layouts/Layout.vue
@@ -78,7 +78,7 @@ export default {
 
   .chevron
     background-color: white
-    border: 1px solid $middle-grey
+    border: 1px solid $grey-300
     top: 5px
     position: fixed
     z-index: 5000
@@ -93,10 +93,10 @@ export default {
     color: $primary
 
   .q-btn
-    color: $dark-grey
+    color: $grey-800
     &:hover
       color: $primary
 
   .menu-icon
-    font-size: 17px;
+    font-size: 17px
 </style>

--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -370,25 +370,25 @@ export default {
   font-style: italic
 
 .auxiliary
-  border-top: 1px solid $middle-grey
-  border-left: 1px solid $middle-grey
-  border-right: 1px solid $middle-grey
+  border-top: 1px solid $grey-300
+  border-left: 1px solid $grey-300
+  border-right: 1px solid $grey-300
   &:nth-child(2)
-    border-bottom: 1px solid $middle-grey
+    border-bottom: 1px solid $grey-300
   div
     padding: 5px
   &-cell
     display: flex
     flex-direction: column
     &:not(:nth-last-child(-n+2))
-      border-bottom: 1px solid $middle-grey
+      border-bottom: 1px solid $grey-300
     &-container
       margin: 0 16px
       @media screen and (max-width: 767px)
         margin: 0 8px
 
 .auxiliary-label
-  border-right: 1px solid $middle-grey
+  border-right: 1px solid $grey-300
 
 .auxiliary-value
   justify-content: flex-end
@@ -427,9 +427,9 @@ export default {
     text-align: center
 
 .spinner-container
-  display: flex;
-  justify-content: center;
-  margin-bottom: 10px;
+  display: flex
+  justify-content: center
+  margin-bottom: 10px
 
 .gauge-wrapper
   display: flex
@@ -444,6 +444,6 @@ export default {
   height: 100px
 
 .person-name
-  font-size: 14px !important;
+  font-size: 14px !important
 
 </style>

--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -417,7 +417,7 @@ export default {
     &:nth-child(2)
       color: $secondary
     &:nth-child(3)
-      color: $grey
+      color: $grey-400
   &-value
     font-size: 48px
     @media screen and (max-width: 767px)

--- a/src/modules/vendor/components/programs/cards/CardContainer.vue
+++ b/src/modules/vendor/components/programs/cards/CardContainer.vue
@@ -175,7 +175,7 @@ export default {
   &-locked-selected
     justify-content: flex-end
     .card-cell
-      background-color: $dark-grey
+      background-color: $grey-800
       color: $white
   .dot
     margin: 0 0 0 3px

--- a/src/modules/vendor/components/programs/cards/CardContainer.vue
+++ b/src/modules/vendor/components/programs/cards/CardContainer.vue
@@ -184,7 +184,7 @@ export default {
   display: flex
   flex-direction: column
 .locked-unselected
-  color: $grey
+  color: $grey-400
 
 .card-cell
   background-color: $primary-light

--- a/src/modules/vendor/components/programs/cards/CardContainer.vue
+++ b/src/modules/vendor/components/programs/cards/CardContainer.vue
@@ -171,7 +171,7 @@ export default {
       background-color: $light-purple
   &-locked
     .card-cell
-      background-color: $light-grey
+      background-color: $grey-100
   &-locked-selected
     justify-content: flex-end
     .card-cell

--- a/src/modules/vendor/components/programs/cards/CardCreationModal.vue
+++ b/src/modules/vendor/components/programs/cards/CardCreationModal.vue
@@ -161,7 +161,7 @@ h6
 
 .card-button
   background-color: $light-grey
-  color: $dark-grey
+  color: $grey-800
   border-radius: 10px
   font-size: 14px
   height: 120px
@@ -191,7 +191,7 @@ h6
     .flashcard-right
       background-color: $grey
     .flashcard-left
-      background-color: $middle-grey
+      background-color: $grey-300
 
   .fill-the-gaps
     font-size: 10px

--- a/src/modules/vendor/components/programs/cards/CardCreationModal.vue
+++ b/src/modules/vendor/components/programs/cards/CardCreationModal.vue
@@ -160,7 +160,7 @@ h6
     grid-template-columns: repeat(auto-fill, 79px)
 
 .card-button
-  background-color: $light-grey
+  background-color: $grey-100
   color: $grey-800
   border-radius: 10px
   font-size: 14px

--- a/src/modules/vendor/components/programs/cards/CardCreationModal.vue
+++ b/src/modules/vendor/components/programs/cards/CardCreationModal.vue
@@ -189,7 +189,7 @@ h6
         width: 30%
         height: 30px
     .flashcard-right
-      background-color: $grey
+      background-color: $grey-400
     .flashcard-left
       background-color: $grey-300
 

--- a/src/modules/vendor/layouts/Layout.vue
+++ b/src/modules/vendor/layouts/Layout.vue
@@ -74,7 +74,7 @@ export default {
 
   .chevron
     background-color: white
-    border: 1px solid $middle-grey
+    border: 1px solid $grey-300
     top: 5px
     position: fixed
     z-index: 5000
@@ -89,10 +89,10 @@ export default {
     color: $primary
 
   .q-btn
-    color: $dark-grey
+    color: $grey-800
     &:hover
       color: $primary
 
   .menu-icon
-    font-size: 17px;
+    font-size: 17px
 </style>


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : aidant

Changements global:
- Ajout d'un fichier CSS `colors.styl` qui permet d'ajouter nos gris à la palette quasar (`color="grey-400"`, `color="grey-300"`...)
- Le gris par défaut de la palette quasar (`#9e9e9e`) est remplacé par notre `grey-400` (`#9B9B9B`)
toutes les props `color="grey"` de la webapp passent le nouveau gris.

Changements locaux (interface aidant):
- Les gris encodés en dur sont à présent en variables stylus (soit le même gris soit le plus proche si il n'existe pas dans notre palette)
Exemple: la couleur des icônes est harmonisée vers notre`$dark-grey`/ `grey-800`
