### PR TITLE
COM-2052: npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,20 +20,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
-      "integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+      "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.13",
+        "@babel/generator": "^7.13.16",
+        "@babel/helper-compilation-targets": "^7.13.16",
         "@babel/helper-module-transforms": "^7.13.14",
-        "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.15",
+        "@babel/helpers": "^7.13.16",
+        "@babel/parser": "^7.13.16",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.15",
-        "@babel/types": "^7.13.14",
+        "@babel/types": "^7.13.16",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -66,12 +66,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+      "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.0",
+        "@babel/types": "^7.13.16",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -96,12 +96,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
-      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.12",
+        "@babel/compat-data": "^7.13.15",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -207,13 +207,13 @@
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
-      "integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz",
+      "integrity": "sha512-1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/traverse": "^7.13.15",
+        "@babel/types": "^7.13.16"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -340,14 +340,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+      "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/traverse": "^7.13.17",
+        "@babel/types": "^7.13.17"
       }
     },
     "@babel/highlight": {
@@ -375,9 +375,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-      "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -732,12 +732,12 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
-      "integrity": "sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.13.16.tgz",
+      "integrity": "sha512-ad3PHUxGnfWF4Efd3qFuznEtZKoBp0spS+DgqzVzRPV7urEBvPLue3y2j80w4Jf2YLzZHj8TOv/Lmvdmh3b2xg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -765,9 +765,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
-      "integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.17.tgz",
+      "integrity": "sha512-UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0"
@@ -1135,9 +1135,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+      "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -1155,17 +1155,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
-      "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+      "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.9",
+        "@babel/generator": "^7.13.16",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.15",
-        "@babel/types": "^7.13.14",
+        "@babel/parser": "^7.13.16",
+        "@babel/types": "^7.13.17",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1188,13 +1188,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+      "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1523,9 +1522,9 @@
       "dev": true
     },
     "@hapi/hoek": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
     },
     "@hapi/joi": {
       "version": "15.1.1",
@@ -1628,9 +1627,9 @@
       "dev": true
     },
     "@quasar/app": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@quasar/app/-/app-2.2.4.tgz",
-      "integrity": "sha512-6Y7R5oFJ9UbEDjAbw5bPamcZWSZ0rSyFTB8IOxKkt0QFFIzKKbGkpzvYlp+gMj/SBBS92PnNyof77fjVF0U6Pg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@quasar/app/-/app-2.2.5.tgz",
+      "integrity": "sha512-FL+cvjvxa4Owd8J1yMfAKLXlmPn7Dwvy2DTSvuGmsIMXrGlM/gN28ZUmlMlyMEK7PiPYVFo2zEOB+Tg5dm4KqA==",
       "dev": true,
       "requires": {
         "@quasar/babel-preset-app": "2.0.1",
@@ -1803,9 +1802,9 @@
       }
     },
     "@quasar/extras": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@quasar/extras/-/extras-1.10.2.tgz",
-      "integrity": "sha512-S5aE/If4Bgl6qAoHqDZcVw6GxeNpksix3N1dp8k3YPMniIaoU/BLACeQYnrGkn3ffZ1+5JzF0teAE3no6WGzEg=="
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@quasar/extras/-/extras-1.10.4.tgz",
+      "integrity": "sha512-FIXvYZPTKFjBmMb9CNMkEqXTgNppixRLWdaZKKb1qn/CScn+jipPzMBOwCfAFwsNPeAGXTwFT1/xzhLWIbwzAw=="
     },
     "@quasar/fastclick": {
       "version": "1.1.4",
@@ -2028,9 +2027,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.9.tgz",
-      "integrity": "sha512-SdAAXZNvWfhtf3X3y1cbbCZhP3xyPh7mfTvzV6CgfWc/ZhiHpyr9bVroe2/RCHIf7gczaNcprhaBLsx0CCJHQA==",
+      "version": "7.2.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
+      "integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -2128,9 +2127,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.0.tgz",
+      "integrity": "sha512-YN1d+ae2MCb4U0mMa+Zlb5lWTdpFShbAj5nmte6lel27waMMBfivrm0prC16p/Di3DyTrmerrYUT8/145HXxVw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3800,9 +3799,9 @@
       "dev": true
     },
     "acorn-walk": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.2.tgz",
