### PR TITLE
COM-2075 disable fields on history loading

### DIFF
--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-dialog v-if="Object.keys(editedEvent).length !== 0" :value="editionModal" @hide="hide">
+  <q-dialog :value="editionModal" @hide="hide">
     <div class="modal-container-md">
       <div class="modal-padding">
         <ni-planning-modal-header v-if="isCustomerPlanning" :value="editedEvent.customer"
@@ -8,41 +8,45 @@
           :value="editedEvent.auxiliary" :selected-person="selectedAuxiliary" @close="close" />
         <ni-planning-modal-header v-else :value="editedEvent.auxiliary" @input="update($event, 'auxiliary')"
           :options="auxiliariesOptions" :selected-person="selectedAuxiliary" @close="close"
-          :disable="isEventTimeStamped" />
+          :disable="isEventTimeStamped || historiesLoading" />
         <div class="modal-subtitle">
           <q-btn-toggle no-wrap :value="editedEvent.type" toggle-color="primary" rounded unelevated
             :options="eventType" />
           <q-btn icon="delete" @click="isRepetition(editedEvent) ? deleteEventRepetition() : deleteEvent()" no-caps flat
-            color="grey" v-if="!isBilledIntervention" data-cy="event-deletion-button" />
+            color="grey" v-if="!isBilledIntervention" data-cy="event-deletion-button" :disable="historiesLoading" />
         </div>
         <template v-if="editedEvent.type !== ABSENCE">
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="editedEvent.dates" required-field
-            :disable="isBilledIntervention" :error="validations.dates.$error" @input="update($event, 'dates')"
-            @blur="validations.dates.$touch" :disable-start-date="isEventTimeStamped" :max="customerStoppedDate"
-            disable-end-date :disable-start-hour="!!startDateTimeStamped" :disable-end-hour="!!endDateTimeStamped" />
+            :disable="isBilledIntervention || historiesLoading" :error="validations.dates.$error" disable-end-date
+            @input="update($event, 'dates')" @blur="validations.dates.$touch" :disable-start-date="isEventTimeStamped"
+            :max="customerStoppedDate" :disable-start-hour="!!startDateTimeStamped"
+            :disable-end-hour="!!endDateTimeStamped" />
         </template>
         <template v-if="editedEvent.type === INTERVENTION">
           <ni-select v-if="isCustomerPlanning" in-modal caption="Auxiliaire" :value="editedEvent.auxiliary"
             :options="auxiliariesOptions" :error="validations.auxiliary.$error" required-field
-            @blur="validations.auxiliary.$touch" @input="update($event, 'auxiliary')" :disable="isEventTimeStamped" />
+            @blur="validations.auxiliary.$touch" @input="update($event, 'auxiliary')"
+            :disable="isEventTimeStamped || historiesLoading" />
           <ni-select v-else in-modal caption="Bénéficiaire" :value="editedEvent.customer"
             :options="getCustomersOptions(editedEvent.dates.startDate)" :error="validations.customer.$error"
             required-field disable />
           <ni-select in-modal :options="customerSubscriptionsOptions" @input="update($event, 'subscription')"
             :value="editedEvent.subscription" :error="validations.subscription.$error" caption="Service"
-            @blur="validations.subscription.$touch" required-field :disable="isBilledIntervention" />
+            @blur="validations.subscription.$touch" required-field
+            :disable="isBilledIntervention || historiesLoading" />
         </template>
         <template v-if="editedEvent.type === INTERNAL_HOUR">
           <ni-select in-modal caption="Type d'heure interne" :value="editedEvent.internalHour"
-            :options="internalHourOptions" :error="validations.internalHour.$error"
+            :options="internalHourOptions" :error="validations.internalHour.$error" :disable="historiesLoading"
             @blur="validations.internalHour.$touch" @input="update($event, 'internalHour')" />
           <ni-search-address :value="editedEvent.address" in-modal @blur="validations.address.$touch"
-            :error="validations.address.$error" :error-message="addressError" @input="update($event, 'address')" />
+            :error="validations.address.$error" :error-message="addressError" @input="update($event, 'address')"
+            :disable="historiesLoading" />
         </template>
         <template v-if="isRepetition(editedEvent) && !isBilledIntervention && !editedEvent.isCancelled">
           <div class="row q-mb-md light-checkbox">
             <q-checkbox :value="editedEvent.shouldUpdateRepetition" label="Appliquer à la répétition"
-              @input="toggleRepetition" dense />
+              @input="toggleRepetition" dense :disable="historiesLoading" />
           </div>
         </template>
         <template v-if="editedEvent.type === ABSENCE">
