### PR TITLE
COM-1832 - update counter limits

### DIFF
--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -273,8 +273,8 @@ export default {
     },
     getCounterStatus (sector) {
       if (!this.auxiliariesStats || !this.auxiliariesStats[sector]) return '';
-      if (this.auxiliariesStats[sector].every(aux => aux.hoursBalanceDetail.hoursCounter > 0)) return 'bg-green-800';
-      if (this.auxiliariesStats[sector].some(aux => aux.hoursBalanceDetail.hoursCounter < -35)) return 'bg-red-800';
+      if (this.auxiliariesStats[sector].every(aux => aux.hoursBalanceDetail.hoursCounter >= 0)) return 'bg-green-800';
+      if (this.auxiliariesStats[sector].some(aux => aux.hoursBalanceDetail.hoursCounter <= -35)) return 'bg-red-800';
       return 'bg-orange-500';
     },
     getInternalHours (sectorId) {


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile 

- Périmetre interface : Client

- Périmetre roles : Auxiliaire / coach

- Cas d'usage : Sur le tableau de bord equipe :
Si mon compteur est a 0, le voyant est vert => exemple Isabelle chez les GIrafes
Si mon compteur est a -35 le voyant est rouge