-      "integrity": "sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
+      "integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
       "dev": true
     },
     "address": {
@@ -4781,14 +4780,14 @@
       }
     },
     "browserslist": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
-      "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001208",
+        "caniuse-lite": "^1.0.30001214",
         "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.712",
+        "electron-to-chromium": "^1.3.719",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
       }
@@ -5053,9 +5052,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+      "version": "1.0.30001218",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001218.tgz",
+      "integrity": "sha512-0ASydOWSy3bB88FbDpJSTt+PfDwnMqrym3yRZfqG8EXSQ06OZhF+q5wgYP/EN+jJMERItNcDQUqMyNjzZ+r5+Q==",
       "dev": true
     },
     "canvas-exif-orientation": {
@@ -6056,18 +6055,18 @@
       }
     },
     "core-js": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
-      "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
+      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.1.tgz",
-      "integrity": "sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.0.tgz",
+      "integrity": "sha512-3wsN9YZJohOSDCjVB0GequOyHax8zFiogSX3XWLE28M1Ew7dTU57tgHjIylSBKSIouwmLBp3g61sKMz/q3xEGA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.3",
+        "browserslist": "^4.16.4",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -6661,9 +6660,9 @@
       "dev": true
     },
     "date-holidays": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-2.1.0.tgz",
-      "integrity": "sha512-SoEjvi/cPAW2JvRgwuSUbEUVukao2b3ZTGSx0Z7SdzKVk4ftdi+0bT7jlEgtf/ILZ+a/gPCxOu6dXUG1JcSyYQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-2.1.1.tgz",
+      "integrity": "sha512-0KbLZOWrLAxSMQeYTQwenO0cHuVamcPfHem62hYGI9ATgW42XeF+lLPSx7L1qOKb9TtMQLjN6upMIzxvuYwA2w==",
       "requires": {
         "date-holidays-parser": "^2.1.0",
         "js-yaml": "^4.0.0",
@@ -7572,9 +7571,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.713",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.713.tgz",
-      "integrity": "sha512-HWgkyX4xTHmxcWWlvv7a87RHSINEcpKYZmDMxkUlHcY+CJcfx7xEfBHuXVsO1rzyYs1WQJ7EgDp2CoErakBIow==",
+      "version": "1.3.722",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.722.tgz",
+      "integrity": "sha512-aAsc906l0RBsVTsGTK+KirVfey9eNtxyejdkbNzkISGxb7AFna3Kf0qvsp8tMttzBt9Bz3HddtYQ+++/PZtRYA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7823,9 +7822,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -8002,20 +8001,18 @@
           "dev": true
         },
         "table": {
-          "version": "6.0.9",
-          "resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
-          "integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
+          "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
           "dev": true,
           "requires": {
             "ajv": "^8.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
             "lodash.clonedeep": "^4.5.0",
             "lodash.flatten": "^4.4.0",
             "lodash.truncate": "^4.4.2",
             "slice-ansi": "^4.0.0",
-            "string-width": "^4.2.0"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0"
           },
           "dependencies": {
             "ajv": {
@@ -8292,15 +8289,16 @@
       "dev": true
     },
     "eslint-webpack-plugin": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.3.tgz",
-      "integrity": "sha512-LewNevZf9ghDCxCGT6QltNWVi8KIYWc4LKcin8K9Azh1hypG7YAmobUDIU67fAPa+eMjRnU4rjEkLbYI1w5/UA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.4.tgz",
+      "integrity": "sha512-7rYh0m76KyKSDE+B+2PUQrlNS4HJ51t3WKpkJg6vo2jFMbEPTG99cBV0Dm7LXSHucN4WGCG65wQcRiTFrj7iWw==",
       "dev": true,
       "requires": {
         "@types/eslint": "^7.2.6",
         "arrify": "^2.0.1",
         "jest-worker": "^26.6.2",
         "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
@@ -8948,9 +8946,9 @@
       }
     },
     "filesize": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
-      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.3.0.tgz",
+      "integrity": "sha512-ytx0ruGpDHKWVoiui6+BY/QMNngtDQ/pJaFwfBpQif0J63+E8DLdFyqS3NkKQn7vIruUEpoGD9JUJSg7Kp+I0g==",
       "dev": true
     },
     "fill-range": {
@@ -9089,9 +9087,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -10047,9 +10045,9 @@
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
-              "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+              "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
               "dev": true,
               "requires": {
                 "domelementtype": "^2.2.0"
@@ -10073,20 +10071,20 @@
           }
         },
         "domutils": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
