### PR TITLE
COM-1875: default value for filter on trello

### DIFF
--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -97,7 +97,7 @@ export default {
           endDate: moment().startOf('d').hours(12).toISOString(),
         },
         address: {},
-        step: null,
+        step: '',
       },
       editedCourseSlot: {},
       editionModal: false,
@@ -176,7 +176,7 @@ export default {
     stepOptions () {
       if (!this.stepsLength) return [{ label: 'Aucune étape disponible', value: '' }];
       return [
-        { label: 'Pas d\'étape spécifiée', value: null },
+        { label: 'Pas d\'étape spécifiée', value: '' },
         ...this.course.subProgram.steps.map((step, index) => ({
           label: `${index + 1} - ${step.name}${step.type === E_LEARNING ? ' (eLearning)' : ''}`,
           value: step._id,
@@ -222,7 +222,7 @@ export default {
           endDate: moment().startOf('d').hours(12).toISOString(),
         },
         address: {},
-        step: null,
+        step: '',
       };
       this.$v.newCourseSlot.$reset();
     },
@@ -243,7 +243,7 @@ export default {
         _id: slot._id,
         dates: has(slot, 'startDate') ? pick(slot, ['startDate', 'endDate']) : defaultDate,
         address: {},
-        step: get(slot, 'step._id') || null,
+        step: get(slot, 'step._id') || '',
       };
       if (slot.address) this.editedCourseSlot.address = { ...slot.address };
       this.editionModal = true;

--- a/src/core/components/form/Select.vue
+++ b/src/core/components/form/Select.vue
@@ -78,8 +78,9 @@ export default {
         }
       });
     },
-    resetValue () {
-      this.onInput(null);
+    resetValue ($event) {
+      this.onInput('');
+      $event.preventDefault();
     },
   },
 };

--- a/src/core/data/user.js
+++ b/src/core/data/user.js
@@ -32,5 +32,5 @@ export const userModel = {
       rib: { iban: '', bic: '' },
     },
   },
-  establishment: null,
+  establishment: '',
 };

--- a/src/modules/client/components/auxiliary/ProfileInfo.vue
+++ b/src/modules/client/components/auxiliary/ProfileInfo.vue
@@ -519,7 +519,7 @@ export default {
     },
     establishmentsOptions () {
       return [
-        { label: 'Non affecté', value: null, inactive: true },
+        { label: 'Non affecté', value: '', inactive: true },
         ...this.establishments.map(est => ({ label: est.name, value: est._id, inactive: false })),
       ];
     },

--- a/src/modules/client/mixins/menuItemsMixin.js
+++ b/src/modules/client/mixins/menuItemsMixin.js
@@ -115,7 +115,7 @@ export const menuItemsMixin = {
           ],
         }, {
           ref: 'customers',
-          label: 'Beneficiaires',
+          label: 'Bénéficiaires',
           children: [
             { name: 'ni customers', icon: 'contacts', label: 'Répertoire bénéficiaires' },
             { name: 'ni customers fundings monitoring', icon: 'view_headline', label: 'Suivi des plans d\'aide' },
@@ -180,7 +180,7 @@ export const menuItemsMixin = {
           ],
         }, {
           ref: 'customers',
-          label: 'Beneficiaires',
+          label: 'Bénéficiaires',
           children: [
             { name: 'auxiliaries customers', icon: 'contacts', label: 'Fiches' },
             { name: 'ni customers fundings monitoring', icon: 'view_headline', label: 'Suivi des plans d\'aide' },

--- a/src/modules/client/pages/ni/auxiliaries/Directory.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Directory.vue
@@ -82,7 +82,7 @@ export default {
           phone: '',
         },
         local: { email: '' },
-        sector: null,
+        sector: '',
         administrative: {
           transportInvoice: { transportType: 'public' },
         },

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -77,8 +77,8 @@ export default {
       customersOptions: [],
       creditNoteEvents: [],
       newCreditNote: {
-        customer: null,
-        thirdPartyPayer: null,
+        customer: '',
+        thirdPartyPayer: '',
         date: '',
         events: [],
         startDate: '',
@@ -87,7 +87,7 @@ export default {
         inclTaxesCustomer: 0,
         exclTaxesTpp: 0,
         inclTaxesTpp: 0,
-        subscription: null,
+        subscription: '',
       },
       editedCreditNote: {},
       creditNotes: [],
@@ -362,7 +362,7 @@ export default {
     // Creation
     resetCreationCreditNoteData () {
       this.newCreditNote = {
-        customer: null,
+        customer: '',
         date: '',
         events: [],
         startDate: '',
@@ -371,8 +371,8 @@ export default {
         inclTaxesCustomer: 0,
         exclTaxesTpp: 0,
         inclTaxesTpp: 0,
-        subscription: null,
-        thirdPartyPayer: null,
+        subscription: '',
+        thirdPartyPayer: '',
       };
       this.creditNoteEvents = [];
       this.hasLinkedEvents = false;

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -382,7 +382,7 @@ export default {
         nature: '',
         defaultUnitAmount: '',
         vat: '',
-        surcharge: null,
+        surcharge: '',
         exemptFromCharges: false,
       },
       editedService: {
@@ -391,7 +391,7 @@ export default {
         defaultUnitAmount: '',
         vat: '',
         nature: '',
-        surcharge: null,
+        surcharge: '',
         exemptFromCharges: false,
       },
       natureOptions: NATURE_OPTIONS,

--- a/src/modules/vendor/components/programs/SubProgramPublicationModal.vue
+++ b/src/modules/vendor/components/programs/SubProgramPublicationModal.vue
@@ -42,13 +42,13 @@ export default {
       access: FREE_ACCESS,
       RESTRICTED_ACCESS,
       ACCESS_OPTIONS,
-      accessCompany: null,
+      accessCompany: '',
     };
   },
   methods: {
     hide () {
       this.access = FREE_ACCESS;
-      this.accessCompany = null;
+      this.accessCompany = '';
       this.$emit('hide');
     },
     input (event) {
@@ -58,7 +58,7 @@ export default {
       this.$emit('submit', this.accessCompany);
     },
     resetAccess () {
-      this.accessCompany = null;
+      this.accessCompany = '';
     },
   },
 };


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client / vendeur

- Périmetre roles : tous

- Cas d'usage : Sur le trello, si je supprime le filtre il ne se remet pas à la valeur par défaut
j'ai choisi la première option de stratégie technique car en mettant à null la valeur par défaut, le champ du sélecteur est vide à l'initialisation

fix boyscoot : menu item bénéficiaire : ajout des accents 
