### PR TITLE
COM-1899: fix minor errors

### DIFF
--- a/src/statics/cguCompani.html
+++ b/src/statics/cguCompani.html
@@ -72,7 +72,7 @@ L’inscription se fait à partir du Site. Pour utiliser les Services, l’Utili
   <ul>
     <li>L’adresse email (obligatoire)</li>
     <li>Le mot de passe personnel (obligatoire)</li>
-    <li>Nom (facultatif)</li>
+    <li>Nom (obligatoire)</li>
     <li>Prénom (facultatif)</li>
   </ul>
   <li>Confirmer son inscription et sa prise de connaissance et son acceptation des présentes Conditions générales.</li>
@@ -105,7 +105,7 @@ Dans le cadre de l'Utilisation des Services, l'Utilisateur s'interdit de se livr
   <li>à respecter les droits des tiers, et notamment les droits de propriété intellectuelle/droit à l’image ;</li>
   <li>à respecter le caractère confidentiel des échanges avec les autres utilisateurs. </li>
 </ul>
-L’Editeur invite les Utilisateurs à l'alerter s'ils découvrent du contenu qui constitue une violation aux lois et règlements en vigueur et aux présentes Conditions générales. Pour signaler un abus, l'Utilisateur peut avertir L’Editeur en envoyant un courrier électronique à l'adresse suivante : support@alenvi.ioCe signalement doit être accompagné de l'ensemble des informations permettant à d'identifier le contenu illicite ou frauduleux.
+L’Editeur invite les Utilisateurs à l'alerter s'ils découvrent du contenu qui constitue une violation aux lois et règlements en vigueur et aux présentes Conditions générales. Pour signaler un abus, l'Utilisateur peut avertir L’Editeur en envoyant un courrier électronique à l'adresse suivante : support@alenvi.io. Ce signalement doit être accompagné de l'ensemble des informations permettant à d'identifier le contenu illicite ou frauduleux.
 <br/><br/>
 FRAUDE : soyez vigilant
 <br/>


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur et client

- Périmetre roles : tous 

- Cas d'usage : dans les CGU le nom était marqué comme facultatif à la création de compte alors qu'il est obligatoire + dans "support@alenvi.ioCe signalement" il manque ". "