-          "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+          "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
             "domelementtype": "^2.2.0",
-            "domhandler": "^4.1.0"
+            "domhandler": "^4.2.0"
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
-              "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+              "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
               "dev": true,
               "requires": {
                 "domelementtype": "^2.2.0"
@@ -10275,9 +10273,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.1.1.tgz",
-      "integrity": "sha512-FIDg9zPvOwMhQ3XKB2+vdxK6WWbVAH7s5QpqQCif7a1TNL76GNAATWA1sy6q2gSfss8UJ/Nwza3N6QnFkKclpA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.0.tgz",
+      "integrity": "sha512-nHn8lcFNmxCalzHGXMn0ojKunXC9twBvJ+y7QNhvK/ep7ZDOXvO7Gph01rSwsMOrG4m6N72gAAWXMYhPZvK6OA==",
       "dev": true,
       "requires": {
         "@types/http-proxy": "^1.17.5",
@@ -10674,9 +10672,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -11034,9 +11032,9 @@
       }
     },
     "javascript-stringify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
-      "integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+      "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
       "dev": true
     },
     "jest-worker": {
@@ -11101,9 +11099,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -12709,9 +12707,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -14064,14 +14062,12 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
+      "integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1",
         "util-deprecate": "^1.0.2"
       }
     },
@@ -14308,9 +14304,9 @@
       }
     },
     "quasar": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/quasar/-/quasar-1.15.10.tgz",
-      "integrity": "sha512-75NXx4EHN2oWxQwbCBxfICs8xbZ5QWHNf5+09CY3YDo4gTAYITtJGdEu2hqxKUTstYAdJ/996HzKq88G0Kq7rQ=="
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-1.15.11.tgz",
+      "integrity": "sha512-H7pNPS5+vlL4uqvhaS6yepUfLvrS64989PSHSqM01w/uG6Ccwz6sSsZKSGkNM8j4ccsDK/8vt+1WhE9KQOhotQ=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -16452,9 +16448,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.6.1.tgz",
-          "integrity": "sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
+          "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -18265,9 +18261,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
-          "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.1.tgz",
+          "integrity": "sha512-z716cpm5TX4uzOzILx8PavOE6C6DKshHDw1aQN52M/yNSqE9s5O8SMfyhCCfCJ3HmTL0NkVOi+8a/55T7YB3bg==",
           "dev": true
         },
         "commander": {
@@ -19072,9 +19068,9 @@
       }
     },
     "ws": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
       "dev": true
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@casl/ability": "^5.2.2",
     "@casl/vue": "^1.2.1",
-    "@quasar/extras": "^1.10.0",
+    "@quasar/extras": "^1.10.4",
     "axios": "^0.21.0",
     "chart.js": "^2.9.4",
     "connect-history-api-fallback": "^1.6.0",
