### PR TITLE
COM-2028 - Fix design bug

### DIFF
--- a/src/core/components/ProfileTabs.vue
+++ b/src/core/components/ProfileTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="profile-tabs column">
+  <div class="profile-tabs flex-column">
     <q-tabs align="justify" color="transparent" v-model="selectedTab" no-caps>
       <q-tab v-for="(tab, index) in tabsContent" :key="index" :label="tab.label" :name="tab.name" :alert="alert(tab)" />
     </q-tabs>

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -90,3 +90,7 @@ div h4:only-child
   @media screen and (max-width: $breakpoint-sm-max)
     height: 30px
     width: 30px
+
+.flex-column
+  display: flex
+  flex-direction: column


### PR DESCRIPTION
Bug constaté :
- Sur Suivi des stagiaires pour une formation ayant beaucoup de créneaux, le design est cassé et le tableau d'émargement sort de la page. Constatable sur dev -> Passer d'une posture de manager à une posture de coach - Rouen (INTER B2B)

Cause : 
- Sur profile tabs, on avait ajouté 'column' à une div de ProfileTabs pour fix le design sur l'édition de carte questionnaire.
  Or column = display flex + flex-direction column + flex-wrap wrap. Et c'est ce flex-wrap qui cassait le design.
  
Résolution : 
- J'ai remplacé column par flex-column, une nouvelle classe qui ne fait que display flex + flex-direction column. Ce qui répare donc le bug sans casser le design de l'édition de carte questionnaire.

commit responsable (git bisect) : https://github.com/sophiemoustard/alenvi-webapp/pull/1061/commits/ce116b11535e3d465416dc71cd22b4d4f7c763a2 