### PR TITLE
COM-2065-2 : undo change on directoryheader

### DIFF
--- a/src/core/components/DirectoryHeader.vue
+++ b/src/core/components/DirectoryHeader.vue
@@ -1,15 +1,18 @@
 <template>
   <div class="row q-mb-md">
-    <div :class="['col-xs-12 col-md-6', { 'q-mb-sm': $q.platform.is.mobile }]">
+    <div :class="titleContainerClass">
       <h4 class="no-margin">{{ title }}</h4>
     </div>
-    <div class="col-xs-12 col-md-6">
+    <div :class="searchBarContainerClass">
       <q-input class="no-border" :value="search" :placeholder="searchPlaceholder" dense borderless
         @input="input" debounce="0" type="search" bg-color="white">
         <template #prepend>
           <q-icon size="xs" name="search" />
         </template>
       </q-input>
+    </div>
+    <div v-if="displayToggle" class="col-xs-12 col-md-2 row justify-end">
+      <q-toggle dense :value="toggleValue" color="primary" :label="toggleLabel" @input="toggle" />
     </div>
   </div>
 </template>
@@ -20,11 +23,25 @@ export default {
   props: {
     title: { type: String, default: '' },
     searchPlaceholder: { type: String, default: 'Rechercher un profil' },
+    toggleLabel: { type: String, default: '' },
+    toggleValue: { type: Boolean, default: false },
+    displayToggle: { type: Boolean, default: false },
     search: { type: String, default: '' },
+  },
+  computed: {
+    titleContainerClass () {
+      return ['col-xs-12', this.displayToggle ? 'col-md-5' : 'col-md-6', { 'q-mb-sm': this.$q.platform.is.mobile }];
+    },
+    searchBarContainerClass () {
+      return ['col-xs-12', this.displayToggle ? 'col-md-5' : 'col-md-6'];
+    },
   },
   methods: {
     input (value) {
       this.$emit('update-search', value);
+    },
+    toggle (value) {
+      this.$emit('toggle', value);
     },
   },
 };


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : le toggle avait disparu sur le répertoire auxilaire, il y est de nouveau. Il ne fallait pas supprimer le toggle de directoryHeader qui est utilisé à plein d'endroit mais juste enlever les props de customerdirectory
