### PR TITLE
COM-1782 no mutating props for establisment creation modal

### DIFF
--- a/src/modules/client/components/config/EstablishmentCreationModal.vue
+++ b/src/modules/client/components/config/EstablishmentCreationModal.vue
@@ -3,25 +3,26 @@
       <template slot="title">
         Ajouter un <span class="text-weight-bold">établissement</span>
       </template>
-      <ni-input in-modal caption="Nom" v-model="newEstablishment.name" :error="validations.name.$error"
+      <ni-input in-modal caption="Nom" :value="newEstablishment.name" :error="validations.name.$error"
         :error-message="establishmentNameError(validations)" @blur="validations.name.$touch"
-        required-field />
-      <ni-input in-modal caption="SIRET" v-model="newEstablishment.siret" :error="validations.siret.$error"
+        required-field @input="update($event, 'name')" />
+      <ni-input in-modal caption="SIRET" :value="newEstablishment.siret" :error="validations.siret.$error"
         :error-message="establishmentSiretError(validations)" @blur="validations.siret.$touch"
-        required-field />
-      <ni-search-address in-modal v-model="newEstablishment.address" color="white"
+        required-field @input="update($event, 'siret')" />
+      <ni-search-address in-modal :value="newEstablishment.address" color="white"
         @blur="validations.address.$touch" :error-message="establishmentAddressError(validations)"
-        :error="validations.address.$error" required-field />
-      <ni-input in-modal caption="Téléphone" v-model="newEstablishment.phone" :error="validations.phone.$error"
+        :error="validations.address.$error" required-field @input="update($event, 'address')" />
+      <ni-input in-modal caption="Téléphone" :value="newEstablishment.phone" :error="validations.phone.$error"
         :error-message="establishmentPhoneError(validations)" @blur="validations.phone.$touch"
-        required-field />
-      <ni-select in-modal caption="Service de santé du travail" v-model="newEstablishment.workHealthService"
+        required-field @input="update($event, 'phone')" />
+      <ni-select in-modal caption="Service de santé du travail" :value="newEstablishment.workHealthService"
         :options="workHealthServices" :error="validations.workHealthService.$error"
         :error-message="establishmentWhsError(validations)" @blur="validations.workHealthService.$touch"
-        required-field />
-      <ni-select in-modal caption="Code URSSAF" v-model="newEstablishment.urssafCode" :options="urssafCodes"
+        required-field @input="update($event, 'workHealthService')" />
+      <ni-select in-modal caption="Code URSSAF" :value="newEstablishment.urssafCode" :options="urssafCodes"
         :error="validations.urssafCode.$error" @blur="validations.urssafCode.$touch"
-        :error-message="establishmentUrssafCodeError(validations)" required-field />
+        :error-message="establishmentUrssafCodeError(validations)" required-field
+        @input="update($event, 'urssafCode')" />
       <template slot="footer">
         <q-btn no-caps class="full-width modal-btn" label="Ajouter un établissement" icon-right="add" color="primary"
           :loading="loading" @click="submit" />
@@ -62,6 +63,9 @@ export default {
     },
     submit () {
       this.$emit('submit');
+    },
+    update (event, prop) {
+      this.$emit('update:newEstablishment', { ...this.newEstablishment, [prop]: event });
     },
   },
 };

--- a/src/modules/client/pages/ni/config/CompanyConfig.vue
+++ b/src/modules/client/pages/ni/config/CompanyConfig.vue
@@ -85,7 +85,7 @@
     </div>
 
     <!-- Establishment creation modal -->
-    <establishment-creation-modal v-model="establishmentCreationModal" :new-establishment="newEstablishment"
+    <establishment-creation-modal v-model="establishmentCreationModal" :new-establishment.sync="newEstablishment"
       :validations="$v.newEstablishment" @hide="resetEstablishmentCreationModal" @submit="createNewEstablishment"
       :loading="loading" :work-health-services="workHealthServices" :urssaf-codes="urssafCodes" />
 
@@ -289,6 +289,7 @@ export default {
 
         await Establishments.create(this.newEstablishment);
         NotifyPositive('Établissement créé.');
+        this.resetEstablishmentCreationModal();
         this.establishmentCreationModal = false;
         await this.getEstablishments();
       } catch (e) {


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : sur la page de configuration generale, vue/no-mutating-props sur la modale de creation d'etablissement. 
+ lorsque je cree un etablissement et que je reviens sur la modale, les champs sont bien reset et je n'ai pas de warning.
