### PR TITLE
COM-2141 

### DIFF
--- a/src/modules/client/components/auxiliary/ProfileContracts.vue
+++ b/src/modules/client/components/auxiliary/ProfileContracts.vue
@@ -402,9 +402,7 @@ export default {
         NotifyPositive('Contrat terminé');
       } catch (e) {
         console.error(e);
-        if (e.status === 403) {
-          return NotifyNegative('Impossible: il y a des interventions horodatées après la date de fin du contrat.');
-        }
+        if (e.status === 403 || e.status === 409) return NotifyNegative(e.data.message);
         NotifyNegative('Erreur lors de la mise à jour du contrat.');
       } finally {
         this.loading = false;

--- a/src/modules/client/components/auxiliary/ProfileContracts.vue
+++ b/src/modules/client/components/auxiliary/ProfileContracts.vue
@@ -402,6 +402,9 @@ export default {
         NotifyPositive('Contrat terminé');
       } catch (e) {
         console.error(e);
+        if (e.status === 403) {
+          return NotifyNegative('Impossible: il y a des interventions horodatées après la date de fin du contrat.');
+        }
         NotifyNegative('Erreur lors de la mise à jour du contrat.');
       } finally {
         this.loading = false;


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np 
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : coach/ admin_client

- Cas d'usage : Lorsque l'on essaie de mettre fin au contrat d'un auxiliaire mais que des événements sont horodatés après la date de fin, le message d'erreur `Impossible: il y a des évènements horodatés après la date de fin du contrat.` s'affiche.
Modification du message d'erreur lorsque l'utilisateur tente de mettre fin a un contrat en entrant une date de fin antérieure a la date de début.
