### PR TITLE
COM-1886: add sticky header

### DIFF
--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :pagination="pagination" binary-state-sort
-      class="q-pa-sm large-table" flat :separator="separator" :selection="selection" :row-key="rowKey" v-on="$listeners"
+      class="q-pa-sm large-table sticky-header-table" flat :separator="separator" :selection="selection"
+      :row-key="rowKey" v-on="$listeners"
       :selected="selected" :visible-columns="formattedVisibleColumns" :hide-bottom="shouldHideBottom">
       <template #header="props">
         <slot name="header" :props="props">
@@ -82,3 +83,20 @@ export default {
   },
 };
 </script>
+
+<style lang="stylus" scoped>
+.sticky-header-table
+  @media screen and (min-width: 768px)
+    height: 85vh
+  @media screen and (min-width : 320px) and (max-width : 480px)
+    height: 55vh
+  @media screen and (min-width : 481px) and (max-width : 767px)
+    height: 75vh
+
+  thead tr th
+    position: sticky
+    z-index: 1
+    background-color: $grey-100
+  thead tr:first-child th
+    top: 0
+</style>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -3,9 +3,7 @@
     <q-table v-if="!loading" :data="data" :columns="columns" :pagination="pagination" binary-state-sort
       flat :separator="separator" :selection="selection" :row-key="rowKey" v-on="$listeners" :selected="selected"
       :visible-columns="formattedVisibleColumns" :hide-bottom="shouldHideBottom"
-      :class="['q-pa-sm large-table sticky-header', isClientInterface ?
-        'client-header'
-        : 'vendor-header']">
+      :class="['q-pa-sm large-table sticky-header', isClientInterface ? 'client-header' : 'vendor-header']">
       <template #header="props">
         <slot name="header" :props="props">
           <q-tr :props="props">

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -4,8 +4,8 @@
       flat :separator="separator" :selection="selection" :row-key="rowKey" v-on="$listeners" :selected="selected"
       :visible-columns="formattedVisibleColumns" :hide-bottom="shouldHideBottom"
       :class="['q-pa-sm large-table sticky-header', isClientInterface ?
-        'client-background-header'
-        : 'vendor-background-header']">
+        'client-header'
+        : 'vendor-header']">
       <template #header="props">
         <slot name="header" :props="props">
           <q-tr :props="props">

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -3,9 +3,9 @@
     <q-table v-if="!loading" :data="data" :columns="columns" :pagination="pagination" binary-state-sort
       flat :separator="separator" :selection="selection" :row-key="rowKey" v-on="$listeners" :selected="selected"
       :visible-columns="formattedVisibleColumns" :hide-bottom="shouldHideBottom"
-      :class="['q-pa-sm large-table', isClientInterface ?
-        'client-sticky-header'
-        : 'vendor-sticky-header']">
+      :class="['q-pa-sm large-table sticky-header', isClientInterface ?
+        'client-background-header'
+        : 'vendor-background-header']">
       <template #header="props">
         <slot name="header" :props="props">
           <q-tr :props="props">

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :pagination="pagination" binary-state-sort
-      class="q-pa-sm large-table sticky-header-table" flat :separator="separator" :selection="selection"
-      :row-key="rowKey" v-on="$listeners" :selected="selected" :visible-columns="formattedVisibleColumns"
-      :hide-bottom="shouldHideBottom">
+      flat :separator="separator" :selection="selection" :row-key="rowKey" v-on="$listeners" :selected="selected"
+      :visible-columns="formattedVisibleColumns" :hide-bottom="shouldHideBottom"
+      :class="['q-pa-sm large-table', isClientInterface ?
+        'client-sticky-header'
+        : 'vendor-sticky-header']">
       <template #header="props">
         <slot name="header" :props="props">
           <q-tr :props="props">
