### PR TITLE
COM-1888 - Fix sort on month in tppBillSlips

### DIFF
--- a/src/modules/client/pages/ni/billing/TppBillSlips.vue
+++ b/src/modules/client/pages/ni/billing/TppBillSlips.vue
@@ -49,6 +49,7 @@ export default {
           align: 'left',
           field: 'month',
           format: value => moment(value, 'MM-YYYY').format('MMMM YYYY'),
+          sort: (a, b) => this.sortMonths(a, b),
         },
         {
           name: 'thirdPartyPayer',
@@ -76,6 +77,12 @@ export default {
     await this.refreshBillSlips();
   },
   methods: {
+    sortMonths (a, b) {
+      const aDate = new Date(a.substring(3), a.substring(0, 2));
+      const bDate = new Date(b.substring(3), b.substring(0, 2));
+
+      return aDate > bDate;
+    },
     async refreshBillSlips () {
       try {
         this.loading = true;

--- a/src/modules/client/pages/ni/billing/TppBillSlips.vue
+++ b/src/modules/client/pages/ni/billing/TppBillSlips.vue
@@ -81,7 +81,10 @@ export default {
       const aDate = new Date(a.substring(3), a.substring(0, 2));
       const bDate = new Date(b.substring(3), b.substring(0, 2));
 
-      return aDate > bDate;
+      if (aDate > bDate) return 1;
+      if (aDate < bDate) return -1;
+
+      return 0;
     },
     async refreshBillSlips () {
       try {


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~

- [ ] J'ai verifié la fonctionnalite sur mobile - np

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
Dans le tableau des bordereaux tier payeurs, je vois la liste bien triée (avant Janvier 2021 était juste après Janvier 2020)