@@ -30,7 +30,7 @@
     "moment-business-days": "^1.2.0",
     "moment-range": "^4.0.1",
     "qs": "^6.10.1",
-    "quasar": "^1.15.9",
+    "quasar": "^1.15.11",
     "vue-analytics": "^5.22.1",
     "vue-chartjs": "^3.5.1",
     "vue-clipboard2": "^0.3.1",
@@ -40,14 +40,14 @@
     "vuelidate": "^0.7.6"
   },
   "devDependencies": {
-    "@quasar/app": "^2.2.1",
+    "@quasar/app": "^2.2.5",
     "@quasar/cli": "^1.1.3",
     "@quasar/quasar-app-extension-testing": "^1.0.3",
     "@quasar/quasar-app-extension-testing-e2e-cypress": "^1.0.0-beta.13",
     "@vue/cli-service": "^4.5.12",
     "@vue/eslint-config-airbnb": "^5.3.0",
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.22.0",
+    "eslint": "^7.25.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-cypress": "^2.11.2",
@@ -55,7 +55,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-vue": "^7.8.0",
-    "eslint-webpack-plugin": "^2.5.3",
+    "eslint-webpack-plugin": "^2.5.4",
     "html-loader": "^1.3.2"
   },
   "engines": {


### PR DESCRIPTION
### Dépendances MAJ

**@quasar/app**  2.2.4 => 2.2.5
* feat(app/wrappers): add TSDoc for boot wrapper
* perf(app): Backport "only recreate the webpack conf when absolutely necessary" from Qv2
* fix(app): Backport "duplicate postcss plugins" fix from Qv2 (when enabling RTL)
https://github.com/quasarframework/quasar/releases/tag/%40quasar%2Fapp-v2.2.5
    
**@quasar/extras** 1.10.2 => 1.10.4 
* feat(extras): Update Google Material fonts and SVGs
* feat(extras): updated Google Material Design fonts and SVGs
https://github.com/quasarframework/quasar/releases 

**eslint** 7.24.0 => 7.25.0   
*  Minor updates and doc
https://github.com/eslint/eslint/blob/master/CHANGELOG.md   

**eslint-webpack-plugin**  2.5.3 => 2.5.4    
*  Bug fixes
https://github.com/webpack-contrib/eslint-webpack-plugin/blob/master/CHANGELOG.md  

**quasar**  1.15.10 => 1.15.11 
*  feat(QTable): new prop (column-sort-order) and new "columns" definition prop (sortOrder)
* fix(QPagination): do not exclude 0 value as a page number
https://github.com/quasarframework/quasar/releases/tag/quasar-v1.15.11


### Dépendances non MAJ

**@casl/vue** : non maj car la version 2 est compatible avec Vue3. Pour Vue2 il faut rester sur la v1

**@quasar/quasar-app-extension-testing-e2e-cypress**

**chart.js** : non maj car relié à vue-chart-js

**date-holidays** : non maj car quasar ne supporte pas les es modules

**eslint-plugin-promise** : non maj car version 4.2.1 necessaire pour eslint-config-standard

**html-loader** : non mis a jour car nécessite webpack5. Quasar utilise webpack4 pour le moment.
Quasar2 utilise webpack5 donc ce paquet sera a mettre a jour au moment ou on fera la migration Quasar2 / Vue3. Pour le moment quasar2 est toujours en beta


### Vulnérabilités
on a 2 vulnérabilités sur la dépendance ssri de vue/cli-service.
Il faudrait que ssri soit en version 8.0.1 mais elle est en 7.1.0.
Un npm audit fix ne résout pas le problème et vue/cli-service est à jour (4.5.12). Plutôt que de downgrade hard vue/cli-service, je pense qu'il vaut mieux attendre la sortie de la version 5 de vue/cli-service qui devrait arriver sous peu, cette dernière étant actuellement en version bêta (https://github.com/vuejs/vue-cli/releases)