@@ -51,32 +55,34 @@
             :error="validations.absenceNature.$error" required-field disable />
           <ni-select in-modal caption="Type d'absence" :value="editedEvent.absence" :options="absenceOptions"
             :error="validations.absence.$error" required-field @blur="validations.absence.$touch"
-            :disable="isHourlyAbsence(editedEvent)" @input="updateAbsence($event)" />
+            :disable="isHourlyAbsence(editedEvent) || historiesLoading" @input="updateAbsence($event)" />
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="editedEvent.dates" required-field
             :disable-end-date="isHourlyAbsence(editedEvent)" :error="validations.dates.$error"
-            @blur="validations.dates.$touch" :disable-end-hour="isDailyAbsence(editedEvent)"
+            @blur="validations.dates.$touch" :disable-end-hour="isDailyAbsence(editedEvent)" :disable="historiesLoading"
             :disable-start-hour="!isIllnessOrWorkAccident(editedEvent)" @input="update($event, 'dates')" />
           <ni-file-uploader v-if="isIllnessOrWorkAccident(editedEvent)" caption="Justificatif d'absence" required-field
             path="attachment" :entity="editedEvent" alt="justificatif absence" name="file" :url="docsUploadUrl"
-            @uploaded="documentUploaded" :additional-value="additionalValue" :disable="!selectedAuxiliary._id"
-            :error="validations.attachment.$error" @delete="deleteDocument(editedEvent.attachment.driveId)" in-modal
-            :extensions="extensions" drive-storage />
+            @uploaded="documentUploaded" :additional-value="additionalValue" :error="validations.attachment.$error"
+            :disable="!selectedAuxiliary._id || historiesLoading" in-modal :extensions="extensions" drive-storage
+            @delete="deleteDocument(editedEvent.attachment.driveId)" />
         </template>
         <ni-input in-modal v-if="!editedEvent.shouldUpdateRepetition" :value="editedEvent.misc" caption="Notes"
-          :disable="isBilledIntervention" @blur="validations.misc.$touch" :error="validations.misc.$error"
-          :required-field="isMiscRequired" @input="update($event, 'misc')" />
+          :disable="isBilledIntervention || historiesLoading" @blur="validations.misc.$touch"
+          :error="validations.misc.$error" :required-field="isMiscRequired" @input="update($event, 'misc')" />
         <template v-if="canCancel">
           <div class="row q-mb-md light-checkbox">
-            <q-checkbox :value="editedEvent.isCancelled" label="Annuler l'évènement" dense
+            <q-checkbox :value="editedEvent.isCancelled" label="Annuler l'évènement" dense :disable="historiesLoading"
             @input="toggleCancellationForm($event)" />
           </div>
           <div class="row justify-between">
             <ni-select in-modal v-if="editedEvent.isCancelled" :value="editedEvent.cancel.condition" required-field
               caption="Conditions" :options="cancellationConditions" @blur="validations.cancel.condition.$touch"
-              :error="validations.cancel.condition.$error" @input="update($event, 'cancel.condition')" />
+              :error="validations.cancel.condition.$error" @input="update($event, 'cancel.condition')"
+              :disable="historiesLoading" />
             <ni-select in-modal v-if="editedEvent.isCancelled" :value="editedEvent.cancel.reason" caption="Motif"
               :options="cancellationReasons" required-field @blur="validations.cancel.reason.$touch"
-              :error="validations.cancel.reason.$error" @input="update($event, 'cancel.reason')" />
+              :error="validations.cancel.reason.$error" @input="update($event, 'cancel.reason')"
+              :disable="historiesLoading" />
           </div>
         </template>
         <div class="q-mb-lg">
@@ -88,7 +94,7 @@
             <ni-button :label="historyButtonLabel" color="grey-800" class="bg-grey-100" @click="toggleHistory" />
           </div>
           <div v-if="displayHistory" class="q-mt-sm">
-            <ni-event-history v-for="history in editedEvent.histories" :key="history._id" :history="history" />
+            <ni-event-history v-for="history in eventHistories" :key="history._id" :history="history" />
           </div>
         </div>
       </div>
@@ -97,7 +103,7 @@
         <div class="row items-center no-wrap">
           <q-select borderless dense :value="editedEvent.address" @input="updateAddress" emit-value behavior="menu"
             :options="customerAddressList(editedEvent)" :readonly="customerAddressList(editedEvent).length === 1"
-            :display-value="editedEvent.address.fullAddress" ref="addressSelect">
+            :display-value="editedEvent.address.fullAddress" ref="addressSelect" :disable="historiesLoading">
             <template #append v-if="customerAddressList(editedEvent).length > 1">
               <ni-button icon="swap_vert" class="select-icon pink-icon" @click.stop="toggleAddressSelect" />
             </template>
