### PR TITLE
COM-1877 - Fix course in client ELearningCourseProfile

### DIFF
--- a/src/core/mixins/traineeFollowUpTableMixin.js
+++ b/src/core/mixins/traineeFollowUpTableMixin.js
@@ -5,9 +5,12 @@ import { formatIdentity } from '@helpers/utils';
 
 export const traineeFollowUpTableMixin = {
   data () {
+    const isClientInterface = !/\/ad\//.test(this.$router.currentRoute.path);
+
     return {
       learners: [],
       loading: false,
+      isClientInterface,
     };
   },
   computed: {


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - np

- Périmetre interface : client

- Périmetre roles : admin / coach

- Cas d'usage : 
Fix les trainees dans la formation elearning côté client (on les prenait tous, alors qu'il ne faut que les trainees de la company du client)