### PR TITLE
COM-1822: fix bug when two auxiliaries on dashboard

### DIFF
--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -84,15 +84,15 @@
           </div>
         </div>
       </q-card-section>
-      <q-card-actions v-show="!displayStats[sector].loading" align="right" class="full-width column">
+      <q-card-actions v-show="!displayStats[sector].loading" align="right" class="full-width column items-end">
         <q-btn flat no-caps color="primary" :icon="getIcon(sector)" label="Voir le détail par auxiliaire"
-          @click="openAuxiliariesDetails(sector)" class="self-end" />
+          @click="openAuxiliariesDetails(sector)" />
         <div v-show="displayStats[sector].loadingDetails" class="col-md-12 col-xs-12 spinner-container">
           <q-spinner-facebook size="25px" color="primary" />
         </div>
         <q-slide-transition>
           <div v-show="displayStats[sector].openedDetails && !displayStats[sector].loadingDetails"
-            class="auxiliary-cell-container row self-start">
+            class="auxiliary-cell-container row">
             <div v-for="auxiliary in auxiliariesStats[sector]" :key="`${sector}-${auxiliary._id}`"
               class="col-md-6 col-xs-12 auxiliary-cell q-mb-lg">
               <div class="row person-name q-mb-md">
@@ -400,9 +400,10 @@ export default {
     &:not(:nth-last-child(-n+2))
       border-bottom: 1px solid $grey-300
     &-container
-      margin: 0 16px
+      padding: 0 16px
+      width: 100%
       @media screen and (max-width: 767px)
-        margin: 0 8px
+        padding: 0 8px
 
 .auxiliary-label
   border-right: 1px solid $grey-300

--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -84,7 +84,7 @@
           </div>
         </div>
       </q-card-section>
-      <q-card-actions v-show="!displayStats[sector].loading" align="right" class="full-width">
+      <q-card-actions v-show="!displayStats[sector].loading" align="right" class="full-width column items-end">
         <q-btn flat no-caps color="primary" :icon="getIcon(sector)" label="Voir le détail par auxiliaire"
           @click="openAuxiliariesDetails(sector)" />
         <div v-show="displayStats[sector].loadingDetails" class="col-md-12 col-xs-12 spinner-container">

--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -84,15 +84,15 @@
           </div>
         </div>
       </q-card-section>
-      <q-card-actions v-show="!displayStats[sector].loading" align="right" class="full-width column items-end">
+      <q-card-actions v-show="!displayStats[sector].loading" align="right" class="full-width column">
         <q-btn flat no-caps color="primary" :icon="getIcon(sector)" label="Voir le détail par auxiliaire"
-          @click="openAuxiliariesDetails(sector)" />
+          @click="openAuxiliariesDetails(sector)" class="self-end" />
         <div v-show="displayStats[sector].loadingDetails" class="col-md-12 col-xs-12 spinner-container">
           <q-spinner-facebook size="25px" color="primary" />
         </div>
         <q-slide-transition>
           <div v-show="displayStats[sector].openedDetails && !displayStats[sector].loadingDetails"
-            class="auxiliary-cell-container row">
+            class="auxiliary-cell-container row self-start">
             <div v-for="auxiliary in auxiliariesStats[sector]" :key="`${sector}-${auxiliary._id}`"
               class="col-md-6 col-xs-12 auxiliary-cell q-mb-lg">
               <div class="row person-name q-mb-md">


### PR DESCRIPTION
-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach/admin/ROF

- Cas d'usage : lorsqu'il n'y a que 2 auxiliaires à afficher le chevron s'aligne avec les compteurs des auxiliaires
(tester avec RIVIA sur avril 2021 par exemple)
