### PR TITLE
COM-2057 - Remove pentecote, pentecote's monday and mother's day from…

### DIFF
--- a/src/core/helpers/moment.js
+++ b/src/core/helpers/moment.js
@@ -12,8 +12,9 @@ const currentHolidays = [
   ...holidays.getHolidays(currentYear + 1),
   ...holidays.getHolidays(currentYear - 1),
 ];
+const omitedHolidays = ['easter 49', 'easter 50', 'sunday before 06-01'];
 moment.updateLocale('fr', {
-  holidays: currentHolidays.map(holiday => holiday.date),
+  holidays: currentHolidays.filter(h => !omitedHolidays.includes(h.rule)).map(holiday => holiday.date),
   holidayFormat: 'YYYY-MM-DD HH:mm:ss',
   workingWeekdays: [1, 2, 3, 4, 5, 6],
 });


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

Suppression de la Pentecôte, du lundi de Pentecôte et de la fête des mères des jours fériés.

Troubleshooting
Je n'ai finalement pas fait la stratégie d'Ulysse car sur api j'avais une erreur : TypeError: holidays.getHolidays is not a function.
Sur webApp et script, je n'ai pas cette erreur. La seule différence que je vois c'est que sur script et webapp on est sur une version 2 et 1 de date-holidays alors que api est en version 3. Mais je ne vois pas pourquoi le simple omit change toute la donne.

Pour tester : vous pouvez vérifier sur le planning que le 23,24 et 30 mai ne sont plus considéré comme férié et  console.log la taille de `currentHolidays.filter(h => !omitedHolidays.includes(h.rule)).map(holiday => holiday.date)` et voir qu'elle est bien réduite de 9 (3 x 3 jours)