@@ -106,7 +112,8 @@
         </div>
       </div>
       <q-btn v-if="!isBilledIntervention" class="modal-btn full-width" no-caps color="primary" :loading="loading"
-        label="Editer l'évènement" @click="submit" icon-right="check" data-cy="event-edition-button" />
+        label="Editer l'évènement" @click="submit" icon-right="check" data-cy="event-edition-button"
+        :disable="historiesLoading" />
     </div>
   </q-dialog>
 </template>
@@ -133,6 +140,8 @@ export default {
     internalHours: { type: Array, default: () => [] },
     validations: { type: Object, default: () => ({}) },
     personKey: { type: String, default: () => '' },
+    eventHistories: { type: Array, default: () => [] },
+    historiesLoading: { type: Boolean, default: false },
   },
   components: {
     'ni-button': Button,
@@ -189,10 +198,10 @@ export default {
       return get(this.selectedCustomer, 'stoppedAt') || '';
     },
     startDateTimeStamped () {
-      return this.editedEvent.histories.some(h => TIME_STAMPING_ACTIONS.includes(h.action) && h.update.startHour);
+      return this.eventHistories.some(h => TIME_STAMPING_ACTIONS.includes(h.action) && h.update.startHour);
     },
     endDateTimeStamped () {
-      return this.editedEvent.histories.some(h => TIME_STAMPING_ACTIONS.includes(h.action) && h.update.endHour);
+      return this.eventHistories.some(h => TIME_STAMPING_ACTIONS.includes(h.action) && h.update.endHour);
     },
     isEventTimeStamped () {
       return !!this.startDateTimeStamped || !!this.endDateTimeStamped;

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -91,7 +91,8 @@
               <q-icon size="sm" name="history" class="q-mr-sm" color="grey-400" />
               <div class="history-list-title text-weight-bold">Activité</div>
             </div>
-            <ni-button :label="historyButtonLabel" color="grey-800" class="bg-grey-100" @click="toggleHistory" />
+            <ni-button :label="historyButtonLabel" color="grey-800" class="bg-grey-100" @click="toggleHistory"
+              :disable="historiesLoading" />
           </div>
           <div v-if="displayHistory" class="q-mt-sm">
             <ni-event-history v-for="history in eventHistories" :key="history._id" :history="history" />

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -337,6 +337,7 @@ export const planningActionMixin = {
         if (!isAllowed) return NotifyWarning('Vous n\'avez pas les droits pour réaliser cette action.');
 
         await this.formatEditedEvent(event);
+
         this.editionModal = true;
         this.editedEventHistories = await EventHistories.list({ eventId: event._id });
       } catch (e) {
@@ -405,7 +406,7 @@ export const planningActionMixin = {
     },
     resetEditionForm () {
       this.$v.editedEvent.$reset();
-      this.editedEvent = {};
+      this.editionModal = false;
     },
     closeEditionModal () {
       this.editionModal = false;

--- a/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -31,7 +31,8 @@
       :edition-modal="editionModal" :internal-hours="internalHours" :active-auxiliaries="activeAuxiliaries"
       :customers="customers" @hide="resetEditionForm" @delete-document="validateDocumentDeletion"
       @document-uploaded="documentUploaded" @submit="updateEvent" @delete-event="validateEventDeletion"
-      @delete-event-repetition="validationDeletionEventRepetition" :person-key="personKey" @close="closeEditionModal" />
+      @delete-event-repetition="validationDeletionEventRepetition" :person-key="personKey" @close="closeEditionModal"
+      :event-histories="editedEventHistories" :histories-loading="historiesLoading" />
   </q-page>
 </template>
 

--- a/src/modules/client/pages/ni/pay/Absences.vue
+++ b/src/modules/client/pages/ni/pay/Absences.vue
@@ -33,7 +33,8 @@
     <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :edited-event.sync="editedEvent"
       :edition-modal="editionModal" :person-key="personKey" :active-auxiliaries="activeAuxiliaries"
       @reset="resetEditionForm" @delete-document="validateDocumentDeletion" @document-uploaded="documentUploaded"
-      @submit="updateEvent" @close="closeEditionModal" @delete-event="validateEventDeletion" />
+      @submit="updateEvent" @close="closeEditionModal" @delete-event="validateEventDeletion"
+      :event-histories="editedEventHistories" :histories-loading="historiesLoading" />
   </q-page>
 </template>
 

--- a/src/modules/client/pages/ni/pay/Absences.vue
+++ b/src/modules/client/pages/ni/pay/Absences.vue
@@ -14,7 +14,7 @@
             :style="col.style">
             <template v-if="col.name === 'actions'">
               <div class="row no-wrap table-actions">
-                <q-btn flat round small color="grey" icon="edit" @click="openEditionModal(props.row)" />
+                <q-btn flat round small color="grey" icon="edit" @click="openAbsenceEditionModal(props.row)" />
               </div>
             </template>
             <template v-if="col.name === 'attachment'">
@@ -32,7 +32,7 @@
     <!-- Absence edition modal -->
     <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :edited-event.sync="editedEvent"
       :edition-modal="editionModal" :person-key="personKey" :active-auxiliaries="activeAuxiliaries"
-      @reset="resetEditionForm" @delete-document="validateDocumentDeletion" @document-uploaded="documentUploaded"
+      @hide="resetEditionForm" @delete-document="validateDocumentDeletion" @document-uploaded="documentUploaded"
       @submit="updateEvent" @close="closeEditionModal" @delete-event="validateEventDeletion"
       :event-histories="editedEventHistories" :histories-loading="historiesLoading" />
   </q-page>
@@ -44,7 +44,6 @@ import Events from '@api/Events';
 import DateRange from '@components/form/DateRange';
 import TitleHeader from '@components/TitleHeader';
 import SimpleTable from '@components/table/SimpleTable';
-import { NotifyWarning } from '@components/popup/notify';
 import { formatIdentity, formatHours, formatHoursWithMinutes } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { formatDate } from '@helpers/date';
@@ -186,14 +185,9 @@ export default {
       }
     },
     // Event edition
-    async openEditionModal (event) {
-      const isAllowed = this.canEditEvent({ auxiliaryId: get(event, 'auxiliary._id'), sectorId: event.sector });
-      if (!isAllowed) return NotifyWarning('Vous n\'avez pas les droits pour réaliser cette action');
-
+    async openAbsenceEditionModal (event) {
       this.selectedAuxiliary = event.auxiliary ? event.auxiliary : { picture: {}, identity: { lastname: '' } };
-      await this.formatEditedEvent(event);
-
-      this.editionModal = true;
+      await this.openEditionModal(event);
     },
   },
 };

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -19,7 +19,8 @@
       :edition-modal="editionModal" :internal-hours="internalHours" :active-auxiliaries="activeAuxiliaries"
       :customers="customers" @hide="resetEditionForm" @delete-document="validateDocumentDeletion"
       @document-uploaded="documentUploaded" @close="closeEditionModal" @delete-event="validateEventDeletion"
-      @delete-event-repetition="validationDeletionEventRepetition" :person-key="personKey" @submit="updateEvent" />
+      @delete-event-repetition="validationDeletionEventRepetition" :person-key="personKey" @submit="updateEvent"
+      :event-histories="editedEventHistories" :histories-loading="historiesLoading" />
   </q-page>
 </template>
 

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -14,7 +14,8 @@
     <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :edited-event.sync="editedEvent"
       :edition-modal="editionModal" :active-auxiliaries="activeAuxiliaries" :customers="customers"
       @reset="resetEditionForm" @submit="updateEvent" @close="closeEditionModal" :person-key="personKey"
-      @delete-event-repetition="validationDeletionEventRepetition" @delete-event="validateEventDeletion" />
+      @delete-event-repetition="validationDeletionEventRepetition" @delete-event="validateEventDeletion"
+      :event-histories="editedEventHistories" :histories-loading="historiesLoading" />
   </q-page>
 </template>
 

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -13,7 +13,7 @@
     <!-- Event edition modal -->
     <ni-event-edition-modal :validations="$v.editedEvent" :loading="loading" :edited-event.sync="editedEvent"
       :edition-modal="editionModal" :active-auxiliaries="activeAuxiliaries" :customers="customers"
-      @reset="resetEditionForm" @submit="updateEvent" @close="closeEditionModal" :person-key="personKey"
+      @hide="resetEditionForm" @submit="updateEvent" @close="closeEditionModal" :person-key="personKey"
       @delete-event-repetition="validationDeletionEventRepetition" @delete-event="validateEventDeletion"
       :event-histories="editedEventHistories" :histories-loading="historiesLoading" />
   </q-page>


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach/auxiliaire

- Cas d'usage : Lorsque j'ouvre une modale d'edition d'evenement, les champs sont desactivés, et s'activent quand les  historiques sont recus. (Pour tester, ne pas hesiter a ralentir artificiellement la connexion avec les devtools)
Tester : 
- sur le planning auxiliaire (cote coach et auxiliaire)
- sur le planning beneficiaire (cote coach et auxiliaire)
- sur l'agenda auxiliaire (cote auxiliaire)
- sur la page absence (cote coach)