### PR TITLE
Com 2075 fix

### DIFF
--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -80,7 +80,7 @@
               :error="validations.cancel.reason.$error" @input="update($event, 'cancel.reason')" />
           </div>
         </template>
-        <div class="q-mb-lg">
+        <div class="q-mb-lg hidden">
           <div class="flex-row items-center justify-between">
             <div class="flex-row">
               <q-icon size="sm" name="history" class="q-mr-sm" color="grey-400" />

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -138,7 +138,7 @@ export default {
   },
   props: {
     workingStats: { type: Object, default: () => ({}) },
-    events: { type: Object, default: () => ({}) },
+    events: { type: Array, default: () => [] },
     persons: { type: Array, default: () => [] },
     filteredSectors: { type: Array, default: () => [] },
     personKey: { type: String, default: 'auxiliary' },
@@ -250,7 +250,9 @@ export default {
       return total / 60;
     },
     getRowEvents (rowId) {
-      return this.events[rowId] || [];
+      const rowEvents = this.events.find(group => group._id === rowId);
+
+      return (!rowEvents || !rowEvents.events) ? [] : rowEvents.events;
     },
     getCellEvents (cellId, day) {
       return this.getRowEvents(cellId)

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -153,7 +153,9 @@ export const planningActionMixin = {
           (!contract.endDate || moment(contract.endDate).isAfter(startDate)));
     },
     getRowEvents (rowId) {
-      return this.events[rowId] || [];
+      const rowEvents = this.events.find(group => group._id === rowId);
+
+      return (!rowEvents || !rowEvents.events) ? [] : rowEvents.events;
     },
     // Event creation
     canCreateEvent (person, selectedDay) {

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -3,6 +3,7 @@ import omit from 'lodash/omit';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
+import cloneDeep from 'lodash/cloneDeep';
 import { required, requiredIf } from 'vuelidate/lib/validators';
 import { subject } from '@casl/ability';
 import InternalHours from '@api/InternalHours';
@@ -333,8 +334,20 @@ export const planningActionMixin = {
       this.editionModal = true;
     },
     formatEditedEvent (event) {
-      const { startDate, endDate, isBilled, auxiliary, subscription, address, customer, internalHour, sector } = event;
-      const eventData = omit(event, ['createdAt', 'updatedAt']);
+      const {
+        createdAt,
+        updatedAt,
+        startDate,
+        endDate,
+        isBilled,
+        auxiliary,
+        subscription,
+        address,
+        customer,
+        internalHour,
+        sector,
+        ...eventData
+      } = cloneDeep(event);
       const dates = { startDate, endDate };
 
       switch (event.type) {

--- a/src/modules/client/pages/ni/pay/Absences.vue
+++ b/src/modules/client/pages/ni/pay/Absences.vue
@@ -44,7 +44,7 @@ import DateRange from '@components/form/DateRange';
 import TitleHeader from '@components/TitleHeader';
 import SimpleTable from '@components/table/SimpleTable';
 import { NotifyWarning } from '@components/popup/notify';
-import { formatIdentity, formatHours } from '@helpers/utils';
+import { formatIdentity, formatHours, formatHoursWithMinutes } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { formatDate } from '@helpers/date';
 import { ABSENCE, ABSENCE_NATURES, ABSENCE_TYPES, DAILY, AUXILIARY } from '@data/constants';
@@ -64,7 +64,6 @@ export default {
   data () {
     return {
       personKey: AUXILIARY,
-      events: [],
       loading: false,
       tableLoading: false,
       absences: [],
@@ -106,7 +105,7 @@ export default {
           name: 'startHour',
           label: 'Heure de début',
           field: 'startDate',
-          format: value => moment(value).format('HH:mm'),
+          format: formatHoursWithMinutes,
           align: 'center',
         },
         {
@@ -117,19 +116,8 @@ export default {
           align: 'center',
           sortable: true,
         },
-        {
-          name: 'endHour',
-          label: 'Heure de fin',
-          field: 'endDate',
-          format: value => moment(value).format('HH:mm'),
-          align: 'center',
-        },
-        {
-          name: 'duration',
-          label: 'Durée',
-          field: row => this.getAbsenceDuration(row),
-          align: 'center',
-        },
+        { name: 'endHour', label: 'Heure de fin', field: 'endDate', format: formatHoursWithMinutes, align: 'center' },
+        { name: 'duration', label: 'Durée', field: this.getAbsenceDuration, align: 'center' },
         {
           name: 'type',
           label: 'Type',

--- a/src/modules/client/pages/ni/pay/Absences.vue
+++ b/src/modules/client/pages/ni/pay/Absences.vue
@@ -44,7 +44,7 @@ import DateRange from '@components/form/DateRange';
 import TitleHeader from '@components/TitleHeader';
 import SimpleTable from '@components/table/SimpleTable';
 import { NotifyWarning } from '@components/popup/notify';
-import { formatIdentity, formatHours, formatHoursWithMinutes } from '@helpers/utils';
+import { formatIdentity, formatHours } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { formatDate } from '@helpers/date';
 import { ABSENCE, ABSENCE_NATURES, ABSENCE_TYPES, DAILY, AUXILIARY } from '@data/constants';
@@ -64,6 +64,7 @@ export default {
   data () {
     return {
       personKey: AUXILIARY,
+      events: [],
       loading: false,
       tableLoading: false,
       absences: [],
@@ -105,7 +106,7 @@ export default {
           name: 'startHour',
           label: 'Heure de début',
           field: 'startDate',
-          format: formatHoursWithMinutes,
+          format: value => moment(value).format('HH:mm'),
           align: 'center',
         },
         {
@@ -116,8 +117,19 @@ export default {
           align: 'center',
           sortable: true,
         },
-        { name: 'endHour', label: 'Heure de fin', field: 'endDate', format: formatHoursWithMinutes, align: 'center' },
-        { name: 'duration', label: 'Durée', field: this.getAbsenceDuration, align: 'center' },
+        {
+          name: 'endHour',
+          label: 'Heure de fin',
+          field: 'endDate',
+          format: value => moment(value).format('HH:mm'),
+          align: 'center',
+        },
+        {
+          name: 'duration',
+          label: 'Durée',
+          field: row => this.getAbsenceDuration(row),
+          align: 'center',
+        },
         {
           name: 'type',
           label: 'Type',

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -55,7 +55,7 @@ export default {
     return {
       loading: false,
       days: [],
-      events: {},
+      events: [],
       customers: [],
       auxiliaries: [],
       internalHours: [],
@@ -161,7 +161,7 @@ export default {
       if (!this.displayAllSectors) {
         this.auxiliaries = [];
         this.filteredSectors = [];
-        this.events = {};
+        this.events = [];
         this.$refs.planningManager.restoreFilter(this.savedSearch);
       } else {
         this.savedSearch = search;
@@ -208,7 +208,7 @@ export default {
         if (this.displayHistory) await this.getEventHistories();
       } catch (e) {
         console.error(e);
-        this.events = {};
+        this.events = [];
       }
     },
     async refreshWorkingStats (params) {

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -59,7 +59,7 @@ export default {
     return {
       loading: false,
       days: [],
-      events: {},
+      events: [],
       customers: [],
       auxiliaries: [],
       startOfWeek: '',
@@ -164,7 +164,7 @@ export default {
           groupBy: CUSTOMER,
         });
       } catch (e) {
-        this.events = {};
+        this.events = [];
       }
     },
     async getAuxiliaries () {


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : coach

- Cas d'usage : Le planning s'affiche + suppression du bouton pour les historiques d'evenement dans la modale. 
J'ai revert un commit de la PR COM-2075  --> Verifier qu'il n'y a pas de changements dans la pr COM-2075 qui sont incompatibles avec ce revert. 
Tester la creation/l'edition d'evenement et de repetitions
