### PR TITLE
COM-2075 - remove -

### DIFF
--- a/src/modules/client/components/planning/EventHistory.vue
+++ b/src/modules/client/components/planning/EventHistory.vue
@@ -242,7 +242,7 @@ export default {
       }
 
       const { to } = this.history.update.endHour;
-      return { pre: `Fin de l'intervention horodaté -  à ${formatHoursWithMinutes(to)} - `, post: '' };
+      return { pre: `Fin de l'intervention horodaté à ${formatHoursWithMinutes(to)} - `, post: '' };
     },
     getEventTimeStampingDetails () {
       const { startHour, endHour } = this.history.update;


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client

- Périmetre roles : Coach / Auxiliaire

- Cas d'usage : il y avait un tiret en trop entre "horodaté" et "à 15h30" sur le message d'horodatage de fin d'evenement
