### PR TITLE
COM-1990: disbale links when missing

### DIFF
--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -12,9 +12,9 @@
               <template v-if="col.name === 'actions'">
                 <div class="row no-wrap table-actions justify-end">
                   <ni-button icon="file_download" color="primary" type="a" target="_blank"
-                    :href="props.row.file.link" />
+                    :href="props.row.file.link" :disable="!props.row.file.link" />
                   <ni-button v-if="canUpdate" icon="delete" color="primary"
-                    @click="validateAttendanceSheetDeletion(props.row)" />
+                    @click="validateAttendanceSheetDeletion(props.row)" :disable="!props.row.file.link" />
                 </div>
               </template>
               <template v-else>{{ col.value }}</template>

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -101,8 +101,8 @@
                     <div class="row no-wrap table-actions">
                       <q-btn flat round small color="primary" :href="getAdministrativeDocumentLink(props.row)" type="a"
                         target="_blank" :disable="!getAdministrativeDocumentLink(props.row)" icon="file_download" />
-                      <q-btn flat round small color="grey" icon="delete"
-                        @click="validateAdministrativeDocumentDeletion(props.row)" />
+                      <q-btn flat round small color="grey" :disable="!getAdministrativeDocumentLink(props.row)"
+                         icon="delete" @click="validateAdministrativeDocumentDeletion(props.row)" />
                     </div>
                   </template>
                   <template v-else>{{ col.value }}</template>


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client/vendeur

- Périmetre roles : admin/ROF/formateur

- Cas d'usage : 
  - Page d’une formation mixte : désactiver les boutons téléchargement et suppression des feuilles d’émargement
  - Page config rh : désactiver le bouton de suppression des documents administratifs
  
Il n'est pas vraiment possible de tester ce ticket étant donné qu'en local les liens sont d'office supprimés au moment du dump. Par conséquent,  on ne peut pas vérifier que les icônes sont activées quand le lien existe sans faire des branchements un peu risqué avec la prod.
Le mieux qu'il peut être fait est de vérifier d'une part que les icônes sont bien désactivés et s'assurer, en checkant la BDD prod, que le disable porte sur le bon champ

Pour les feuilles d'émargement, le test exhaustif pourra être effectué lors de la MES car les liens des feuilles d'émargements sont conservés en staging mais pour la config RH il faudra attendre la prod pour s'en assurer