### PR TITLE
Com 1757

### DIFF
--- a/src/core/components/courses/ELearningIndicator.vue
+++ b/src/core/components/courses/ELearningIndicator.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="elearning-indicator text-weight-bold text-pink-500">{{ indicator }}</div>
+</template>
+
+<script>
+export default {
+  name: 'ELearningIndicator',
+  props: {
+    indicator: { type: Number, default: 0 },
+  },
+};
+</script>
+
+<style lang="stylus" scoped>
+.elearning-indicator
+  font-size: 36px
+</style>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -133,7 +133,7 @@ export default {
       return this.courses.filter(course => course.format === STRICTLY_E_LEARNING) || [];
     },
     eLearningCoursesOnGoing () {
-      return this.eLearningCourses.filter(course => course.progress === 1) || [];
+      return this.eLearningCourses.filter(course => course.progress < 1) || [];
     },
     eLearningCoursesOnGoingText () {
       const formation = this.eLearningCoursesOnGoing > 1 ? 'formations' : 'formation';

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="q-mb-xl">
+    <p class="text-weight-bold">Utilisation du eLearning</p>
+      <span>{{ eLearningCourses.length }}</span>
+      <span>{{ eLearningCoursesCompleted.length }}</span>
+      <span>{{ eLearningActivitiesCompleted.length }}</span>
+
     <p class="text-weight-bold">Formations suivies</p>
     <q-card>
       <ni-expanding-table :data="courses" :columns="columns" :loading="loading">
@@ -42,7 +47,7 @@
 import { mapState } from 'vuex';
 import get from 'lodash/get';
 import Courses from '@api/Courses';
-import { BLENDED, E_LEARNING } from '@data/constants';
+import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
 import { sortStrings } from '@helpers/utils';
 import Progress from '@components/CourseProgress';
 import { NotifyNegative } from '@components/popup/notify';
@@ -100,6 +105,19 @@ export default {
   },
   computed: {
     ...mapState('userProfile', ['userProfile']),
+    eLearningCourses () {
+      return this.courses.filter(course => course.format === STRICTLY_E_LEARNING) || [];
+    },
+    eLearningCoursesCompleted () {
+      return this.eLearningCourses.filter(course => course.progress === 1) || [];
+    },
+    eLearningActivitiesCompleted () {
+      return this.eLearningCourses
+        .map(course => course.subProgram.steps
+          .map(step => step.activities.map(act => act.activityHistories).flat())
+          .flat())
+        .flat();
+    },
   },
   async created () {
     try {

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -1,45 +1,48 @@
 <template>
-  <div class="q-mb-xl">
-    <p class="text-weight-bold">Utilisation du eLearning</p>
-      <span>{{ eLearningCourses.length }}</span>
-      <span>{{ eLearningCoursesCompleted.length }}</span>
-      <span>{{ eLearningActivitiesCompleted.length }}</span>
-
-    <p class="text-weight-bold">Formations suivies</p>
-    <q-card>
-      <ni-expanding-table :data="courses" :columns="columns" :loading="loading">
-        <template #row="{ props }">
-          <q-td v-for="col in props.cols" :key="col.name" :props="props">
-            <template v-if="col.name === 'progress'">
-              <ni-progress class="q-ml-lg" :value="col.value" />
-            </template>
-            <template v-else-if="col.name === 'expand'">
-              <q-icon :name="props.expand ? 'expand_less' : 'expand_more'" />
-            </template>
-            <template v-else-if="col.name === 'name'">
-              <div @click.stop="goToCourseProfile(props)" :class="[{ 'name': canBeRedirected(props) }]">
-                {{ col.value }}
+  <div>
+    <div class="q-mb-xl">
+      <p class="text-weight-bold">Utilisation du eLearning</p>
+        <span>{{ eLearningCourses.length }}</span>
+        <span>{{ eLearningCoursesCompleted.length }}</span>
+        <span>{{ eLearningActivitiesCompleted.length }}</span>
+    </div>
+    <div class="q-mb-xl">
+      <p class="text-weight-bold">Formations suivies</p>
+      <q-card>
+        <ni-expanding-table :data="courses" :columns="columns" :loading="loading">
+          <template #row="{ props }">
+            <q-td v-for="col in props.cols" :key="col.name" :props="props">
+              <template v-if="col.name === 'progress'">
+                <ni-progress class="q-ml-lg" :value="col.value" />
+              </template>
+              <template v-else-if="col.name === 'expand'">
+                <q-icon :name="props.expand ? 'expand_less' : 'expand_more'" />
+              </template>
+              <template v-else-if="col.name === 'name'">
+                <div @click.stop="goToCourseProfile(props)" :class="[{ 'name': canBeRedirected(props) }]">
+                  {{ col.value }}
+                </div>
+              </template>
+              <template v-else>{{ col.value }}</template>
+            </q-td>
+          </template>
+          <template #expanding-row="{ props }">
+            <q-td colspan="100%">
+              <div v-for="(step, stepIndex) in props.row.subProgram.steps" :key="step._id" :props="props"
+                class="q-ma-sm expanding-table-expanded-row">
+                <div>
+                  <q-icon :name="step.type === E_LEARNING ? 'stay_current_portrait' : 'mdi-teach'" />
+                  {{ stepIndex + 1 }} - {{ step.name }}
+                </div>
+                <div class="expanding-table-progress-container">
+                  <ni-progress class="expanding-table-sub-progress" :value="step.progress" />
+                </div>
               </div>
-            </template>
-            <template v-else>{{ col.value }}</template>
-          </q-td>
-        </template>
-        <template #expanding-row="{ props }">
-          <q-td colspan="100%">
-            <div v-for="(step, stepIndex) in props.row.subProgram.steps" :key="step._id" :props="props"
-              class="q-ma-sm expanding-table-expanded-row">
-              <div>
-                <q-icon :name="step.type === E_LEARNING ? 'stay_current_portrait' : 'mdi-teach'" />
-                {{ stepIndex + 1 }} - {{ step.name }}
-              </div>
-              <div class="expanding-table-progress-container">
-                <ni-progress class="expanding-table-sub-progress" :value="step.progress" />
-              </div>
-            </div>
-          </q-td>
-        </template>
-      </ni-expanding-table>
-    </q-card>
+            </q-td>
+          </template>
+        </ni-expanding-table>
+      </q-card>
+    </div>
   </div>
 </template>
 

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -2,9 +2,27 @@
   <div>
     <div class="q-mb-xl">
       <p class="text-weight-bold">Utilisation du eLearning</p>
-        <span>{{ eLearningCourses.length }}</span>
-        <span>{{ eLearningCoursesCompleted.length }}</span>
-        <span>{{ eLearningActivitiesCompleted.length }}</span>
+      <div class="row">
+        <div class="col-sm-6 col-xs-12">
+          <q-card flat class="q-pa-md right-stats">
+            <div class="text-weight-bold q-mb-sm">Vue globale</div>
+            <div class="text-center">
+              <div>
+                <ni-e-learning-indicator :indicator="eLearningCoursesOnGoing.length" />
+                <span>{{ eLearningCoursesOnGoingText }}</span>
+              </div>
+              <div>
+                <ni-e-learning-indicator :indicator="eLearningCoursesCompleted.length" />
+                <span>{{ eLearningCoursesCompletedText }}</span>
+              </div>
+              <div>
+                <ni-e-learning-indicator :indicator="eLearningActivitiesCompleted.length" />
+                <span>{{ eLearningActivitesCompletedText }}</span>
+              </div>
+            </div>
+          </q-card>
+        </div>
+      </div>
     </div>
     <div class="q-mb-xl">
       <p class="text-weight-bold">Formations suivies</p>
@@ -51,16 +69,18 @@ import { mapState } from 'vuex';
 import get from 'lodash/get';
 import Courses from '@api/Courses';
 import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
-import { sortStrings } from '@helpers/utils';
+import { sortStrings, formatQuantity } from '@helpers/utils';
 import Progress from '@components/CourseProgress';
 import { NotifyNegative } from '@components/popup/notify';
 import ExpandingTable from '@components/table/ExpandingTable';
+import ELearningIndicator from '@components/courses/ELearningIndicator';
 
 export default {
   name: 'ProfileCourses',
   components: {
     'ni-progress': Progress,
     'ni-expanding-table': ExpandingTable,
+    'ni-e-learning-indicator': ELearningIndicator,
   },
   data () {
     return {
@@ -111,8 +131,18 @@ export default {
     eLearningCourses () {
       return this.courses.filter(course => course.format === STRICTLY_E_LEARNING) || [];
     },
+    eLearningCoursesOnGoing () {
+      return this.eLearningCourses.filter(course => course.progress === 1) || [];
+    },
+    eLearningCoursesOnGoingText () {
+      const formation = this.eLearningCoursesOnGoing > 1 ? 'formations' : 'formation';
+      return `${formation} eLearning en cours`;
+    },
     eLearningCoursesCompleted () {
       return this.eLearningCourses.filter(course => course.progress === 1) || [];
+    },
+    eLearningCoursesCompletedText () {
+      return this.eLearningCoursesCompleted > 1 ? 'formations eLearning terminées' : 'formation eLearning terminée';
     },
     eLearningActivitiesCompleted () {
       return this.eLearningCourses
@@ -121,6 +151,10 @@ export default {
           .flat())
         .flat();
     },
+    eLearningActivitesCompletedText () {
+      return this.eLearningCoursesCompleted > 1 ? 'activités eLearning réalisées' : 'activité eLearning réalisée';
+    },
+
   },
   async created () {
     try {
@@ -135,6 +169,7 @@ export default {
     }
   },
   methods: {
+    formatQuantity,
     goToCourseProfile (props) {
       if (!this.isVendorInterface && props.row.subProgram.isStrictlyELearning) {
         props.expand = !props.expand;
@@ -163,7 +198,13 @@ export default {
 
 <style lang="stylus" scoped>
 .name
-  width: fit-content;
+  width: fit-content
   text-decoration: underline
   color: $primary
+
+.right-stats
+  margin-right: 8px
+  @media (max-width: 599px)
+    margin-right: 0px
+    margin-bottom: 8px
 </style>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -6,18 +6,16 @@
         <div class="col-sm-6 col-xs-12">
           <q-card flat class="q-pa-md right-stats">
             <div class="text-weight-bold q-mb-sm">Vue globale</div>
-            <div class="text-center">
-              <div>
+            <div class="row">
+              <div class="col-3 indicators-container stats-container">
                 <ni-e-learning-indicator :indicator="eLearningCoursesOnGoing.length" />
-                <span>{{ eLearningCoursesOnGoingText }}</span>
-              </div>
-              <div>
                 <ni-e-learning-indicator :indicator="eLearningCoursesCompleted.length" />
-                <span>{{ eLearningCoursesCompletedText }}</span>
-              </div>
-              <div>
                 <ni-e-learning-indicator :indicator="eLearningActivitiesCompleted.length" />
-                <span>{{ eLearningActivitesCompletedText }}</span>
+              </div>
+              <div class="col-9 stats-container">
+                <div>{{ eLearningCoursesOnGoingText }}</div>
+                <div>{{ eLearningCoursesCompletedText }}</div>
+                <div>{{ eLearningActivitesCompletedText }}</div>
               </div>
             </div>
           </q-card>
@@ -208,4 +206,16 @@ export default {
   @media (max-width: 599px)
     margin-right: 0px
     margin-bottom: 8px
+
+.indicators-container
+  text-align: end
+  padding-right: 16px
+  display: flex
+  flex-direction: column
+  justify-content: space-around
+
+.stats-container
+  display: flex
+  flex-direction: column
+  justify-content: space-around
 </style>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -67,6 +67,7 @@
 <script>
 import { mapState } from 'vuex';
 import get from 'lodash/get';
+import uniqBy from 'lodash/uniqBy';
 import Courses from '@api/Courses';
 import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
 import { sortStrings, formatQuantity } from '@helpers/utils';
@@ -145,14 +146,14 @@ export default {
       return this.eLearningCoursesCompleted > 1 ? 'formations eLearning terminées' : 'formation eLearning terminée';
     },
     eLearningActivitiesCompleted () {
-      return this.eLearningCourses
+      return uniqBy(this.eLearningCourses
         .map(course => course.subProgram.steps
           .map(step => step.activities.map(act => act.activityHistories).flat())
           .flat())
-        .flat();
+        .flat(), '_id');
     },
     eLearningActivitesCompletedText () {
-      return this.eLearningCoursesCompleted > 1 ? 'activités eLearning réalisées' : 'activité eLearning réalisée';
+      return this.eLearningActivitiesCompleted > 1 ? 'activités eLearning réalisées' : 'activité eLearning réalisée';
     },
 
   },

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -7,12 +7,12 @@
           <q-card flat class="q-pa-md right-stats">
             <div class="text-weight-bold q-mb-sm">Vue globale</div>
             <div class="row">
-              <div class="col-3 indicators-container stats-container">
+              <div class="col-3 text-right q-pr-md column justify-around">
                 <ni-e-learning-indicator :indicator="eLearningCoursesOnGoing.length" />
                 <ni-e-learning-indicator :indicator="eLearningCoursesCompleted.length" />
                 <ni-e-learning-indicator :indicator="eLearningActivitiesCompleted.length" />
               </div>
-              <div class="col-9 stats-container">
+              <div class="col-9 column justify-around">
                 <div>{{ eLearningCoursesOnGoingText }}</div>
                 <div>{{ eLearningCoursesCompletedText }}</div>
                 <div>{{ eLearningActivitesCompletedText }}</div>
@@ -209,16 +209,4 @@ export default {
   @media (max-width: 599px)
     margin-right: 0px
     margin-bottom: 8px
-
-.indicators-container
-  text-align: end
-  padding-right: 16px
-  display: flex
-  flex-direction: column
-  justify-content: space-around
-
-.stats-container
-  display: flex
-  flex-direction: column
-  justify-content: space-around
 </style>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -68,7 +68,7 @@ import get from 'lodash/get';
 import uniqBy from 'lodash/uniqBy';
 import Courses from '@api/Courses';
 import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
-import { sortStrings, formatQuantity } from '@helpers/utils';
+import { sortStrings } from '@helpers/utils';
 import Progress from '@components/CourseProgress';
 import { NotifyNegative } from '@components/popup/notify';
 import ExpandingTable from '@components/table/ExpandingTable';
@@ -134,14 +134,16 @@ export default {
       return this.eLearningCourses.filter(course => course.progress < 1) || [];
     },
     eLearningCoursesOnGoingText () {
-      const formation = this.eLearningCoursesOnGoing > 1 ? 'formations' : 'formation';
+      const formation = this.eLearningCoursesOnGoing.length > 1 ? 'formations' : 'formation';
       return `${formation} eLearning en cours`;
     },
     eLearningCoursesCompleted () {
       return this.eLearningCourses.filter(course => course.progress === 1) || [];
     },
     eLearningCoursesCompletedText () {
-      return this.eLearningCoursesCompleted > 1 ? 'formations eLearning terminées' : 'formation eLearning terminée';
+      return this.eLearningCoursesCompleted.length > 1
+        ? 'formations eLearning terminées'
+        : 'formation eLearning terminée';
     },
     eLearningActivitiesCompleted () {
       return uniqBy(this.eLearningCourses
@@ -151,7 +153,9 @@ export default {
         .flat(), '_id');
     },
     eLearningActivitesCompletedText () {
-      return this.eLearningActivitiesCompleted > 1 ? 'activités eLearning réalisées' : 'activité eLearning réalisée';
+      return this.eLearningActivitiesCompleted.length > 1
+        ? 'activités eLearning réalisées'
+        : 'activité eLearning réalisée';
     },
 
   },
@@ -168,7 +172,6 @@ export default {
     }
   },
   methods: {
-    formatQuantity,
     goToCourseProfile (props) {
       if (!this.isVendorInterface && props.row.subProgram.isStrictlyELearning) {
         props.expand = !props.expand;

--- a/src/core/components/table/ExpandingTable.vue
+++ b/src/core/components/table/ExpandingTable.vue
@@ -30,7 +30,7 @@ export default {
     data: { type: Array, default: () => [] },
     columns: { type: Array, default: () => [] },
     loading: { type: Boolean, default: false },
-    pagination: { type: Object, default: () => ({}) },
+    pagination: { type: Object, default: () => ({ rowsPerPage: 0 }) },
     rowKey: { type: String, default: '_id' },
     hideBottom: { type: Boolean, default: true },
   },

--- a/src/modules/client/pages/ni/courses/Dashboard.vue
+++ b/src/modules/client/pages/ni/courses/Dashboard.vue
@@ -10,11 +10,11 @@
       </div>
       <div class="elearning">
         <div class="column items-center">
-          <div class="elearning-indicator text-weight-bold text-pink-500">{{ activeLearners }}</div>
+          <ni-e-learning-indicator :indicator="activeLearners" />
           <div class="text-center">apprenants actifs</div>
         </div>
         <div class="column items-center">
-          <div class="elearning-indicator text-weight-bold text-pink-500">{{ activityHistories.length }}</div>
+          <ni-e-learning-indicator :indicator="activityHistories.length" />
           <div class="text-center">activités de eLearning réalisées</div>
         </div>
       </div>
@@ -28,12 +28,14 @@ import ActivityHistories from '@api/ActivityHistories';
 import DateRange from '@components/form/DateRange';
 import { NotifyNegative, NotifyPositive } from '@components/popup/notify';
 import moment from '@helpers/moment';
+import ELearningIndicator from '@components/courses/ELearningIndicator';
 
 export default {
   name: 'CourseDashboard',
   metaInfo: { title: 'Tableau de bord des formations' },
   components: {
     'ni-date-range': DateRange,
+    'ni-e-learning-indicator': ELearningIndicator,
   },
   data () {
     return {
@@ -89,7 +91,4 @@ export default {
   flex-direction: row
   justify-content: space-around
   flex: 1
-
-.elearning-indicator
-  font-size: 36px
 </style>


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client/vendeur

- Périmetre roles : coach/admin/rof

- Cas d'usage : Sur la page d'un apprenant, j'ai un encadre qui m'indique son nombre de formations en cours/terminees et le nombre d'activtes realisees. 
Verifier egalement l'affichage sur le tableau de bord suite à la creation d'un composant pour l'affichage des chiffres.

Interrogation: Le fait de tester la pr de Kenny sur l'affichage de la colonnes du nombre d'activites sur le repertoire apprenant m'a fait me rendre compte que je comptais certains historiques d'activites deux fois (j'ai donc ajoute le uniqBy).
Ca me fait m'interroger sur le fait qu'on calcule certaines stats dans le front et que potentiellement on peut avoir des incoherences. Pour cette stat en particulier, on pourrait populer le champs dans le Users.getById (une fois la pr de Kenny merge), mais je m'interrogeais plus globalement sur les stats qui se retrouvent a plusieurs endroits dans l'app ou des stats differentes mais liées (ex: sur le tableau de bord le nombre d'activites peut etre calcule en sommant les activites de tous les utilisateurs). 