### PR TITLE
COM-1923 - Fix modal opening condition

### DIFF
--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -214,6 +214,8 @@ export const payMixin = {
         startDate: moment().startOf('M').toISOString(),
         endDate: moment().endOf('M').toISOString(),
       },
+      pay: {},
+      surchargeDetailKey: '',
     };
   },
   methods: {
@@ -329,6 +331,24 @@ export const payMixin = {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement du document.');
       }
+    },
+    shouldDisplayDetails (id, details, draftPays) {
+      const draft = draftPays.find(dp => dp.auxiliary._id === id);
+      if (!draft) return false;
+
+      return Object.keys(draft[details]).length || (draft.diff[details] && Object.keys(draft.diff[details]).length);
+    },
+    openSurchargeDetailModal (id, details, draftPays) {
+      const draft = draftPays.find(ds => ds.auxiliary._id === id);
+      if (!draft) return;
+
+      this.pay = draft;
+      this.surchargeDetailKey = details;
+      this.surchargeDetailModal = true;
+    },
+    resetSurchargeDetail () {
+      this.pay = {};
+      this.surchargeDetailKey = '';
     },
   },
 };

--- a/src/modules/client/pages/ni/pay/ContractEnds.vue
+++ b/src/modules/client/pages/ni/pay/ContractEnds.vue
@@ -27,17 +27,20 @@
           <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
             :style="col.style">
             <template v-if="col.name === 'surchargedAndExempt'">
-              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndExemptDetails')"
+              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndExemptDetails', draftFinalPay)"
                 class="cursor-pointer text-primary"
-                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndExemptDetails')">
+                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndExemptDetails', draftFinalPay)">
                 {{ col.value }}
               </div>
               <div v-else>{{ col.value }}</div>
             </template>
             <template v-else-if="col.name === 'surchargedAndNotExempt'">
-              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndNotExemptDetails')"
-                class="cursor-pointer text-primary"
-                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndNotExemptDetails')">
+              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndNotExemptDetails', draftFinalPay)"
+                class="cursor-pointer text-primary" @click="openSurchargeDetailModal(
+                  props.row.auxiliary._id,
+                  'surchargedAndNotExemptDetails',
+                  draftFinalPay
+                )">
                 {{ col.value }}
               </div>
               <div v-else>{{ col.value }}</div>
@@ -116,8 +119,6 @@ export default {
       tableLoading: false,
       surchargeDetailModal: false,
       surchargeDetails: {},
-      pay: {},
-      surchargeDetailKey: '',
       CONTRACT_END,
     };
   },
@@ -155,18 +156,6 @@ export default {
         console.error(e);
       }
     },
-    openSurchargeDetailModal (id, details) {
-      const draft = this.draftFinalPay.find(ds => ds.auxiliary._id === id);
-      if (!draft) return;
-
-      this.pay = draft;
-      this.surchargeDetailKey = details;
-      this.surchargeDetailModal = true;
-    },
-    resetSurchargeDetail () {
-      this.pay = {};
-      this.surchargeDetailKey = '';
-    },
     validateFinalPayListCreation () {
       this.$q.dialog({
         title: 'Confirmation',
@@ -189,12 +178,6 @@ export default {
         console.error(e);
         NotifyNegative('Erreur lors de la création des soldes tout compte.');
       }
-    },
-    shouldDisplayDetails (id, details) {
-      const draft = this.draftFinalPay.find(dp => dp.auxiliary._id === id);
-      if (!draft) return false;
-
-      return Object.keys(draft[details]).length || (draft.diff[details] && Object.keys(draft.diff[details]).length);
     },
   },
 };

--- a/src/modules/client/pages/ni/pay/ContractEnds.vue
+++ b/src/modules/client/pages/ni/pay/ContractEnds.vue
@@ -27,14 +27,16 @@
           <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
             :style="col.style">
             <template v-if="col.name === 'surchargedAndExempt'">
