### PR TITLE
COM-1760: endDate non excluded

### DIFF
--- a/src/modules/client/pages/ni/courses/Dashboard.vue
+++ b/src/modules/client/pages/ni/courses/Dashboard.vue
@@ -61,8 +61,11 @@ export default {
     async getActivityHistories () {
       try {
         if (!this.dates.startDate || moment(this.dates.startDate).isAfter(this.dates.endDate)) return;
-
-        this.activityHistories = await ActivityHistories.list(this.dates);
+        const { endDate } = this.dates;
+        this.activityHistories = await ActivityHistories.list({
+          ...this.dates,
+          endDate: moment(endDate).endOf('d').toISOString(),
+        });
         NotifyPositive('Données mises a jour.');
       } catch (e) {
         this.activityHistories = [];


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach admin

- Cas d'usage : date de fin exclue alors qu'elle devrait être inclus (ex: on a pas les mêmes stats pour un 13/01 -> 15/01 et un 13/01 -> 16/01 alors que le 16 n'est pas encore passé et que ça devrait être identique)
