### PR TITLE
COM-1968 - update heroku-ssl-redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1991,9 +1991,9 @@
       }
     },
     "@types/connect-history-api-fallback": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.3.tgz",
-      "integrity": "sha512-7SxFCd+FLlxCfwVwbyPxbR4khL9aNikJhrorw8nUIOqeuooc9gifBuDQOJw5kzN7i6i3vLn9G8Wde/4QDihpYw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.4.tgz",
+      "integrity": "sha512-Kf8v0wljR5GSCOCF/VQWdV3ZhKOVA73drXtY3geMTQgHy9dgqQ0dLrf31M0hcuWkhFzK5sP0kkS3mJzcKVtZbw==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -7099,9 +7099,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
+      "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
       "dev": true
     },
     "diffie-hellman": {
@@ -7562,9 +7562,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.689",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.689.tgz",
-      "integrity": "sha512-WCn+ZaU3V8WttlLNSOGOAlR2XpxibGre7slwGrYBB6oTjYPgP29LNDGG6wLvLTMseLdE+G1vno7PfY7JyDV48g==",
+      "version": "1.3.690",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+      "integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==",
       "dev": true
     },
     "elegant-spinner": {
@@ -9937,9 +9937,9 @@
       "dev": true
     },
     "heroku-ssl-redirect": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heroku-ssl-redirect/-/heroku-ssl-redirect-0.0.4.tgz",
-      "integrity": "sha1-IboHB6pQO1CkEqCUar+qiO99CCw="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/heroku-ssl-redirect/-/heroku-ssl-redirect-0.1.1.tgz",
+      "integrity": "sha512-kL/DvLR2J53iB3TXasQlo5JwF/j2L2zkala6Ddk9o6JwIPeDvbTGT9Aty8WElxcF389ObICCeyf2m7RKpCg5Bg=="
     },
     "hex-color-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "date-holidays": "^2.0.2",
     "dotenv": "^8.2.0",
     "express": "^4.16.3",
-    "heroku-ssl-redirect": "0.0.4",
+    "heroku-ssl-redirect": "^0.1.1",
     "ibantools": "^3.2.4",
     "joi": "^17.3.0",
     "moment": "^2.29.1",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const express = require('express');
 const history = require('connect-history-api-fallback');
-const sslRedirect = require('heroku-ssl-redirect');
+const sslRedirect = require('heroku-ssl-redirect').default;
 
 const app = express();
 


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
~~- [ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Toutes

- Périmetre roles : Tous

- Cas d'usage : MAJ de heroku-ssl-redirect
en passant de la version 0.0.4 a la version 0.1.1, ils ont changé l'export de leur fichier : il sont passer de `module.exports` à `export default`. il faut donc egalement changer la maniere dont nous l'importons dans le fichier `server.js`
solution trouvée ici : https://www.gitmemory.com/issue/paulomcnally/node-heroku-ssl-redirect/17/686772810
explication de la solution : https://stackoverflow.com/questions/43247696/javascript-require-vs-require-default