-              <div v-if="props.row.surchargedAndExempt" class="cursor-pointer text-primary"
+              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndExemptDetails')"
+                class="cursor-pointer text-primary"
                 @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndExemptDetails')">
                 {{ col.value }}
               </div>
               <div v-else>{{ col.value }}</div>
             </template>
             <template v-else-if="col.name === 'surchargedAndNotExempt'">
-              <div v-if="props.row.surchargedAndNotExempt" class="cursor-pointer text-primary"
+              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndNotExemptDetails')"
+                class="cursor-pointer text-primary"
                 @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndNotExemptDetails')">
                 {{ col.value }}
               </div>
@@ -187,6 +189,12 @@ export default {
         console.error(e);
         NotifyNegative('Erreur lors de la création des soldes tout compte.');
       }
+    },
+    shouldDisplayDetails (id, details) {
+      const draft = this.draftFinalPay.find(dp => dp.auxiliary._id === id);
+      if (!draft) return false;
+
+      return Object.keys(draft[details]).length || (draft.diff[details] && Object.keys(draft.diff[details]).length);
     },
   },
 };

--- a/src/modules/client/pages/ni/pay/ToPay.vue
+++ b/src/modules/client/pages/ni/pay/ToPay.vue
@@ -41,17 +41,17 @@
           <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
               :style="col.style">
             <template v-if="col.name === 'surchargedAndExempt'">
-              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndExemptDetails')"
+              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndExemptDetails', draftPay)"
                 class="cursor-pointer text-primary"
-                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndExemptDetails')">
+                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndExemptDetails', draftPay)">
                 {{ col.value }}
               </div>
               <div v-else>{{ col.value }}</div>
             </template>
             <template v-else-if="col.name === 'surchargedAndNotExempt'">
-              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndNotExemptDetails')"
+              <div v-if="shouldDisplayDetails(props.row.auxiliary._id, 'surchargedAndNotExemptDetails', draftPay)"
                 class="cursor-pointer text-primary"
-                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndNotExemptDetails')">
+                @click="openSurchargeDetailModal(props.row.auxiliary._id, 'surchargedAndNotExemptDetails', draftPay)">
                 {{ col.value }}
               </div>
               <div v-else>{{ col.value }}</div>
@@ -152,8 +152,6 @@ export default {
         'bonus',
       ],
       surchargeDetailModal: false,
-      pay: {},
-      surchargeDetailKey: '',
       selectedSector: '',
       tableLoading: false,
       sortOptions: [
@@ -237,24 +235,6 @@ export default {
       } finally {
         this.tableLoading = false;
       }
-    },
-    shouldDisplayDetails (id, details) {
-      const draft = this.draftPay.find(dp => dp.auxiliary._id === id);
-      if (!draft) return false;
-
-      return Object.keys(draft[details]).length || (draft.diff[details] && Object.keys(draft.diff[details]).length);
-    },
-    openSurchargeDetailModal (id, details) {
-      const draft = this.draftPay.find(dp => dp.auxiliary._id === id);
-      if (!draft) return;
-
-      this.pay = draft;
-      this.surchargeDetailKey = details;
-      this.surchargeDetailModal = true;
-    },
-    resetSurchargeDetail () {
-      this.pay = {};
-      this.surchargeDetailKey = '';
     },
     validateCreation () {
       this.$q.dialog({


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement : ~~
  -  ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites ~~

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
Dans le tableau STC, je peux cliquer sur la modale exo / majo lorsque les interventions exo et majo relèvent de la diff et pas du mois sélectionné.

Comment tester :
- créer une auxiliaire
- lui ajouter une heure de travail exo / majo (dimanche / 1er janvier, ...) en janvier.
- mettre fin à son contrat en février
- vérifier que sur le tableau STC vous pouvez cliquer sur les heures exo majo.
- verifier que sur la branche locale 'dev' ce n'est pas le cas