### PR TITLE
COM-2095: block creation and edition after stopping date

### DIFF
--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -7,14 +7,14 @@
     <q-field :error="hasError" error-message="Date(s) et heure(s) invalide(s)" borderless>
       <div class="datetime-container row justify-evenly items-center">
         <ni-date-input :value="value.startDate" @input="update($event, 'startDate')" class="date-item"
-          @blur="blurHandler" :disable="disable || disableStartDate" />
+          @blur="blurHandler" :disable="disable || disableStartDate" :max="max" />
         <ni-time-input :value="startHour" @input="updateHours($event, 'startHour')" class="time-item"
           @blur="blurHandler" :disable="disable || disableStartHour" />
         <p class="delimiter">-</p>
         <ni-time-input :value="endHour" @input="updateHours($event, 'endHour')" class="time-item"
           @blur="blurHandler" :disable="disable || disableEndHour" :min="startHour" />
         <ni-date-input :value="value.endDate" @input="update($event, 'endDate')" class="date-item"
-          @blur="blurHandler" :min="value.startDate" :disable="disable || disableEndDate" />
+          @blur="blurHandler" :min="value.startDate" :disable="disable || disableEndDate" :max="max" />
       </div>
     </q-field>
   </div>
@@ -43,6 +43,7 @@ export default {
     disableEndDate: { type: Boolean, default: false },
     disableEndHour: { type: Boolean, default: false },
     disableStartHour: { type: Boolean, default: false },
+    max: { type: String, default: '' },
   },
   validations () {
     return {

--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -51,3 +51,11 @@ export const addDays = (value, days) => {
 
   return date.setDate(date.getDate() + days);
 };
+
+export const isBefore = (date1, date2) => new Date(date1) < new Date(date2);
+
+export const isSameOrBefore = (date1, date2) => new Date(date1) <= new Date(date2);
+
+export const isAfter = (date1, date2) => new Date(date1) > new Date(date2);
+
+export const isSameOrAfter = (date1, date2) => new Date(date1) >= new Date(date2);

--- a/src/core/mixins/learnerDirectoryMixin.js
+++ b/src/core/mixins/learnerDirectoryMixin.js
@@ -1,6 +1,6 @@
 import { formatIdentity, sortStrings, removeDiacritics } from '@helpers/utils';
 import Users from '@api/Users';
-import { dateDiff, formatDateDiff } from '../helpers/date';
+import { dateDiff, formatDateDiff } from '@helpers/date';
 
 export const learnerDirectoryMixin = {
   data () {

--- a/src/modules/client/components/planning/DeleteEventsModal.vue
+++ b/src/modules/client/components/planning/DeleteEventsModal.vue
@@ -1,8 +1,8 @@
 <template>
   <ni-modal :value="value" @hide="hide" @input="input"
     title="Suppression d'interventions sur une période">
-    <ni-select in-modal caption="Bénéficiaire" v-model="deletedEvents.customer" :options="customersOptions"
-      required-field @blur="$v.deletedEvents.customer.$touch"
+    <ni-select in-modal caption="Bénéficiaire" v-model="deletedEvents.customer"
+      :options="customersOptions(deletedEvents.startDate)" required-field @blur="$v.deletedEvents.customer.$touch"
       :error="$v.deletedEvents.customer.$error" />
     <ni-option-group :display-caption="false" v-model="deletedEvents.inRange" type="radio"
       :options="deletetionOptions" inline />

--- a/src/modules/client/components/planning/DeleteEventsModal.vue
+++ b/src/modules/client/components/planning/DeleteEventsModal.vue
@@ -2,7 +2,7 @@
   <ni-modal :value="value" @hide="hide" @input="input"
     title="Suppression d'interventions sur une période">
     <ni-select in-modal caption="Bénéficiaire" v-model="deletedEvents.customer"
-      :options="customersOptions(deletedEvents.startDate)" required-field @blur="$v.deletedEvents.customer.$touch"
+      :options="getCustomersOptions(deletedEvents.startDate)" required-field @blur="$v.deletedEvents.customer.$touch"
       :error="$v.deletedEvents.customer.$error" />
     <ni-option-group :display-caption="false" v-model="deletedEvents.inRange" type="radio"
       :options="deletetionOptions" inline />

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -14,15 +14,15 @@
         <template v-if="newEvent.type !== ABSENCE">
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="newEvent.dates" required-field
             :error="validations.dates.$error" @blur="validations.dates.$touch" disable-end-date
-            @input="update($event, 'dates')" />
+            @input="update($event, 'dates')" :max="stoppingDate" />
         </template>
         <template v-if="newEvent.type === INTERVENTION">
           <ni-select v-if="isCustomerPlanning" in-modal caption="Auxiliaire" :value="newEvent.auxiliary"
             :options="auxiliariesOptions" :error="validations.auxiliary.$error" required-field
             @blur="validations.auxiliary.$touch" @input="update($event, 'auxiliary')" />
-          <ni-select v-else in-modal caption="Bénéficiaire" :value="newEvent.customer" :options="customersOptions"
-            :error="validations.customer.$error" required-field @blur="validations.customer.$touch"
-            @input="updateCustomer($event)" data-cy="event-creation-customer" />
+          <ni-select v-else in-modal caption="Bénéficiaire" :value="newEvent.customer"
+            :options="customersOptions(newEvent.dates.startDate)" :error="validations.customer.$error" required-field
+            @blur="validations.customer.$touch" @input="updateCustomer($event)" data-cy="event-creation-customer" />
           <ni-select in-modal caption="Service" :value="newEvent.subscription" :error="validations.subscription.$error"
             :options="customerSubscriptionsOptions" required-field @blur="validations.subscription.$touch"
             data-cy="event-creation-service" @input="update($event, 'subscription')" />
@@ -165,6 +165,10 @@ export default {
         TRANSPORT_ACCIDENT,
         ILLNESS,
       ].includes(this.newEvent.absence);
+    },
+    stoppingDate () {
+      const customer = this.customers.find(c => c._id === this.newEvent.customer);
+      return get(customer, 'stoppedAt') || '';
     },
   },
   watch: {

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -14,7 +14,7 @@
         <template v-if="newEvent.type !== ABSENCE">
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="newEvent.dates" required-field
             :error="validations.dates.$error" @blur="validations.dates.$touch" disable-end-date
-            @input="update($event, 'dates')" :max="stoppingDate" />
+            @input="update($event, 'dates')" :max="customerStoppedDate" />
         </template>
         <template v-if="newEvent.type === INTERVENTION">
           <ni-select v-if="isCustomerPlanning" in-modal caption="Auxiliaire" :value="newEvent.auxiliary"
@@ -166,7 +166,7 @@ export default {
         ILLNESS,
       ].includes(this.newEvent.absence);
     },
-    stoppingDate () {
+    customerStoppedDate () {
       return get(this.selectedCustomer, 'stoppedAt') || '';
     },
   },

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -21,7 +21,7 @@
             :options="auxiliariesOptions" :error="validations.auxiliary.$error" required-field
             @blur="validations.auxiliary.$touch" @input="update($event, 'auxiliary')" />
           <ni-select v-else in-modal caption="Bénéficiaire" :value="newEvent.customer"
-            :options="customersOptions(newEvent.dates.startDate)" :error="validations.customer.$error" required-field
+            :options="getCustomersOptions(newEvent.dates.startDate)" :error="validations.customer.$error" required-field
             @blur="validations.customer.$touch" @input="updateCustomer($event)" data-cy="event-creation-customer" />
           <ni-select in-modal caption="Service" :value="newEvent.subscription" :error="validations.subscription.$error"
             :options="customerSubscriptionsOptions" required-field @blur="validations.subscription.$touch"
@@ -167,8 +167,7 @@ export default {
       ].includes(this.newEvent.absence);
     },
     stoppingDate () {
-      const customer = this.customers.find(c => c._id === this.newEvent.customer);
-      return get(customer, 'stoppedAt') || '';
+      return get(this.selectedCustomer, 'stoppedAt') || '';
     },
   },
   watch: {

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -26,7 +26,7 @@
             :options="auxiliariesOptions" :error="validations.auxiliary.$error" required-field
             @blur="validations.auxiliary.$touch" @input="update($event, 'auxiliary')" />
           <ni-select v-else in-modal caption="Bénéficiaire" :value="editedEvent.customer"
-            :options="customersOptions(editedEvent.dates.startDate)" :error="validations.customer.$error"
+            :options="getCustomersOptions(editedEvent.dates.startDate)" :error="validations.customer.$error"
             required-field disable />
           <ni-select in-modal :options="customerSubscriptionsOptions" @input="update($event, 'subscription')"
             :value="editedEvent.subscription" :error="validations.subscription.$error" caption="Service"
@@ -185,8 +185,7 @@ export default {
       return `Cette absence est une prolongation de ${nature.label.toLowerCase()} commencant le ${startDate}`;
     },
     stoppingDate () {
-      const customer = this.customers.find(c => c._id === this.editedEvent.customer);
-      return get(customer, 'stoppedAt') || '';
+      return get(this.selectedCustomer, 'stoppedAt') || '';
     },
   },
   methods: {

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -19,7 +19,7 @@
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="editedEvent.dates" required-field
             :disable="isBilledIntervention" :error="validations.dates.$error" @input="update($event, 'dates')"
             @blur="validations.dates.$touch" :disable-start-date="!!editedEvent.startDateTimeStampedCount"
-            disable-end-date :disable-start-hour="!!editedEvent.startDateTimeStampedCount" :max="stoppingDate" />
+            disable-end-date :disable-start-hour="!!editedEvent.startDateTimeStampedCount" :max="customerStoppedDate" />
         </template>
         <template v-if="editedEvent.type === INTERVENTION">
           <ni-select v-if="isCustomerPlanning" in-modal caption="Auxiliaire" :value="editedEvent.auxiliary"
@@ -184,7 +184,7 @@ export default {
 
       return `Cette absence est une prolongation de ${nature.label.toLowerCase()} commencant le ${startDate}`;
     },
-    stoppingDate () {
+    customerStoppedDate () {
       return get(this.selectedCustomer, 'stoppedAt') || '';
     },
   },

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -19,14 +19,15 @@
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="editedEvent.dates" required-field
             :disable="isBilledIntervention" :error="validations.dates.$error" @input="update($event, 'dates')"
             @blur="validations.dates.$touch" :disable-start-date="!!editedEvent.startDateTimeStampedCount"
-            disable-end-date :disable-start-hour="!!editedEvent.startDateTimeStampedCount" />
+            disable-end-date :disable-start-hour="!!editedEvent.startDateTimeStampedCount" :max="stoppingDate" />
         </template>
         <template v-if="editedEvent.type === INTERVENTION">
           <ni-select v-if="isCustomerPlanning" in-modal caption="Auxiliaire" :value="editedEvent.auxiliary"
             :options="auxiliariesOptions" :error="validations.auxiliary.$error" required-field
             @blur="validations.auxiliary.$touch" @input="update($event, 'auxiliary')" />
-          <ni-select v-else in-modal caption="Bénéficiaire" :value="editedEvent.customer" :options="customersOptions"
-            :error="validations.customer.$error" required-field disable />
+          <ni-select v-else in-modal caption="Bénéficiaire" :value="editedEvent.customer"
+            :options="customersOptions(editedEvent.dates.startDate)" :error="validations.customer.$error"
+            required-field disable />
           <ni-select in-modal :options="customerSubscriptionsOptions" @input="update($event, 'subscription')"
             :value="editedEvent.subscription" :error="validations.subscription.$error" caption="Service"
             @blur="validations.subscription.$touch" required-field :disable="isBilledIntervention" />
@@ -111,6 +112,7 @@
 </template>
 
 <script>
+import get from 'lodash/get';
 import set from 'lodash/set';
 import Button from '@components/Button';
 import { INTERVENTION, ABSENCE, OTHER, NEVER, ABSENCE_TYPES } from '@data/constants';
@@ -181,6 +183,10 @@ export default {
       const startDate = moment(this.editedEvent.extension.startDate).format('DD/MM/YYYY');
 
       return `Cette absence est une prolongation de ${nature.label.toLowerCase()} commencant le ${startDate}`;
+    },
+    stoppingDate () {
+      const customer = this.customers.find(c => c._id === this.editedEvent.customer);
+      return get(customer, 'stoppedAt') || '';
     },
   },
   methods: {

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -22,7 +22,7 @@ import {
   OTHER,
   WORK_ACCIDENT,
 } from '@data/constants';
-import { frAddress } from '@helpers/vuelidateCustomVal';
+import { frAddress, maxDate } from '@helpers/vuelidateCustomVal';
 import { defineAbilitiesFor } from '@helpers/ability';
 import moment from '@helpers/moment';
 import { validationMixin } from '@mixins/validationMixin';
@@ -37,7 +37,10 @@ export const planningActionMixin = {
       newEvent: {
         type: { required },
         dates: {
-          startDate: { required },
+          startDate: {
+            required,
+            maxDate: this.getStoppingDate(this.newEvent) ? maxDate(this.getStoppingDate(this.newEvent)) : '',
+          },
           endDate: {
             required: requiredIf(() => this.newEvent &&
               (this.newEvent.type !== ABSENCE || this.newEvent.absenceNature === DAILY)),
@@ -78,7 +81,10 @@ export const planningActionMixin = {
       },
       editedEvent: {
         dates: {
-          startDate: { required },
+          startDate: {
+            required,
+            maxDate: this.getStoppingDate(this.editedEvent) ? maxDate(this.getStoppingDate(this.editedEvent)) : '',
+          },
           endDate: { required },
         },
         auxiliary: { required: requiredIf(item => item && item.type !== INTERVENTION) },
@@ -579,6 +585,10 @@ export const planningActionMixin = {
       } finally {
         this.loading = false;
       }
+    },
+    getStoppingDate (event) {
+      const customer = this.customers ? this.customers.find(c => c._id === event.customer) : null;
+      return get(customer, 'stoppedAt') || '';
     },
   },
 };

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -39,7 +39,9 @@ export const planningActionMixin = {
         dates: {
           startDate: {
             required,
-            maxDate: this.getStoppingDate(this.newEvent) ? maxDate(this.getStoppingDate(this.newEvent)) : '',
+            maxDate: this.getCustomerStoppedDate(this.newEvent)
+              ? maxDate(this.getCustomerStoppedDate(this.newEvent))
+              : '',
           },
           endDate: {
             required: requiredIf(() => this.newEvent &&
@@ -83,7 +85,9 @@ export const planningActionMixin = {
         dates: {
           startDate: {
             required,
-            maxDate: this.getStoppingDate(this.editedEvent) ? maxDate(this.getStoppingDate(this.editedEvent)) : '',
+            maxDate: this.getCustomerStoppedDate(this.editedEvent)
+              ? maxDate(this.getCustomerStoppedDate(this.editedEvent))
+              : '',
           },
           endDate: { required },
         },
@@ -586,7 +590,7 @@ export const planningActionMixin = {
         this.loading = false;
       }
     },
-    getStoppingDate (event) {
+    getCustomerStoppedDate (event) {
       const customer = this.customers ? this.customers.find(c => c._id === event.customer) : null;
       return get(customer, 'stoppedAt') || '';
     },

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -105,16 +105,6 @@ export const planningModalMixin = {
         ...formatAndSortIdentityOptions(this.activeAuxiliaries),
       ];
     },
-    customersOptions () {
-      if (this.customers.length === 0) return [];
-      if (!this.selectedAuxiliary || !this.selectedAuxiliary._id) {
-        return formatAndSortIdentityOptions(this.customers); // Unassigned event
-      }
-
-      if (!this.selectedAuxiliary.contracts) return [];
-
-      return formatAndSortIdentityOptions(this.customers);
-    },
     internalHourOptions () {
       return this.internalHours.map(hour => ({ label: hour.name, value: hour._id }));
     },
@@ -231,6 +221,19 @@ export const planningModalMixin = {
           });
         }
       }
+    },
+    customersOptions (startDate) {
+      if (this.customers.length === 0) return [];
+
+      const activeCustomers = this.customers
+        .filter(customer => !customer.stoppedAt || startDate < customer.stoppedAt);
+      if (!this.selectedAuxiliary || !this.selectedAuxiliary._id) {
+        return formatAndSortIdentityOptions(activeCustomers); // Unassigned event
+      }
+
+      if (!this.selectedAuxiliary.contracts) return [];
+
+      return formatAndSortIdentityOptions(activeCustomers);
     },
   },
 };

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -222,7 +222,7 @@ export const planningModalMixin = {
         }
       }
     },
