### PR TITLE
COM-1991 fix startDateError

### DIFF
--- a/src/modules/client/pages/ni/pay/ContractMonitoring.vue
+++ b/src/modules/client/pages/ni/pay/ContractMonitoring.vue
@@ -31,7 +31,7 @@
     <version-edition-modal v-model="versionEditionModal" :edited-version.sync="editedVersion" :loading="loading"
       :validations="$v.editedVersion" :min-start-date="editedVersionMinStartDate" @hide="resetVersionEditionModal"
       @submit="editVersion" :gross-hourly-rate-error="grossHourlyRateError($v.editedVersion)"
-      :start-date-error="startDateError" />
+      :start-date-error="startDateError($v.editedVersion)" />
   </q-page>
 </template>
 


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : sur la page de suivi contrats/avenants, essayer de modifier un contrat/avenant, si il y a une erreur dans la startDate, cela s'affiche bien. (+ plus d'erreur dans la console en arrivant sur la page)
