### PR TITLE
COM-1851 table enhancements

### DIFF
--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -24,7 +24,7 @@
       <template #body="props">
         <q-tr :props="props">
           <q-td v-for="col in props.cols" :key="col.name" :props="props">
-            <div v-if="col.name === 'trainee'" :class="showBorders(col.value)">
+            <div v-if="col.name === 'trainee'">
               <q-item>
                 <q-item-section avatar>
                   <img class="avatar" :src="props.row.picture ? props.row.picture.link : DEFAULT_AVATAR">
@@ -114,11 +114,6 @@ export default {
     traineesCount (slotId) {
       return this.attendances.filter(a => a.courseSlot === slotId).length;
     },
-    showBorders (value) {
-      if (value === this.course.trainees[0].identity) return 'first-cell';
-      if (value === this.course.trainees[this.course.trainees.length - 1].identity) return 'last-cell';
-      return '';
-    },
     async refreshAttendances (courseSlots) {
       if (courseSlots.length) {
         try {
@@ -179,21 +174,19 @@ export default {
   font-size: 12px
 .header
   border-right: 1px solid $grey-200
-.first-cell
-  border-top: 1px solid $grey-200
-  margin-top: 16px
-  padding-top: 8px
-  margin-right: 16px
-.last-cell
-  border-bottom: 1px solid $grey-200
-  padding-bottom: 8px
-  margin-right: 16px
 .table
   thead tr:first-child th:first-child
     background-color: white
 
   td:first-child
     background-color: white
+
+  tr:first-child
+    td:first-child
+        border-top: 1px solid $grey-200
+  tr:last-child
+    td:first-child
+      border-bottom: 1px solid $grey-200
 
   th:first-child
   td:first-child

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card flat>
-    <q-table :data="course.trainees" :columns="columns" class="q-pa-md table" :pagination="{ rowsPerPage: 0 }"
-      separator="none" :hide-bottom="!noTrainees" :loading="loading" v-if="!noSlots">
+    <q-table v-if="!noSlots" :data="course.trainees" :columns="columns" class="q-pa-md table"
+      separator="none" :hide-bottom="!noTrainees" :loading="loading" :pagination="{ rowsPerPage: 0 }">
       <template #header="props">
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props">

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -24,7 +24,7 @@
       <template #body="props">
         <q-tr :props="props">
           <q-td v-for="col in props.cols" :key="col.name" :props="props">
-            <div v-if="col.name === 'trainee'">
+            <div v-if="col.name === 'trainee'" :class="showBorders(col.value)">
               <q-item>
                 <q-item-section avatar>
                   <img class="avatar" :src="props.row.picture ? props.row.picture.link : DEFAULT_AVATAR">
@@ -114,6 +114,11 @@ export default {
     traineesCount (slotId) {
       return this.attendances.filter(a => a.courseSlot === slotId).length;
     },
+    showBorders (value) {
+      if (value === this.course.trainees[0].identity) return 'first-cell';
+      if (value === this.course.trainees[this.course.trainees.length - 1].identity) return 'last-cell';
+      return '';
+    },
     async refreshAttendances (courseSlots) {
       if (courseSlots.length) {
         try {
@@ -173,7 +178,16 @@ export default {
 .no-data
   font-size: 12px
 .header
-  border-right: 1px solid $grey-200;
+  border-right: 1px solid $grey-200
+.first-cell
+  border-top: 1px solid $grey-200
+  margin-top: 16px
+  padding-top: 8px
+  margin-right: 16px
+.last-cell
+  border-bottom: 1px solid $grey-200
+  padding-bottom: 8px
+  margin-right: 16px
 .table
   thead tr:first-child th:first-child
     background-color: white

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -4,7 +4,7 @@
       separator="none" :hide-bottom="!noTrainees" :loading="loading" :pagination="{ rowsPerPage: 0 }">
       <template #header="props">
         <q-tr :props="props">
-          <q-th v-for="col in props.cols" :key="col.name" :props="props" class="header">
+          <q-th v-for="col in props.cols" :key="col.name" :props="props">
             <div v-if="/(slot)/.test(col.name)">
               <div class="text-primary date">{{ col.month }}</div>
               <div class="number">{{ col.day }}</div>
@@ -24,7 +24,7 @@
       <template #body="props">
         <q-tr :props="props">
           <q-td v-for="col in props.cols" :key="col.name" :props="props">
-            <div v-if="col.name === 'trainee'">
+            <div v-if="col.name === 'trainee'" class="rows">
               <q-item>
                 <q-item-section avatar>
                   <img class="avatar" :src="props.row.picture ? props.row.picture.link : DEFAULT_AVATAR">
@@ -172,21 +172,27 @@ export default {
   font-size: 16px
 .no-data
   font-size: 12px
-.header
-  border-right: 1px solid $grey-200
+
 .table
   thead tr:first-child th:first-child
     background-color: white
 
   td:first-child
     background-color: white
-
+  th
+    border-right: 1px solid $grey-200
   tr:first-child
     td:first-child
+      .rows
         border-top: 1px solid $grey-200
+        padding-top: 8px
+        margin-right: 16px
   tr:last-child
     td:first-child
-      border-bottom: 1px solid $grey-200
+      .rows
+        border-bottom: 1px solid $grey-200
+        padding-bottom: 8px
+        margin-right: 16px
 
   th:first-child
   td:first-child

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -88,7 +88,7 @@ export default {
           slot: s._id,
           field: '_id',
           align: 'center',
-          style: 'width: 80px',
+          style: 'width: 80px; min-width: 80px',
           month: upperCaseFirstLetter(moment(s.startDate).format('MMM')),
           day: moment(s.startDate).date(),
           weekDay: upperCaseFirstLetter(moment(s.startDate).format('ddd')),

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card flat>
     <q-table :data="course.trainees" :columns="columns" class="q-pa-md table" :pagination="{ rowsPerPage: 0 }"
-      separator="none" hide-bottom :loading="loading">
+      separator="none" :hide-bottom="!noTrainees" :loading="loading" v-if="!noSlots">
       <template #header="props">
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props">
@@ -15,7 +15,7 @@
               </div>
               <div class="text-grey-800">
                 <q-icon name="supervisor_account" />
-                {{ col.traineesCount }}
+                {{ traineesCount(col.slot) }}
               </div>
             </div>
           </q-th>
@@ -33,11 +33,17 @@
               </q-item>
             </div>
             <q-checkbox v-else :value="checkboxValue(col.value, col.slot)" dense size="sm"
-              @input="updateCheckbox(col.value, col.slot)" />
+              @input="updateCheckbox(col.value, col.slot)" :disable="loading" />
           </q-td>
         </q-tr>
       </template>
+      <template #no-data>
+        <div class="text-center text-italic">Aucun apprenant n'a été ajouté à cette formation</div>
+      </template>
     </q-table>
+    <div v-if="noSlots" class="text-center text-italic q-pa-lg no-data">
+      Aucun créneau n'a été ajouté à cette formation
+    </div>
   </q-card>
 </template>
 
@@ -70,7 +76,7 @@ export default {
         name: 'trainee',
         align: 'left',
         field: 'identity',
-        style: 'width: 200px',
+        style: 'max-width: 200px',
         classes: 'ellipsis',
       }];
       if (!this.course.slots) return columns;
@@ -82,15 +88,20 @@ export default {
           slot: s._id,
           field: '_id',
           align: 'center',
-          style: 'width: 80px',
+          style: 'min-width: 80px',
           month: upperCaseFirstLetter(moment(s.startDate).format('MMM')),
           day: moment(s.startDate).date(),
           weekDay: upperCaseFirstLetter(moment(s.startDate).format('ddd')),
           startHour: moment(s.startDate).format('LT'),
           endHour: moment(s.endDate).format('LT'),
-          traineesCount: 0,
         })),
       ];
+    },
+    noTrainees () {
+      return !this.course.trainees.length;
+    },
+    noSlots () {
+      return !this.course.slots.length;
     },
   },
   methods: {
@@ -99,6 +110,9 @@ export default {
         return !!this.attendances.find(a => a.trainee === traineeId && a.courseSlot === slotId);
       }
       return false;
+    },
+    traineesCount (slotId) {
+      return this.attendances.filter(a => a.courseSlot === slotId).length;
     },
     async refreshAttendances (courseSlots) {
       if (courseSlots.length) {
@@ -156,6 +170,18 @@ export default {
   font-size: 24px
 .date
   font-size: 16px
+.no-data
+  font-size: 12px
 .table
-  display: table
+  thead tr:first-child th:first-child
+    background-color: white
+
+  td:first-child
+    background-color: white
+
+  th:first-child
+  td:first-child
+    position: sticky
+    left: 0
+    z-index: 1
 </style>

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -4,7 +4,7 @@
       separator="none" :hide-bottom="!noTrainees" :loading="loading" :pagination="{ rowsPerPage: 0 }">
       <template #header="props">
         <q-tr :props="props">
-          <q-th v-for="col in props.cols" :key="col.name" :props="props">
+          <q-th v-for="col in props.cols" :key="col.name" :props="props" class="header">
             <div v-if="/(slot)/.test(col.name)">
               <div class="text-primary date">{{ col.month }}</div>
               <div class="number">{{ col.day }}</div>
@@ -76,7 +76,7 @@ export default {
         name: 'trainee',
         align: 'left',
         field: 'identity',
-        style: 'max-width: 200px',
+        style: !this.$q.platform.is.mobile ? 'max-width: 250px' : 'max-width: 150px',
         classes: 'ellipsis',
       }];
       if (!this.course.slots) return columns;
@@ -88,7 +88,7 @@ export default {
           slot: s._id,
           field: '_id',
           align: 'center',
-          style: 'min-width: 80px',
+          style: 'width: 80px',
           month: upperCaseFirstLetter(moment(s.startDate).format('MMM')),
           day: moment(s.startDate).date(),
           weekDay: upperCaseFirstLetter(moment(s.startDate).format('ddd')),
@@ -172,6 +172,8 @@ export default {
   font-size: 16px
 .no-data
   font-size: 12px
+.header
+  border-right: 1px solid $grey-200;
 .table
   thead tr:first-child th:first-child
     background-color: white


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : formateur

- Cas d'usage : amélioration du tableau d'émargement

separators: je n'ai pas trouvé un moyen de les ajouter sans désaxer les colonnes

scroll: j'ai enlevé le display-table pour pouvoir avoir un scroll, le display-table servait à garder les colonnes a gauche.
j'ai deux possibilités de rendu (cf mon commentaire sur les width des colonnes)