-    customersOptions (startDate) {
+    getCustomersOptions (startDate) {
       if (this.customers.length === 0) return [];
 
       const activeCustomers = this.customers

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -38,6 +38,7 @@ import {
 } from '@data/constants';
 import { formatAndSortIdentityOptions } from '@helpers/utils';
 import moment from '@helpers/moment';
+import { isBefore } from '@helpers/date';
 import PlanningModalHeader from 'src/modules/client/components/planning/PlanningModalHeader';
 
 export const planningModalMixin = {
@@ -226,7 +227,7 @@ export const planningModalMixin = {
       if (this.customers.length === 0) return [];
 
       const activeCustomers = this.customers
-        .filter(customer => !customer.stoppedAt || startDate < customer.stoppedAt);
+        .filter(customer => !customer.stoppedAt || !startDate || isBefore(startDate, customer.stoppedAt));
       if (!this.selectedAuxiliary || !this.selectedAuxiliary._id) {
         return formatAndSortIdentityOptions(activeCustomers); // Unassigned event
       }

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -24,7 +24,7 @@ import get from 'lodash/get';
 import Events from '@api/Events';
 import Customers from '@api/Customers';
 import Users from '@api/Users';
-import { NotifyNegative } from '@components/popup/notify';
+import { NotifyNegative, NotifyWarning } from '@components/popup/notify';
 import {
   INTERVENTION,
   DEFAULT_AVATAR,
@@ -176,6 +176,11 @@ export default {
     openCreationModal (vEvent) {
       const { dayIndex, person } = vEvent;
       const selectedDay = this.days[dayIndex];
+
+      if (moment(selectedDay).toDate().toISOString() > person.stoppedAt) {
+        return NotifyWarning('Le bénéficiare est arrêté à cette date.');
+      }
+
       this.newEvent = {
         type: INTERVENTION,
         repetition: { frequency: NEVER },

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -37,6 +37,7 @@ import {
 } from '@data/constants';
 import { formatIdentity } from '@helpers/utils';
 import moment from '@helpers/moment';
+import { isAfter } from '@helpers/date';
 import { planningActionMixin } from 'src/modules/client/mixins/planningActionMixin';
 import Planning from 'src/modules/client/components/planning/Planning';
 import EventCreationModal from 'src/modules/client/components/planning/EventCreationModal';
@@ -177,7 +178,7 @@ export default {
       const { dayIndex, person } = vEvent;
       const selectedDay = this.days[dayIndex];
 
-      if (moment(selectedDay).toDate().toISOString() > person.stoppedAt) {
+      if (isAfter(selectedDay, person.stoppedAt)) {
         return NotifyWarning('Le bénéficiare est arrêté à cette date.');
       }
 


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach/admin/aux

- Cas d'usage : je ne peux pas créer une intervention pour un bénéficiaire arrêté (postérieur à la data d'arrêt)
  - arrêter un bénéficiaire
  - essayer de lui créer une intervention après sa date d'arrêt (planning aux et bénéficiaire) (pop up warning)
  - essayer de modifier une autre intervention postérieure à la date d'arrêt pour l'affecter au bénéficiaire arrêté (il ne doit pas apparaitre dans la liste)
  - essayer de modifier une intervention du bénéficiaire antérieure à la date d'arrêt pour la faire passer après la date d'arrêt (on doit avoir un message d'erreur sur la date)

