### PR TITLE
dont send company if user already have one on coachlist

### DIFF
--- a/src/core/components/table/CoachList.vue
+++ b/src/core/components/table/CoachList.vue
@@ -169,7 +169,11 @@ export default {
         }
         if (userInfo.exists && get(userInfo, 'user.role.client')) return NotifyNegative('Utilisateur déjà existant');
         if (userInfo.exists) {
-          await Users.updateById(userInfo.user._id, { role: this.newCoach.role, company: this.company._id });
+          const payload = { role: this.newCoach.role };
+          if (!user.company) payload.company = this.company._id;
+
+          await Users.updateById(userInfo.user._id, payload);
+
           NotifyPositive('Coach créé');
           await this.getUsers();
           this.coachCreationModal = false;


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client/vendeur

- Périmetre roles : admin

- Cas d'usage : 
Dans les cas suivant, verifier que l'on cree bien un objet UserCompany :

Ajout d'un apprenant dans une structure (verifier sur le repertoire apprenant cote client + ajout de stagiaire intra (cote client et coté vendeur + ajout de stagiaire inter cote vendeur)

Ajout d'un coach (cote client et cote vendeur)

Ajout d'une auxiliaire

Ajout d'un aidant

Verifier egalement que si l'utilisateur a deja une entreprise, cela ne recree pas un UserCompany.
Verifier les cas de creation ainsi que de modification d'utilisateurs