### PR TITLE
dont show timestamp in event histories feed

### DIFF
--- a/src/modules/client/components/planning/EventHistoryFeed.vue
+++ b/src/modules/client/components/planning/EventHistoryFeed.vue
@@ -8,7 +8,8 @@
     </div>
     <div class="scroll-container" ref="scrollTargetRef">
       <q-infinite-scroll @load="load" :offset="100" :scroll-target="$refs.scrollTargetRef">
-        <ni-event-history v-for="history in eventHistories" :key="history._id" :history="history" class="q-ma-xs" />
+        <ni-event-history v-for="history in eventHistoriesExceptTimeStamping" :key="history._id" :history="history"
+          class="q-ma-xs" />
         <div slot="loading" class="loading">
           <q-spinner />
         </div>
@@ -20,6 +21,7 @@
 <script>
 import Button from '@components/Button';
 import NiEventHistory from 'src/modules/client/components/planning/EventHistory';
+import { TIME_STAMPING_ACTIONS } from 'src/core/data/constants';
 
 export default {
   name: 'EventHistoryFeed',
@@ -36,6 +38,9 @@ export default {
     },
     top () {
       return window.innerWidth >= 768 ? 60 : 100;
+    },
+    eventHistoriesExceptTimeStamping () {
+      return this.eventHistories.filter(eH => !TIME_STAMPING_ACTIONS.includes(eH.action));
     },
   },
   methods: {


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client + mobile erp

- Périmetre roles : coach

- Cas d'usage : dans le flux d'historique des evenements je n'ai pas ceux lié a l'horodatage. 
