### PR TITLE
COM-1846: add checkbox for commutative answers on fillthegap cards

### DIFF
--- a/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
+++ b/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
@@ -3,8 +3,8 @@
     <ni-input class="q-mb-lg" caption="Texte" v-model="card.gappedText" required-field
       @blur="updateCard('gappedText')" :error="$v.card.gappedText.$error" type="textarea" @focus="saveTmp('gappedText')"
       :error-message="gappedTextTagCodeErrorMsg" :disable="disableEdition" />
-    <q-checkbox v-model="card.areAnswersCommutative" @input="updateCard('areAnswersCommutative')"
-      label="Réponses interchangeables" class="q-mb-lg" dense />
+    <q-checkbox v-model="card.canSwitchAnswers" @input="updateCard('canSwitchAnswers')"
+      label="Réponses interchangeables" class="q-mb-lg" dense :disable="disableEdition" />
     <div class="row gutter-profile-x">
       <div v-for="(answer, i) in card.falsyGapAnswers" :key="i" class="col-md-6 col-xs-12 answers">
         <ni-input class="input" v-model="card.falsyGapAnswers[i].text" :disable="disableEdition"

--- a/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
+++ b/src/modules/vendor/components/programs/cards/templates/FillTheGaps.vue
@@ -3,6 +3,8 @@
     <ni-input class="q-mb-lg" caption="Texte" v-model="card.gappedText" required-field
       @blur="updateCard('gappedText')" :error="$v.card.gappedText.$error" type="textarea" @focus="saveTmp('gappedText')"
       :error-message="gappedTextTagCodeErrorMsg" :disable="disableEdition" />
+    <q-checkbox v-model="card.areAnswersCommutative" @input="updateCard('areAnswersCommutative')"
+      label="Réponses interchangeables" class="q-mb-lg" dense />
     <div class="row gutter-profile-x">
       <div v-for="(answer, i) in card.falsyGapAnswers" :key="i" class="col-md-6 col-xs-12 answers">
         <ni-input class="input" v-model="card.falsyGapAnswers[i].text" :disable="disableEdition"

--- a/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
+++ b/src/modules/vendor/components/programs/cards/templates/QuestionAnswer.vue
@@ -4,7 +4,7 @@
       @blur="updateCard('question')" :error="$v.card.question.$error" :error-message="questionErrorMsg"
       :disable="disableEdition" class="q-mb-lg" />
     <q-checkbox v-model="card.isQuestionAnswerMultipleChoiced" @input="updateCard('isQuestionAnswerMultipleChoiced')"
-      size="sm" :disable="disableEdition" label="Sélection multiple" class="q-mb-lg" />
+      dense :disable="disableEdition" label="Sélection multiple" class="q-mb-lg" />
     <div v-for="(answer, i) in card.qcAnswers" :key="i" class="answers">
       <ni-input :caption="`Réponse ${i + 1}`" v-model="card.qcAnswers[i].text" @focus="saveTmp(`qcAnswers[${i}].text`)"
         @blur="updateTextAnswer(i)" class="input" :disable="disableEdition" :required-field="answerIsRequired(i)"


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : ROF

- Cas d'usage :  je peux indiquer à l'aide d'une checkbox si dans les textes à trou les réponses sont interchangeables ou non