@@ -65,6 +67,12 @@ export default {
   components: {
     'ni-pagination': Pagination,
   },
+  data () {
+    const isClientInterface = !/\/ad\//.test(this.$router.currentRoute.path);
+    return {
+      isClientInterface,
+    };
+  },
   computed: {
     shouldHideBottom () {
       return this.hideBottom || (!!this.data.length && this.data.length <= this.rowsPerPage[0]);
@@ -83,20 +91,3 @@ export default {
   },
 };
 </script>
-
-<style lang="stylus" scoped>
-  .sticky-header-table
-    @media screen and (max-height : 735px)
-      height: 70vh
-    @media screen and (min-height : 736px) and (max-height : 1023px)
-      height: 85vh
-    @media screen and (min-height : 1024px)
-      height: 65vh
-
-    thead tr th
-      position: sticky
-      z-index: 1
-      background-color: $grey-100
-    thead tr:first-child th
-      top: 0
-</style>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -2,8 +2,8 @@
   <div class="relative-position table-spinner-container">
     <q-table v-if="!loading" :data="data" :columns="columns" :pagination="pagination" binary-state-sort
       class="q-pa-sm large-table sticky-header-table" flat :separator="separator" :selection="selection"
-      :row-key="rowKey" v-on="$listeners"
-      :selected="selected" :visible-columns="formattedVisibleColumns" :hide-bottom="shouldHideBottom">
+      :row-key="rowKey" v-on="$listeners" :selected="selected" :visible-columns="formattedVisibleColumns"
+      :hide-bottom="shouldHideBottom">
       <template #header="props">
         <slot name="header" :props="props">
           <q-tr :props="props">
@@ -85,18 +85,18 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-.sticky-header-table
-  @media screen and (min-width: 768px)
-    height: 85vh
-  @media screen and (min-width : 320px) and (max-width : 480px)
-    height: 55vh
-  @media screen and (min-width : 481px) and (max-width : 767px)
-    height: 75vh
+  .sticky-header-table
+    @media screen and (max-height : 735px)
+      height: 70vh
+    @media screen and (min-height : 736px) and (max-height : 1023px)
+      height: 85vh
+    @media screen and (min-height : 1024px)
+      height: 65vh
 
-  thead tr th
-    position: sticky
-    z-index: 1
-    background-color: $grey-100
-  thead tr:first-child th
-    top: 0
+    thead tr th
+      position: sticky
+      z-index: 1
+      background-color: $grey-100
+    thead tr:first-child th
+      top: 0
 </style>

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -67,8 +67,6 @@ div h4:only-child
   @media screen and (min-width: $breakpoint-md-min)
     padding: 2rem 2rem 1rem
   @media screen and (max-width: $breakpoint-sm-max)
-    padding: 1rem
-  @media screen and (max-height 735px)
     padding: 1rem 1rem 0rem 1rem
 
 // Used in q-dialog

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -68,6 +68,8 @@ div h4:only-child
     padding: 2rem 2rem 1rem
   @media screen and (max-width: $breakpoint-sm-max)
     padding: 1rem
+  @media screen and (max-height 735px)
+    padding: 1rem 1rem 0rem 1rem
 
 // Used in q-dialog
 .modal-message

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -246,11 +246,11 @@
     max-width: 230px
     width: 25%
 
-.client-background-header
+.client-header
   thead tr th
     background-color: $grey-100
 
-.vendor-background-header
+.vendor-header
   thead tr th
     background-color: $peach-100
 

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -246,22 +246,20 @@
     max-width: 230px
     width: 25%
 
-.client-sticky-header
-  max-height: 85vh
-
+.client-background-header
   thead tr th
-    position: sticky
-    z-index: 1
     background-color: $grey-100
-  thead tr:first-child th
-    top: 0
 
-.vendor-sticky-header
+.vendor-background-header
+  thead tr th
+    background-color: $peach-100
+
+
+.sticky-header
   max-height: 85vh
 
   thead tr th
     position: sticky
     z-index: 1
-    background-color: $peach-100
   thead tr:first-child th
     top: 0

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -245,3 +245,23 @@
   &-progress-container
     max-width: 230px
     width: 25%
+
+.client-sticky-header
+  max-height: 85vh
+
+  thead tr th
+    position: sticky
+    z-index: 1
+    background-color: $grey-100
+  thead tr:first-child th
+    top: 0
+
+.vendor-sticky-header
+  max-height: 85vh
+
+  thead tr th
+    position: sticky
+    z-index: 1
+    background-color: $peach-100
+  thead tr:first-child th
+    top: 0

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -254,7 +254,6 @@
   thead tr th
     background-color: $peach-100
 
-
 .sticky-header
   max-height: 85vh
 


### PR DESCRIPTION
- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : auxiliaires, coach, planning referent, admin

- Cas d'usage : on fixe le header des tableaux SimpleTable pour pouvoir le garder en scrollant (notamment sur mobile)
