### PR TITLE
Remove missing user_id cookie in trainer route

### DIFF
--- a/src/modules/vendor/router/routes.js
+++ b/src/modules/vendor/router/routes.js
@@ -1,5 +1,3 @@
-import { Cookies } from 'quasar';
-import get from 'lodash/get';
 import { TRAINER } from '@data/constants';
 import { canNavigate } from '@helpers/alenvi';
 import store from 'src/store/index';
@@ -201,12 +199,6 @@ const routes = [
         path: 'trainers/management/courses/:courseId',
         name: 'trainers courses info',
         component: () => import('src/modules/vendor/pages/ni/management/BlendedCourseProfile'),
-        async beforeEnter (to, from, next) {
-          await store.dispatch('course/fetchCourse', { courseId: to.params.courseId });
-          const { course } = store.state.course;
-
-          return Cookies.get('user_id') === get(course, 'trainer._id') ? next() : next('/404');
-        },
         props: true,
         meta: {
           cookies: ['alenvi_token', 'refresh_token'],

--- a/src/modules/vendor/router/routes.js
+++ b/src/modules/vendor/router/routes.js
@@ -1,3 +1,4 @@
+import get from 'lodash/get';
 import { TRAINER } from '@data/constants';
 import { canNavigate } from '@helpers/alenvi';
 import store from 'src/store/index';
@@ -199,6 +200,17 @@ const routes = [
         path: 'trainers/management/courses/:courseId',
         name: 'trainers courses info',
         component: () => import('src/modules/vendor/pages/ni/management/BlendedCourseProfile'),
+        beforeEnter: async (to, from, next) => {
+          try {
+            await store.dispatch('course/fetchCourse', { courseId: to.params.courseId });
+            const { course } = store.state.course;
+            const { loggedUser } = store.state.main;
+
+            return loggedUser._id === get(course, 'trainer._id') ? next() : next('/404');
+          } catch (e) {
+            console.error(e);
+          }
+        },
         props: true,
         meta: {
           cookies: ['alenvi_token', 'refresh_token'],


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : vendor

- Périmetre roles : trainer

- Cas d'usage : 
Je ne pouvais pas cliqué sur une formation mixte en tant que trainer sur le trello -> j'avais une 404.
C'était dû à un oubli de cookie
