### PR TITLE
Com 2192

### DIFF
--- a/public/favicon_metadata/site.webmanifest
+++ b/public/favicon_metadata/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "",
     "icons": [
         {
-            "src": "https://storage.googleapis.com/compani-main/android-chrome-192x192.png",
+            "src": "https://storage.googleapis.com/compani-main/manifest/blue-android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "https://storage.googleapis.com/compani-main/android-chrome-512x512.png",
+            "src": "https://storage.googleapis.com/compani-main/manifest/blue-android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/src/core/components/Banner.vue
+++ b/src/core/components/Banner.vue
@@ -16,7 +16,7 @@ export default {
   data () {
     const interfaceType = /\/ad\//.test(this.$router.currentRoute.path) ? VENDOR : CLIENT;
     return {
-      backgroundClass: interfaceType === CLIENT ? 'bg-grey-300' : 'bg-peach-200',
+      backgroundClass: interfaceType === CLIENT ? 'bg-copper-grey-200' : 'bg-peach-200',
     };
   },
 };

--- a/src/core/components/Button.vue
+++ b/src/core/components/Button.vue
@@ -8,7 +8,7 @@
 export default {
   name: 'Button',
   props: {
-    color: { type: String, default: 'grey' },
+    color: { type: String, default: 'copper-500' },
     disable: { type: Boolean, default: false },
     flat: { type: Boolean, default: true },
     href: { type: String, default: '' },

--- a/src/core/components/CompaniHeader.vue
+++ b/src/core/components/CompaniHeader.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="row justify-between signup-header-padding bg-white items-center col-12">
-    <img style="height: 30px" :src="PINK_LOGO" alt="Logo Compani">
+    <img style="height: 30px" :src="BLUE_TEXT_LOGO" alt="Logo Compani">
     <p class="no-margin" style="font-size: 0.8rem; text-align: right">Espace Alenvi</p>
   </div>
 </template>
 
 <script>
-import { PINK_LOGO } from '@data/constants';
+import { BLUE_TEXT_LOGO } from '@data/constants';
 
 export default {
   name: 'CompaniHeader',
   data () {
     return {
-      PINK_LOGO,
+      BLUE_TEXT_LOGO,
     };
   },
 };

--- a/src/core/components/ProfileTabs.vue
+++ b/src/core/components/ProfileTabs.vue
@@ -44,7 +44,7 @@ export default {
       & > .q-tab__indicator
         color: $primary
     /deep/.q-tab__indicator
-      color: $grey-300
+      color: $copper-grey-300
       opacity: 1
     .q-tab-panels
       background-color: inherit
@@ -84,7 +84,7 @@ export default {
         & :not(.q-tab--active)
           & .q-tab__content
             & .q-tab__label
-              color: $grey-800
+              color: $copper-grey-800
         & .q-tab--active
           & .q-tab__content
             & .q-tab__label

--- a/src/core/components/courses/CourseCell.vue
+++ b/src/core/components/courses/CourseCell.vue
@@ -153,7 +153,7 @@ export default {
     display: flex;
     flex-wrap: wrap;
     font-size: 12px;
-    color: $grey-400;
+    color: $copper-grey-600;
   .item-section-container
     display: flex;
   .q-item__section--side
@@ -181,14 +181,11 @@ export default {
   .slots
     height: 10px;
     flex: 1;
-    background-color: $pink-100;
-    border: solid 1px $pink-400;
+    background-color: $copper-300;
     &-happened
       background-color: $primary;
-      border: none;
     &-to-plan
       background-color: $secondary;
-      border: none;
 
   .additional-infos
     color: $primary;

--- a/src/core/components/courses/CourseContainer.vue
+++ b/src/core/components/courses/CourseContainer.vue
@@ -24,7 +24,7 @@ export default {
 
     return {
       interfaceType,
-      backgroundClass: interfaceType === CLIENT ? 'bg-grey-300' : 'bg-peach-200',
+      backgroundClass: interfaceType === CLIENT ? 'bg-copper-grey-200' : 'bg-peach-200',
     };
   },
   computed: {

--- a/src/core/components/courses/OpenQuestionChart.vue
+++ b/src/core/components/courses/OpenQuestionChart.vue
@@ -28,7 +28,7 @@ export default {
 .card
   padding: 16px 32px
 .subtitle
-  color: $grey-800
+  color: $copper-grey-800
   font-size: 14px
 .answer-container
   border-radius: 3px !important

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -11,8 +11,8 @@
               :style="col.style">
               <template v-if="col.name === 'actions'">
                 <div class="row no-wrap table-actions justify-end">
-                  <ni-button icon="file_download" color="primary" type="a" target="_blank"
-                    :href="props.row.file.link" :disable="!props.row.file.link" />
+                  <ni-button icon="file_download" color="primary" type="a" :href="props.row.file.link"
+                    :disable="!props.row.file.link" />
                   <ni-button v-if="canUpdate" icon="delete" color="primary"
                     @click="validateAttendanceSheetDeletion(props.row)" :disable="!props.row.file.link" />
                 </div>

--- a/src/core/components/courses/QuestionAnswerChart.vue
+++ b/src/core/components/courses/QuestionAnswerChart.vue
@@ -48,7 +48,7 @@ export default {
   padding: 16px 32px
 
 .subtitle
-  color: $grey-800
+  color: $copper-grey-800
   font-size: 14px
 
 .percentage

--- a/src/core/components/courses/QuestionnaireAnswersCell.vue
+++ b/src/core/components/courses/QuestionnaireAnswersCell.vue
@@ -34,7 +34,7 @@ export default {
     border-radius: 8px
   .type
     font-size: 14px;
-    color: $grey-800;
+    color: $copper-grey-800;
   .name
     word-break: break-word;
     height: 48px;
@@ -42,6 +42,6 @@ export default {
     border-radius: 8px
     width: 100px
     text-align: center
-    color: $grey-800
-    background-color: $grey-300
+    color: $copper-grey-800
+    background-color: $copper-grey-300
 </style>

--- a/src/core/components/courses/QuestionnaireCell.vue
+++ b/src/core/components/courses/QuestionnaireCell.vue
@@ -3,12 +3,12 @@
     <q-card-section>
       <div class="row justify-between">
         <div class="version">Version {{ index }}</div>
-        <div v-if="questionnaire.status === DRAFT" class="draft">
-          <q-icon size="12px" name="edit" color="orange-500" />
+        <div v-if="questionnaire.status === DRAFT" class="info-warning draft">
+          <q-icon size="12px" name="edit" />
           Brouillon
         </div>
-        <div v-else class="published">
-          <q-icon size="12px" name="check_circle" color="green-800" />
+        <div v-else class="published info-active">
+          <q-icon size="12px" name="check_circle" />
           Publié
         </div>
       </div>
@@ -43,13 +43,11 @@ export default {
       cursor: pointer
   .version
     font-size: 14px;
-    color: $grey-800;
+    color: $copper-grey-800;
   .draft
     font-size: 12px;
-    color: $orange-500;
   .published
     font-size: 12px;
-    color: $green-800;
   .name
     margin 16px 0px;
     word-break: break-word;

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -364,7 +364,7 @@ export default {
   &-content
     margin: 5px 10px
     display: flex
-    background-color: $pink-100
+    background-color: $copper-100
     flex-direction: column
     border-radius: 4px !important
   &-content > .q-item

--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -53,7 +53,7 @@ export default {
   padding: 16px 32px
 
 .subtitle
-  color: $grey-800
+  color: $copper-grey-800
   font-size: 14px
 
 .percentage

--- a/src/core/components/form/DateInput.vue
+++ b/src/core/components/form/DateInput.vue
@@ -8,7 +8,7 @@
       :disable="disable" :class="{ 'borders': inModal }" :error-message="errorMessage" @blur="blur" ref="dateInput"
       @focus="focus">
       <template #append>
-        <q-icon name="event" class="cursor-pointer" @click="focus" color="grey-600">
+        <q-icon name="event" class="cursor-pointer" @click="focus" color="copper-grey-600">
           <q-menu ref="qDateMenu" anchor="bottom right" self="top right">
             <q-date minimal :value="date" @input="select" :options="dateOptions" :disable="disable" />
           </q-menu>
@@ -81,10 +81,6 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-  .borders
-    /deep/ .q-field__control
-      border: 1px solid $grey-300
-
   .q-input
     /deep/ .q-field__control
       font-size: 16px

--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -76,7 +76,7 @@ export default {
 
 <style lang="stylus" scoped>
   .date-container-borders
-    border: solid 1px $grey-300
+    border: solid 1px $copper-grey-300
     border-radius: 3px
 
   /deep/ .q-field__append

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -113,7 +113,7 @@ export default {
 <style lang="stylus" scoped>
   .datetime-container
     width: 100%
-    border: 1px solid $grey-300
+    border: 1px solid $copper-grey-300
     border-radius: 3px;
     @media screen and (min-width: 768px)
       flex-wrap: nowrap;

--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -115,7 +115,7 @@ export default {
   /deep/ .q-uploader
     width: 100%
     &--bordered
-      border: 1px solid $grey-300
+      border: 1px solid $copper-grey-300
     .q-uploader__list
       display: none
     .q-uploader__header-content
@@ -123,7 +123,7 @@ export default {
       height: 38px
       margin: 0
       .q-btn__content
-        color: $grey-400
+        color: $copper-grey-400
     .q-btn
       margin: 0
       padding: 0

--- a/src/core/components/form/Input.vue
+++ b/src/core/components/form/Input.vue
@@ -29,8 +29,7 @@
           <q-icon size="xs" :name="icon" />
         </template>
         <template v-if="isPassword" #append>
-          <ni-button :icon="isPassword && showPassword ? 'visibility' : 'visibility_off'" color="middle-grey"
-            @click.native="showPassword = !showPassword" size="sm" />
+          <ni-button :icon="passwordIcon" @click="toggleIcon" size="sm" />
         </template>
       </q-input>
     </template>
@@ -82,8 +81,14 @@ export default {
     inputType () {
       return this.isPassword && this.showPassword ? 'text' : this.type;
     },
+    passwordIcon () {
+      return this.isPassword && this.showPassword ? 'visibility' : 'visibility_off';
+    },
   },
   methods: {
+    toggleIcon () {
+      this.showPassword = !this.showPassword;
+    },
     updateInputFile () {
       this.$emit('input', this.$refs.inputFile.files[0]);
     },
@@ -123,8 +128,6 @@ export default {
       height: 100%
       width: 100%
       font-size: 0
-    &.borders
-      border: 1px solid $grey-300
   .file-error
     color: $secondary
     line-height: 1

--- a/src/core/components/form/TimeInput.vue
+++ b/src/core/components/form/TimeInput.vue
@@ -9,7 +9,8 @@
       :error-message="errorMessage" :error="error" :disable="disable" @blur="onBlur" :rules="['time']" mask="time"
       data-cy="time-input">
       <template #append>
-        <q-icon name="far fa-clock" class="cursor-pointer" @click.native="selectTime = !selectTime" color="grey-600">
+        <q-icon name="far fa-clock" class="cursor-pointer" @click.native="selectTime = !selectTime"
+          color="copper-grey-600">
           <q-menu ref="qTimeMenu" anchor="bottom right" self="top right">
             <q-list dense padding>
               <q-item v-for="(hour, index) in hoursOptions" :key="index" clickable @click="select(hour.value)"

--- a/src/core/components/menu/SideMenuFooter.vue
+++ b/src/core/components/menu/SideMenuFooter.vue
@@ -47,6 +47,11 @@ export default {
   components: {
     'ni-button': Button,
   },
+  data () {
+    return {
+      interfaceLogo: 'https://storage.googleapis.com/compani-main/icons/blue_icon_small.png',
+    };
+  },
   computed: {
     ...mapGetters({
       clientRole: 'main/getClientRole',
@@ -58,11 +63,6 @@ export default {
     userCanFeedback () {
       return [...COACH_ROLES, AUXILIARY, PLANNING_REFERENT].includes(this.clientRole) ||
         [TRAINER, VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(this.vendorRole);
-    },
-    interfaceLogo () {
-      return this.interfaceType === CLIENT
-        ? 'https://storage.googleapis.com/compani-main/favicon_bordeaux-32x32.png'
-        : 'https://storage.googleapis.com/compani-main/favicon-32x32.png';
     },
     accessBothInterface () {
       return this.clientRole && this.vendorRole;

--- a/src/core/components/menu/SideMenuFooter.vue
+++ b/src/core/components/menu/SideMenuFooter.vue
@@ -8,14 +8,14 @@
       <div class="sidemenu-footer-icons">
         <q-item-section v-if="userCanFeedback">
           <ni-button icon="mdi-lightbulb-on-outline" color="secondary" size="sm"
-            @click.native="openExtenalUrl('https://compani.atlassian.net/servicedesk/customer/portal/2')" />
+            @click="openExtenalUrl('https://compani.atlassian.net/servicedesk/customer/portal/2')" />
         </q-item-section>
         <q-item-section v-if="isAuxiliaryWithCompany">
           <ni-button class="messenger" icon="mdi-facebook-messenger" color="blue" size="sm"
             @click.native="clickHandler" />
         </q-item-section>
         <q-item-section>
-          <ni-button class="person" icon="person" @click.native="goToProfile" size="sm" />
+          <ni-button class="person" icon="person" @click="goToProfile" size="sm" />
         </q-item-section>
       </div>
     </q-item>

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -10,11 +10,11 @@
               <div class="text-primary date">{{ col.month }}</div>
               <div class="number">{{ col.day }}</div>
               <div class="text-weight-bold date">{{ col.weekDay }}</div>
-              <div class="text-grey">
+              <div class="text-copper-grey-400">
                 <div>{{ col.startHour }}</div>
                 <div>{{ col.endHour }}</div>
               </div>
-              <div class="text-grey-800">
+              <div class="text-copper-grey-800">
                 <q-icon name="supervisor_account" />
                 {{ traineesCount(col.slot) }}
               </div>
@@ -297,17 +297,17 @@ export default {
   td:first-child
     background-color: white
   th
-    border-right: 1px solid $grey-200
+    border-right: 1px solid $copper-grey-200
   tr:first-child
     td:first-child
       .rows
-        border-top: 1px solid $grey-200
+        border-top: 1px solid $copper-grey-200
         padding-top: 8px
         margin-right: 16px
   tr:last-child
     td:first-child
       .rows
-        border-bottom: 1px solid $grey-200
+        border-bottom: 1px solid $copper-grey-200
         padding-bottom: 8px
         margin-right: 16px
 

--- a/src/core/components/table/Pagination.vue
+++ b/src/core/components/table/Pagination.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row justify-between full-width text-grey-600">
+  <div class="row justify-between full-width text-copper-grey-600">
     <div class="row items-center">
       <q-btn-toggle class="on-left no-shadow" :value="rowsPerPage" :options="rowsPerPageOptions" size="12px"
         toggle-text-color="primary" toggle-color="white" no-caps dense @input="update($event, 'rowsPerPage')" />
@@ -83,9 +83,9 @@ export default {
 <style lang="stylus" scoped>
   /deep/ .q-btn-group
     & > .q-btn-item:first-child
-      border: 1px solid $grey-300
+      border: 1px solid $copper-grey-300
     & > .q-btn-item:not(:first-child)
-      border: 1px solid $grey-300
+      border: 1px solid $copper-grey-300
       border-left: none
     & > .q-btn-item:last-child
       font-weight: bold

--- a/src/core/components/table/PrefixedCellContent.vue
+++ b/src/core/components/table/PrefixedCellContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row no-wrap items-center">
-    <q-icon v-if="cellValue > 0" name="mdi-plus-circle-outline" color="grey" class="balance-icon" />
+    <q-icon v-if="cellValue > 0" name="mdi-plus-circle-outline" color="copper-grey-400" class="balance-icon" />
     <q-icon v-if="cellValue < 0" name="mdi-minus-circle-outline" color="secondary" class="balance-icon" />
     <div>{{ content }}</div>
   </div>

--- a/src/core/components/table/ResponsiveTable.vue
+++ b/src/core/components/table/ResponsiveTable.vue
@@ -22,7 +22,7 @@
         </slot>
       </template>
       <template #no-data>
-        <div class="full-width row text-grey-800 justify-center">
+        <div class="full-width row text-copper-grey-800 justify-center">
           <span class="text-italic q-pb-sm" style="font-size: 0.8rem">{{ noDataLabel }}</span>
           <q-separator />
         </div>

--- a/src/core/components/table/SimpleTable.vue
+++ b/src/core/components/table/SimpleTable.vue
@@ -32,7 +32,7 @@
         <slot name="bottom-row" :props="props" />
       </template>
       <template #no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm text-grey-800">
+        <div v-show="!loading" class="full-width row q-gutter-sm text-copper-grey-800">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/components/table/TableList.vue
+++ b/src/core/components/table/TableList.vue
@@ -14,7 +14,7 @@
         </q-tr>
       </template>
       <template #no-data>
-        <div v-show="!loading" class="full-width row q-gutter-sm text-grey-800">
+        <div v-show="!loading" class="full-width row q-gutter-sm text-copper-grey-800">
           <span>Pas de données disponibles</span>
         </div>
       </template>

--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -4,7 +4,7 @@ export const IDENTIFICATION = 'identification';
 export const CONTRACT_END = 'contract_end';
 
 // MEDIA
-export const PINK_LOGO = 'https://storage.googleapis.com/compani-main/compani_texte_rose_1000.png';
+export const BLUE_TEXT_LOGO = 'https://storage.googleapis.com/compani-main/icons/compani_texte_bleu.png';
 export const DOC_EXTENSIONS = 'image/jpg, image/jpeg, application/pdf';
 export const IMAGE_EXTENSIONS = 'image/jpg, image/jpeg, image/png';
 export const VIDEO_EXTENSIONS = 'video/*';

--- a/src/core/mixins/sideMenuMixin.js
+++ b/src/core/mixins/sideMenuMixin.js
@@ -1,20 +1,16 @@
 import { mapState } from 'vuex';
 import get from 'lodash/get';
-import { CLIENT } from '@data/constants';
+import { BLUE_TEXT_LOGO } from '../data/constants';
 
 export const sideMenuMixin = {
   data () {
     return {
       userFirstname: '',
+      companiLogo: BLUE_TEXT_LOGO,
     };
   },
   computed: {
     ...mapState('main', ['loggedUser']),
-    companiLogo () {
-      return this.interfaceType === CLIENT
-        ? 'https://storage.googleapis.com/compani-main/compani_texte_rose.png'
-        : 'https://storage.googleapis.com/compani-main/compani_texte_bordeaux.png';
-    },
   },
   watch: {
     loggedUser () {

--- a/src/core/pages/DocumentSigned.vue
+++ b/src/core/pages/DocumentSigned.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="signed">
-    <p><img :src="PINK_LOGO" alt="Logo Compani" style="max-width: 250px"></p>
+    <p><img :src="BLUE_TEXT_LOGO" alt="Logo Compani" style="max-width: 250px"></p>
     <p>{{ acknowledgement }}</p>
     <p><q-btn v-if="$q.platform.is.mobile" color="primary" label="Accueil" icon="home" @click="$router.push('/')" /></p>
   </div>
 </template>
 
 <script>
-import { PINK_LOGO } from '@data/constants';
+import { BLUE_TEXT_LOGO } from '@data/constants';
 
 export default {
   name: 'DocumentSigned',
@@ -16,7 +16,7 @@ export default {
   },
   data () {
     return {
-      PINK_LOGO,
+      BLUE_TEXT_LOGO,
     };
   },
   computed: {

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro')
+@import url('https://fonts.googleapis.com/css?family=Avenir')
 @import './input'
 @import './drawer'
 @import './btn'
@@ -14,8 +14,8 @@
 @import './history'
 
 body
-  color: black
-  font-family: 'Source Sans Pro', 'Roboto', 'Helvetica', 'Arial'
+  color: $copper-grey-900
+  font-family: 'Avenir'
   font-size: 16px
 
   @media screen and (max-width: 767px)
@@ -31,7 +31,7 @@ div h4:only-child
   margin-bottom: 0
 
 .client-background
-  background: $grey-100
+  background: $copper-grey-100
 
 .vendor-background
   background: $peach-100

--- a/src/css/chip.styl
+++ b/src/css/chip.styl
@@ -8,7 +8,7 @@
       left: 50%
       transform: translate(-50%, -50%)
   .q-chip
-    background: $grey-800
+    background: $copper-grey-800
     width: 100%
     padding: 0 10px
     justify-content: flex-end
@@ -31,7 +31,7 @@
   .avatar
     z-index: 2
     box-shadow: none
-    border: 1px solid $grey-600
+    border: 1px solid $copper-grey-600
     @media screen and (min-width: $breakpoint-md-min)
       width: 2.5rem
       height: 2.5rem

--- a/src/css/colors.styl
+++ b/src/css/colors.styl
@@ -1,56 +1,101 @@
-// over-riding default grey color as grey-400
+// over-riding default grey color as copper-grey-400
 .text-grey
-  color: $grey-400
+  color: $copper-grey-400
 .bg-grey
-  background: $grey-400
+  background: $copper-grey-400
 
 // adding our other shades of grey in quasar color palette
-//GREY
-.text-grey-800
-  color: $grey-800
-.bg-grey-800
-  background: $grey-800
+// COPPER-GREY
+.text-copper-grey-900
+  color: $copper-grey-900
+.bg-copper-grey-900
+  background: $copper-grey-900
 
-.text-grey-600
-  color: $grey-600
-.bg-grey-600
-  background: $grey-600
+.text-copper-grey-800
+  color: $copper-grey-800
+.bg-copper-grey-800
+  background: $copper-grey-800
 
-.text-grey-300
-  color: $grey-300
-.bg-grey-300
-  background: $grey-300
+.text-copper-grey-700
+  color: $copper-grey-700
+.bg-copper-grey-700
+  background: $copper-grey-700
 
-.text-grey-400
-  color: $grey-400
-.bg-grey-400
-  background: $grey-400
+.text-copper-grey-600
+  color: $copper-grey-600
+.bg-copper-grey-600
+  background: $copper-grey-600
 
-.text-grey-100
-  color: $grey-100
-.bg-grey-100
-  background: $grey-100
+.text-copper-grey-500
+  color: $copper-grey-500
+.bg-copper-grey-500
+  background: $copper-grey-500
 
-// PINK
-.text-pink-800
-  color: $pink-800
-.bg-grey-800
-  background: $pink-800
+.text-copper-grey-400
+  color: $copper-grey-400
+.bg-copper-grey-400
+  background: $copper-grey-400
 
-.text-pink-500
-  color: $pink-500
-.bg-pink-500
-  background: $pink-500
+.text-copper-grey-300
+  color: $copper-grey-300
+.bg-copper-grey-300
+  background: $copper-grey-300
 
-.text-pink-400
-  color: $pink-400
-.bg-pink-400
-  background: $pink-400
+.text-copper-grey-200
+  color: $copper-grey-200
+.bg-copper-grey-200
+  background: $copper-grey-200
 
-.text-pink-100
-  color: $pink-100
-.bg-pink-100
-  background: $pink-100
+.text-copper-grey-100
+  color: $copper-grey-100
+.bg-copper-grey-100
+  background: $copper-grey-100
+
+// COPPER
+.text-copper-900
+  color: $copper-900
+.bg-copper-900
+  background: $copper-900
+
+.text-copper-800
+  color: $copper-800
+.bg-copper-800
+  background: $copper-800
+
+.text-copper-700
+  color: $copper-700
+.bg-copper-700
+  background: $copper-700
+
+.text-copper-600
+  color: $copper-600
+.bg-copper-600
+  background: $copper-600
+
+.text-copper-500
+  color: $copper-500
+.bg-copper-500
+  background: $copper-500
+
+.text-copper-400
+  color: $copper-400
+.bg-copper-400
+  background: $copper-400
+
+.text-copper-300
+  color: $copper-300
+.bg-copper-300
+  background: $copper-300
+
+.text-copper-200
+  color: $copper-200
+.bg-copper-200
+  background: $copper-200
+
+.text-copper-100
+  color: $copper-100
+.bg-copper-100
+  background: $copper-100
 
 // PEACH
 .text-peach-100
@@ -63,16 +108,62 @@
 .bg-peach-200
   background: $peach-200
 
-// OTHER
-.text-green-800
-  color: $green-800
-.bg-green-800
-  background: $green-800
+// ORANGE
+.text-orange-900
+  color: $orange-900
+.bg-orange-900
+  background: $orange-900
+
+.text-orange-800
+  color: $orange-800
+.bg-orange-800
+  background: $orange-800
+
+.text-orange-700
+  color: $orange-700
+.bg-orange-700
+  background: $orange-700
+
+.text-orange-600
+  color: $orange-600
+.bg-orange-600
+  background: $orange-600
 
 .text-orange-500
   color: $orange-500
 .bg-orange-500
   background: $orange-500
+
+.text-orange-400
+  color: $orange-400
+.bg-orange-400
+  background: $orange-400
+
+.text-orange-300
+  color: $orange-300
+.bg-orange-300
+  background: $orange-300
+
+.text-orange-200
+  color: $orange-200
+.bg-orange-200
+  background: $orange-200
+
+.text-orange-100
+  color: $orange-100
+.bg-orange-100
+  background: $orange-100
+
+.text-orange-50
+  color: $orange-50
+.bg-orange-50
+  background: $orange-50
+
+// OTHER
+.text-green-800
+  color: $green-800
+.bg-green-800
+  background: $green-800
 
 .text-red-800
   color: $red-800

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -29,14 +29,14 @@
             line-height: 20px
           & .q-item__section--side
             padding: 0
-            color: $grey-600
+            color: $copper-grey-600
           & .q-item__section--avatar
             min-width: 24px
           & .q-item__label
             font-size: 1rem
       & .q-item
         & .q-item__section--side
-          color: $grey-600
+          color: $copper-grey-600
         & .q-item__section--avatar
           min-width: 38px
 
@@ -46,12 +46,12 @@
         align-items: flex-end
         & .q-item
           min-height: 40px
-          border-top: 1px solid $grey-100
+          border-top: 1px solid $copper-grey-100
           padding: 6px 2px 0px 16px
         & .sidemenu-footer-user
           font-size: 11px
           font-weight: bold
-          color: $grey-400
+          color: $copper-grey-400
         & .sidemenu-footer-icons
           margin-right: 10px
           display: flex

--- a/src/css/history.styl
+++ b/src/css/history.styl
@@ -7,7 +7,7 @@
     display: block
     margin: auto
     width: 95%
-    border-bottom: 1px solid $grey-100
+    border-bottom: 1px solid $copper-grey-100
   &-cell
     margin: 2px 10px 0 2px
     padding: 4px
@@ -17,15 +17,15 @@
       flex: 1;
   &-info
     font-weight: bold
-    color: $grey-800
+    color: $copper-grey-800
     white-space: pre-line
   &-details
     font-size: 12px
-    color: $grey-800
+    color: $copper-grey-800
     margin: 3px 0 5px
     white-space: pre-line
   &-signature
-    color: $grey-800
+    color: $copper-grey-800
     font-size: 12px
     font-style: italic
     display: flex

--- a/src/css/icon.styl
+++ b/src/css/icon.styl
@@ -6,14 +6,10 @@
   margin: 0 20px 0 3px;
   &-active
     background: $green-800
-  &-inactive
-    background: $pink-800
   &-error
     background: $orange-500
-  &-stopped
-    background: $red-800
   &-archived
-    background: $grey-400
+    background: $copper-grey-400
 
 .balance-icon
   cursor: default !important
@@ -23,4 +19,9 @@
   &-active
     color: $green-800
   &-warning
+    color: $orange-700
+    i
+      color: $orange-500
+i
+  &.info-warning
     color: $orange-500

--- a/src/css/input.styl
+++ b/src/css/input.styl
@@ -33,7 +33,7 @@
 
 .borders
   .q-field__control
-    border: 1px solid $grey-300
+    border: 1px solid $copper-grey-300
     border-radius: 3px
 
 .q-input

--- a/src/css/planning.styl
+++ b/src/css/planning.styl
@@ -18,31 +18,31 @@
     width: 100%
     justify-content: space-between
     font-size: 0.6875rem
-    color: $grey-800
+    color: $copper-grey-800
   &-billed
     position: absolute;
     right: 0;
     bottom: 0;
     width: fit-content;
   &-intervention
-    background: $pink-100
+    background: $copper-100
   &-internal_hour
-    background: $pink-400
+    background: $copper-400
   &-absence
-    background: $grey-100
+    background: $copper-grey-100
   &-unavailability
     background: repeating-linear-gradient(
       45deg,
-      $grey-100,
-      $grey-100 3px,
+      $copper-grey-100,
+      $copper-grey-100 3px,
       white 3px,
       white 7px
     )
   &-cancelled
     background: repeating-linear-gradient(
       45deg,
-      $pink-100,
-      $pink-100 3px,
+      $copper-100,
+      $copper-100 3px,
       white 3px,
       white 7px
     )
@@ -55,15 +55,15 @@
   border-style: hidden;
 
   td
-    border-left: 1px solid $grey-300
-    border-right: 1px solid $grey-300
+    border-left: 1px solid $copper-grey-300
+    border-right: 1px solid $copper-grey-300
     padding: 0px 5px 5px 5px;
   tr:not(:first-child)
     td:before
       content: '';
       display: block;
       width: 98%;
-      border-bottom: 1px solid $grey-300
+      border-bottom: 1px solid $copper-grey-300
 
   .days
     &-header
@@ -74,7 +74,7 @@
         align-items: center;
     &-name
       font-size: 1.125rem
-      color: $grey-400
+      color: $copper-grey-400
     &-number
       font-size: 1.5rem
       font-weight: 600
@@ -102,7 +102,7 @@
         left: 0;
         bottom: 0;
         top: 6px;
-        border-right: 1px solid $grey-300;
+        border-right: 1px solid $copper-grey-300;
     .bottom-border
       &:after
         content: ''
@@ -110,12 +110,12 @@
         left: 6px
         right: 6px
         bottom: 0
-        border-bottom: 1px solid $grey-300;
+        border-bottom: 1px solid $copper-grey-300;
   &-header
     font-size: 1.2em
     position: -webkit-sticky
     position: sticky
-    background-color: $grey-100
+    background-color: $copper-grey-100
     top: 0
     left: 0
     right: 0
@@ -158,7 +158,7 @@
     padding: 4px
   &-hour
     position: absolute
-    color: $grey-300
+    color: $copper-grey-300
     font-size: 12px
     bottom: -3px
 
@@ -183,10 +183,10 @@
 
 .customer
   &-info
-    background: $grey-300
+    background: $copper-grey-300
     padding: 5px 25px
     & .q-if-inverted
-      background: $grey-300 !important
+      background: $copper-grey-300 !important
       border: none
   &-address
     margin-right: 6px

--- a/src/css/quasar.variables.styl
+++ b/src/css/quasar.variables.styl
@@ -1,20 +1,42 @@
-$primary = $pink-500
+$primary = $copper-500
 $secondary = $orange-500
 $negative = $red-800
 
-// GREY
-$grey-800 = #4E4E4E
-$grey-600 = #737373
-$grey-400 = #9B9B9B
-$grey-300 = #D0D0D0
-$grey-200 = #E0E0E0
-$grey-100 = #EEEEEE
+// COPPER_GREY
+$copper-grey-900 = #0F232A
+$copper-grey-800 = #1E343B
+$copper-grey-700 = #334C55
+$copper-grey-600 = #476069
+$copper-grey-500 = #64818B
+$copper-grey-400 = #94AFB8
+$copper-grey-300 = #CBDBE1
+$copper-grey-200 = #E2ECF0
+$copper-grey-100 = #F3F6F7
+$copper-grey-50 = #F9FBFB;
 
-// PINK
-$pink-800 = #8D0E56
-$pink-500 = #E2007A
-$pink-400 = #E6C6D6
-$pink-100 = #FFECF6
+// COPPER
+$copper-900 = #000F1F
+$copper-800 = #00223B
+$copper-700 = #003A57
+$copper-600 = #005774
+$copper-500 = #1D7C8F
+$copper-400 = #45A5AD
+$copper-300 = #78C7C9
+$copper-200 = #AAE3DE
+$copper-100 = #DAF2EE
+$copper-50 = #F0FAF7
+
+// ORANGE
+$orange-900 = #78350F
+$orange-800 = #92400E
+$orange-700 = #B45309
+$orange-600 = #D97706
+$orange-500 = #F5970B
+$orange-400 = #F9B233
+$orange-300 = #FCC74D
+$orange-200 = #FDDE8A
+$orange-100 = #FEF1C7
+$orange-50 = #FFFBEB
 
 // PEACH
 $peach-200 = #EBD2B8
@@ -22,9 +44,8 @@ $peach-100 = #FFEDDA
 
 // OTHER
 $green-800 = #0F9319
-$orange-500 = #F29400
 $red-800 = #DB2828
 
 // SEPARATOR
-$separator-color = $grey-200
-$table-border-color = $grey-300
+$separator-color = $copper-grey-200
+$table-border-color = $copper-grey-300

--- a/src/css/table.styl
+++ b/src/css/table.styl
@@ -208,7 +208,7 @@
       &:hover
         background: white
       .avatar
-        border: 1px solid $grey-400
+        border: 1px solid $copper-grey-400
         width: 30px
         height: 30px
       &:not(.q-tr--no-hover)
@@ -216,7 +216,7 @@
           cursor: pointer
           background: white !important
           box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.2)
-          border: 1px solid $grey-300
+          border: 1px solid $copper-grey-300
     td
       font-weight: 400
       border: none
@@ -252,7 +252,7 @@
 
 .client-header
   thead tr th
-    background-color: $grey-100
+    background-color: $copper-grey-100
 
 .vendor-header
   thead tr th

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -11,12 +11,12 @@
     <meta name="msapplication-config" content="favicon_metadata/browserconfig.xml">
     <meta name="msapplication-TileColor" content="#dedede">
     <meta name="theme-color" content="#ffffff">
-    <link rel="apple-touch-icon" sizes="180x180" href="https://storage.googleapis.com/compani-main/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="https://storage.googleapis.com/compani-main/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="https://storage.googleapis.com/compani-main/favicon-16x16.png">
-    <link rel="manifest" href="favicon_metadata/site.webmanifest">
-    <link rel="mask-icon" href="https://storage.googleapis.com/compani-main/favicon.ico">
-    <link rel="shortcut icon" href="https://storage.googleapis.com/compani-main/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://storage.googleapis.com/compani-main/icons/blue-apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://storage.googleapis.com/compani-main/icons/blue_favicon_32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://storage.googleapis.com/compani-main/icons/blue_favicon_16x16.png">
+    <link rel="manifest" href="favicon_metadata/blue_site.webmanifest">
+    <link rel="mask-icon" href="https://storage.googleapis.com/compani-main/icons/blue_favicon.ico">
+    <link rel="shortcut icon" href="https://storage.googleapis.com/compani-main/icons/blue_favicon.ico">
   </head>
   <body>
     <!-- DO NOT touch the following DIV -->

--- a/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
+++ b/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
@@ -15,8 +15,8 @@
     <div class="row profile-info">
       <div class="col-6 q-pl-lg">
         <div class="row items-center">
-          <div :class="['dot', userActivity.active ? 'dot-active' : 'dot-inactive']" />
-          <div>{{ userActivity.status }}</div>
+          <div :class="['dot', userActivity.active ? 'dot-active' : 'dot-error']" />
+          <div :class="[userActivity.active ? 'text-green-800' : 'text-orange-700']">{{ userActivity.status }}</div>
         </div>
         <div class="row items-center">
           <q-icon name="restore" class="q-mr-md" size="1rem" />
@@ -25,7 +25,7 @@
       </div>
       <div class="q-pl-lg col-6 row">
         <div class="relative-position">
-          <q-icon size="36px" name="phone_iphone" color="grey-2" />
+          <q-icon size="36px" name="phone_iphone" color="copper-grey-300" />
           <q-icon v-if="!userProfile.isConfirmed" class="chip-icon" name="cancel" color="secondary" size="16px" />
           <q-icon v-if="userProfile.isConfirmed" class="chip-icon" name="check_circle" color="green-800" size="16px" />
         </div>
@@ -189,7 +189,7 @@ export default {
   .avatar
     width: 59px
     height: 59px
-    border: 1px solid $grey-400
+    border: 1px solid $copper-grey-400
 
   .send-message-link
     color: $primary

--- a/src/modules/client/components/contracts/ContractsCell.vue
+++ b/src/modules/client/components/contracts/ContractsCell.vue
@@ -14,13 +14,13 @@
               :style="col.style">
               <template v-if="col.name === 'contractEmpty'">
                 <div class="row justify-center table-actions">
-                  <q-btn flat round small color="primary" @click="dlTemplate(props.row, contract, contractIndex)"
-                    icon="file_download" :disable="!canDownload(props.row, contractIndex)" />
+                  <ni-button @click="dlTemplate(props.row, contract, contractIndex)" icon="file_download"
+                    :disable="!canDownload(props.row, contractIndex)" />
                 </div>
               </template>
               <template v-if="col.name === 'contractSigned'">
                 <div v-if="hasToBeSignedOnline(props.row) && shouldSignContract(props.row.signature)">
-                  <q-btn v-if="!props.row.endDate" no-caps small color="primary" label="Signer"
+                  <ni-button :flat="false" v-if="!props.row.endDate" label="Signer"
                   @click="openSignatureModal(props.row.signature.eversignId)" />
                 </div>
                 <div v-else-if="!getContractLink(props.row) && displayUploader && !hasToBeSignedOnline(props.row)"
@@ -30,8 +30,7 @@
                     @fail="failMsg" />
                 </div>
                 <div v-else-if="getContractLink(props.row)" class="row justify-center table-actions">
-                  <q-btn flat round small color="primary" type="a" :href="getContractLink(props.row)" target="_blank"
-                    icon="file_download" />
+                  <ni-button type="a" :href="getContractLink(props.row)" target="_blank" icon="file_download" />
                 </div>
                 <div v-else-if="hasToBeSignedOnline(props.row)" class="row justify-center table-actions">
                   <p class="no-margin">En attente de signature</p>
@@ -40,15 +39,15 @@
               <template v-else-if="col.name === 'archives'">
                 <div class="row archives justify-center">
                   <div v-for="archive in col.value" :key="archive._id">
-                    <q-btn flat round small color="primary" type="a" :href="getArchiveLink(archive)" target="_blank"
-                      icon="file_download" :disable="!getArchiveLink(archive)" />
+                    <ni-button type="a" :href="getArchiveLink(archive)" target="_blank" icon="file_download"
+                      :disable="!getArchiveLink(archive)" />
                   </div>
                 </div>
               </template>
               <template v-else-if="col.name === 'actions'">
                 <div v-if="!contract.endDate && !props.row.endDate" class="row no-wrap table-actions contract-actions">
-                  <q-btn flat round small color="grey" icon="edit" @click="openVersionEdition(contract, props.row)" />
-                  <q-btn flat round small color="grey" icon="delete" :disable="!props.row.canBeDeleted"
+                  <ni-button icon="edit" @click="openVersionEdition(contract, props.row)" />
+                  <ni-button icon="delete" :disable="!props.row.canBeDeleted"
                     @click="deleteVersion(contract._id, props.row._id)" />
                 </div>
               </template>
@@ -59,9 +58,9 @@
       </ni-responsive-table>
       <q-card-actions align="right">
         <template v-if="displayActions && !contract.endDate">
-          <q-btn flat no-caps color="primary" icon="add" label="Ajouter un avenant"
+          <ni-button icon="add" label="Ajouter un avenant"
             @click="openVersionCreation(contract)" :disable="contractsLoading" />
-          <q-btn flat no-caps color="grey-6" icon="clear" label="Mettre fin au contrat"
+          <ni-button icon="clear" label="Mettre fin au contrat"
             @click="openEndContract(contract)" :disable="contractsLoading" />
         </template>
       </q-card-actions>

--- a/src/modules/client/components/customers/CustomerProfileHeader.vue
+++ b/src/modules/client/components/customers/CustomerProfileHeader.vue
@@ -12,7 +12,7 @@
     <div class="row profile-info column">
       <div class="row items-center">
         <div :class="getDotClass(getStatus(this.customer))" />
-        <div>{{ STATUS_TYPES[getStatus(this.customer)] }}</div>
+        <div :class="getDotTextClass(getStatus(this.customer))">{{ STATUS_TYPES[getStatus(this.customer)] }}</div>
       </div>
       <div class="row items-center">
         <q-icon name="restore" class="q-mr-md" size="1rem" />
@@ -125,8 +125,15 @@ export default {
     getDotClass (value) {
       return {
         'dot dot-active': value === ACTIVATED,
-        'dot dot-stopped': value === STOPPED,
+        'dot dot-error': value === STOPPED,
         'dot dot-archived': value === ARCHIVED,
+      };
+    },
+    getDotTextClass (value) {
+      return {
+        'text-green-800': value === ACTIVATED,
+        'text-orange-700': value === STOPPED,
+        'text-copper-grey-700': value === ARCHIVED,
       };
     },
     async refreshCustomer () {

--- a/src/modules/client/components/customers/ProfileFollowUp.vue
+++ b/src/modules/client/components/customers/ProfileFollowUp.vue
@@ -26,7 +26,7 @@
         <div class="col-md-6 col-xs-12 referent items-center">
           <img :src="auxiliaryAvatar" class="avatar q-mr-sm">
           <ni-select v-model="customer.referent._id" :options="auxiliariesOptions" no-error icon="swap_vert"
-            @focus="saveTmp('referent')" @input="updateCustomer('referent')" bg-color="neutral-grey" />
+            @focus="saveTmp('referent')" @input="updateCustomer('referent')" />
         </div>
       </div>
     </div>

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -25,8 +25,8 @@
         <ni-option-group :value="newCreditNote.events" :options="creditNoteEventsOptions" caption="Évènements"
           type="checkbox" required-field inline :error="validations.events.$error" @input="update($event, 'events')" />
       </template>
-      <div v-if="newCreditNoteHasNoEvents" class="light warning">
-        <p>Il n'y a aucune intervention facturée pour le bénéficiaire aux dates données</p>
+      <div v-if="newCreditNoteHasNoEvents" class="text-orange-700">
+        <p>Il n'y a aucune intervention facturée pour le bénéficiaire aux dates données.</p>
       </div>
       <div class="row justify-between items-baseline">
         <div class="col-6 light">
@@ -143,8 +143,5 @@ export default {
 
 <style lang="stylus" scoped>
   .light
-    font-size: 14px;
-
-  .warning
-    color: $red;
+    font-size: 14px
 </style>

--- a/src/modules/client/components/customers/billing/CreditNoteEditionModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteEditionModal.vue
@@ -25,8 +25,8 @@
             type="checkbox" required-field inline :disable="!editedCreditNote.isEditable"
             :error="validations.events.$error" @input="update($event, 'events')" />
         </template>
-        <div v-if="editedCreditNoteHasNoEvents" class="light warning">
-          <p>Il n'y a aucune intervention facturée pour le bénéficiaire aux dates données</p>
+        <div v-if="editedCreditNoteHasNoEvents" class="light text-orange-700">
+          <p>Il n'y a aucune intervention facturée pour le bénéficiaire aux dates données.</p>
         </div>
         <div class="row justify-between items-baseline">
           <div class="col-6 light">
@@ -134,8 +134,5 @@ export default {
 
 <style lang="stylus" scoped>
   .light
-    font-size: 14px;
-
-  .warning
-    color: $red;
+    font-size: 14px
 </style>

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -49,9 +49,9 @@
             </q-item>
           </template>
           <template v-else-if="col.name === 'actions' && displayActions">
-            <q-btn v-if="paymentTypes.includes(props.row.type)" flat dense color="grey" icon="edit"
+            <q-btn v-if="paymentTypes.includes(props.row.type)" flat dense color="primary" icon="edit"
               @click="openEditionModal(props.row)" />
-            <q-btn v-if="REFUND === props.row.nature" flat dense color="grey" icon="delete"
+            <q-btn v-if="REFUND === props.row.nature" flat dense color="primary" icon="delete"
               @click="deleteRefund(props.row)" />
           </template>
           <template v-else>{{ col.value }}</template>
@@ -141,7 +141,7 @@ export default {
   },
   methods: {
     balanceIconColor (val) {
-      return this.isZero(val) || !this.isNegative(val) ? 'grey' : 'secondary';
+      return this.isZero(val) || !this.isNegative(val) ? 'copper-grey-400' : 'secondary';
     },
     balanceIcon (val) {
       return this.isZero(val) || !this.isNegative(val) ? 'mdi-plus-circle-outline' : 'mdi-minus-circle-outline';

--- a/src/modules/client/components/customers/billing/PaymentCreationModal.vue
+++ b/src/modules/client/components/customers/billing/PaymentCreationModal.vue
@@ -106,5 +106,5 @@ export default {
         width: 50%
         border-radius: 20px
         margin: 5px
-        background-color: $grey-300
+        background-color: $copper-grey-300
 </style>

--- a/src/modules/client/components/customers/billing/ProfileBilling.vue
+++ b/src/modules/client/components/customers/billing/ProfileBilling.vue
@@ -43,7 +43,7 @@
                     :href="getUrl(props.row)" icon="file_download" target="_blank" />
                   <q-btn v-else data-cy="link" flat round small color="primary" icon="file_download"
                     @click="downloadTaxCertificate(props.row)" :disable="pdfLoading" />
-                  <q-btn v-if="isCoach" flat round small dense color="grey" icon="delete"
+                  <q-btn v-if="isCoach" flat round small dense color="copper-grey-400" icon="delete"
                     @click="validateTaxCertificateDeletion(col.value, props.row)" />
                 </div>
               </template>

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -44,10 +44,10 @@
                 :style="col.style">
                 <template v-if="col.name === 'actions'">
                   <div class="row no-wrap table-actions">
-                    <q-btn flat dense color="grey" icon="history" @click="showHistory(col.value)" />
-                    <q-btn flat dense color="grey" icon="edit" @click="openSubscriptionEditionModal(col.value)"
+                    <ni-button icon="history" @click="showHistory(col.value)" />
+                    <ni-button @click="openSubscriptionEditionModal(col.value)" icon="edit"
                       :disable="get(props, 'row.service.isArchived') || false" />
-                    <q-btn flat dense color="grey" icon="delete" :disable="props.row.eventCount > 0"
+                    <ni-button icon="delete" :disable="props.row.eventCount > 0"
                       @click="validateSubscriptionsDeletion(col.value)" />
                   </div>
                 </template>
@@ -57,7 +57,7 @@
           </template>
         </ni-responsive-table>
         <q-card-actions align="right">
-          <q-btn :disable="serviceOptions.length === 0 || subscriptionsLoading" flat no-caps color="primary" icon="add"
+          <ni-button :disable="serviceOptions.length === 0 || subscriptionsLoading" icon="add"
             label="Ajouter une souscription" @click="openNewSubscriptionModal = true" />
         </q-card-actions>
       </q-card>
@@ -85,8 +85,8 @@
                 </template>
                 <template v-if="col.name === 'actions'">
                   <div class="row no-wrap table-actions">
-                    <q-btn flat dense color="grey" icon="edit" @click="openEditionModalHelper(col.value)" />
-                    <q-btn flat dense color="grey" icon="delete" @click="validateHelperDeletion(col.value)" />
+                    <ni-button icon="edit" @click="openEditionModalHelper(col.value)" />
+                    <ni-button icon="delete" @click="validateHelperDeletion(col.value)" />
                   </div>
                 </template>
                 <template v-else>{{ col.value }}</template>
@@ -95,7 +95,7 @@
           </template>
         </ni-responsive-table>
         <q-card-actions align="right">
-          <q-btn flat no-caps color="primary" icon="add" label="Ajouter un aidant" @click="openNewHelperModal = true"
+          <ni-button icon="add" label="Ajouter un aidant" @click="openNewHelperModal = true"
             :disable="helpersLoading" />
         </q-card-actions>
       </q-card>
@@ -126,10 +126,8 @@
               <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
                 :style="col.style">
                 <template v-if="col.name === 'emptyMandate'">
-                  <q-btn v-if="customer.payment.mandates && getRowIndex(customer.payment.mandates, props.row) == 0" flat
-                    round small color="primary" @click="downloadMandate(props.row)">
-                    <q-icon name="file_download" />
-                  </q-btn>
+                  <ni-button v-if="customer.payment.mandates && getRowIndex(customer.payment.mandates, props.row) == 0"
+                    @click="downloadMandate(props.row)" icon="file_download" />
                 </template>
                 <template v-else-if="col.name === 'signedMandate'">
                   <div v-if="!props.row.drive || !getMandateLink(props.row)" class="row justify-center table-actions">
@@ -137,8 +135,7 @@
                       field-name="file" auto-upload :accept="extensions" @uploaded="refreshMandates"
                       @failed="failMsg" />
                   </div>
-                  <q-btn v-else flat round small color="primary" type="a" :href="getMandateLink(props.row)"
-                    target="_blank" icon="file_download" />
+                  <ni-button v-else type="a" :href="getMandateLink(props.row)" icon="file_download" />
                 </template>
                 <template v-else-if="col.name === 'signedAt'">
                   <ni-date-input
@@ -147,7 +144,7 @@
                     @focus="saveTmpSignedAt(getRowIndex(customer.payment.mandates, props.row))" in-modal />
                 </template>
                 <template v-else-if="col.name === 'signed'">
-                  <div :class="[{ 'dot dot-active': col.value, 'dot dot-inactive': !col.value }]" />
+                  <div :class="[{ 'dot dot-active': col.value, 'dot dot-error': !col.value }]" />
                 </template>
                 <template v-else>{{ col.value }}</template>
               </q-td>
@@ -181,7 +178,7 @@
           </template>
         </ni-responsive-table>
         <q-card-actions align="right">
-          <q-btn :disable="fundingSubscriptionsOptions.length === 0 || fundingsLoading" flat no-caps color="primary"
+          <ni-button :disable="fundingSubscriptionsOptions.length === 0 || fundingsLoading"
             icon="add" label="Ajouter un financement" @click="openFundingCreationModal" />
         </q-card-actions>
       </q-card>
@@ -217,11 +214,10 @@
                       field-name="file" :accept="extensions" auto-upload @uploaded="refreshQuotes"
                       @failed="failMsg" />
                   </div>
-                  <q-btn v-else flat round small color="primary" type="a" :href="getQuoteLink(props.row)"
-                    target="_blank" icon="file_download" />
+                  <ni-button v-else type="a" :href="getQuoteLink(props.row)" icon="file_download" />
                 </template>
                 <template v-else-if="col.name === 'signed'">
-                  <div :class="[{ 'dot dot-active': col.value, 'dot dot-inactive': !col.value }]" />
+                  <div :class="[{ 'dot dot-active': col.value, 'dot dot-error': !col.value }]" />
                 </template>
                 <template v-else>{{ col.value }}</template>
               </q-td>
@@ -229,8 +225,8 @@
           </template>
         </ni-responsive-table>
         <q-card-actions align="right">
-          <q-btn :disable="this.subscriptions.length === 0 || quotesLoading" flat no-caps color="primary" icon="add"
-            label="Générer un devis" @click="generateQuote" />
+          <ni-button :disable="this.subscriptions.length === 0 || quotesLoading" icon="add" label="Générer un devis"
+            @click="generateQuote" />
         </q-card-actions>
       </q-card>
     </div>
@@ -1073,9 +1069,6 @@ export default {
   .mandate-table
     td
       word-break: break-all
-
-  .dot-inactive
-    background: $secondary
 
   @media screen and (min-width: 768px)
     .dot

--- a/src/modules/client/components/pay/PaySurchargeDetailsModal.vue
+++ b/src/modules/client/components/pay/PaySurchargeDetailsModal.vue
@@ -77,11 +77,11 @@ export default {
     display: flex
     flex-direction: row
     width: 100%;
-    border: 1px solid $grey-300
+    border: 1px solid $copper-grey-300
     &:not(:nth-child(2)) // first-child is title
       border-top: none
 
   .surcharge-type
     width: 60%
-    border-right: 1px solid $grey-300
+    border-right: 1px solid $copper-grey-300
 </style>

--- a/src/modules/client/components/planning/Agenda.vue
+++ b/src/modules/client/components/planning/Agenda.vue
@@ -149,8 +149,8 @@ export default {
           180deg,
           white,
           white 13.1%,
-          $grey-100,
-          $grey-100 13.3%
+          $copper-grey-100,
+          $copper-grey-100 13.3%
         )
         height: 100%
         position: relative
@@ -172,7 +172,7 @@ export default {
 
       .planning-hour
         position: absolute
-        color: $grey-300
+        color: $copper-grey-300
         font-size: 12px
         padding: 0 5px
 

--- a/src/modules/client/components/planning/AuxiliaryIndicators.vue
+++ b/src/modules/client/components/planning/AuxiliaryIndicators.vue
@@ -107,16 +107,16 @@ export default {
 
   .indicator
     display: flex;
-    border-top: 1px solid $grey-300
-    border-left: 1px solid $grey-300
-    border-right: 1px solid $grey-300
+    border-top: 1px solid $copper-grey-300
+    border-left: 1px solid $copper-grey-300
+    border-right: 1px solid $copper-grey-300
     .indicator-title
       padding: 5px
     .indicator-hours
       padding: 5px
-      border-left:  1px solid $grey-300
+      border-left:  1px solid $copper-grey-300
     &:last-child
-      border-bottom: 1px solid $grey-300
+      border-bottom: 1px solid $copper-grey-300
 
   .highlight
     color: $primary
@@ -129,11 +129,11 @@ export default {
       padding: 0 12px
 
   .economic-indicators
-    border-left: 5px solid $pink-800 !important
-  .quality-indicators
     border-left: 5px solid $primary !important
+  .quality-indicators
+    border-left: 5px solid $copper-300 !important
 
   .quality-indicators-item
-    border-top: 1px solid $grey-300
+    border-top: 1px solid $copper-grey-300
     padding: 10px 0
 </style>

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -292,7 +292,7 @@ export default {
       width: 24%
       border-radius: 20px
       margin: 5px
-      background-color: $grey-300
+      background-color: $copper-grey-300
       @media screen and (max-width: 767px)
         width: 45%
 

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -13,7 +13,8 @@
           <q-btn-toggle no-wrap :value="editedEvent.type" toggle-color="primary" rounded unelevated
             :options="eventType" />
           <q-btn icon="delete" @click="isRepetition(editedEvent) ? deleteEventRepetition() : deleteEvent()" no-caps flat
-            color="grey" v-if="!isBilledIntervention" data-cy="event-deletion-button" :disable="historiesLoading" />
+            color="copper-grey-400" v-if="!isBilledIntervention" data-cy="event-deletion-button"
+            :disable="historiesLoading" />
         </div>
         <template v-if="editedEvent.type !== ABSENCE">
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="editedEvent.dates" required-field
@@ -87,12 +88,12 @@
         </template>
         <div class="q-mb-lg">
           <div class="flex-row items-center justify-between">
-            <div class="flex-row">
-              <q-icon size="sm" name="history" class="q-mr-sm" color="grey-400" />
+            <div class="flex-row items-center">
+              <q-icon size="sm" name="history" class="q-mr-sm" color="copper-grey-400" />
               <div class="history-list-title text-weight-bold">Activité</div>
             </div>
-            <ni-button :label="historyButtonLabel" color="grey-800" class="bg-grey-100" @click="toggleHistory"
-              :disable="historiesLoading" />
+            <ni-button :label="historyButtonLabel" color="copper-grey-800" class="bg-copper-grey-100"
+              @click="toggleHistory" :disable="historiesLoading" />
           </div>
           <div v-if="displayHistory" class="q-mt-sm">
             <ni-event-history v-for="history in eventHistories" :key="history._id" :history="history" />
@@ -193,7 +194,7 @@ export default {
       const nature = ABSENCE_TYPES.find(abs => abs.value === this.editedEvent.absence);
       const startDate = moment(this.editedEvent.extension.startDate).format('DD/MM/YYYY');
 
-      return `Cette absence est une prolongation de ${nature.label.toLowerCase()} commencant le ${startDate}`;
+      return `Cette absence est une prolongation de ${nature.label.toLowerCase()} commencant le ${startDate}.`;
     },
     customerStoppedDate () {
       return get(this.selectedCustomer, 'stoppedAt') || '';
@@ -291,12 +292,12 @@ export default {
         width: 100%
 
   .light-checkbox
-    color: $grey-400
+    color: $copper-grey-400
     font-size: 14px
 
   .infos
     font-style: italic;
-    color: $grey-400;
+    color: $copper-grey-400;
 
   .history-list-title
     font-size: 14px

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -333,7 +333,7 @@ export default {
       .line
         width: 1px;
         height: 100%;
-        background: $grey-100;
+        background: $copper-grey-100;
         margin: 0;
         position: absolute;
         z-index: -1;

--- a/src/modules/client/components/planning/PlanningNavigation.vue
+++ b/src/modules/client/components/planning/PlanningNavigation.vue
@@ -9,7 +9,7 @@
       <div data-cy="week-number" class="week-number"><span>{{ weekNumber }}</span></div>
     </div>
     <div class="planning-navigation-actions col-6">
-      <div class="text-grey-800">
+      <div class="text-copper-grey-800">
         <q-btn data-cy="planning_before" icon="chevron_left" dense flat round @click="goToPreviousWeek()" />
         <q-btn data-cy="planning_after" icon="chevron_right" dense flat round @click="goToNextWeek()" />
         <q-btn data-cy="planning_today" icon="today" dense flat round @click="goToToday" />

--- a/src/modules/client/components/table/ToBillRow.vue
+++ b/src/modules/client/components/table/ToBillRow.vue
@@ -3,7 +3,8 @@
     <q-td v-for="col in props.cols" :key="col.name" :props="props" :data-cy="`col-${col.name}`"
       :style="{width: col.name === 'externalBilling' ? '100px' : '200px'}">
       <template v-if="index === 0 && col.name === 'externalBilling' && bill.thirdPartyPayer">
-        <q-checkbox :value="bill.externalBilling" color="grey" dense @input="update($event, 'externalBilling')" />
+        <q-checkbox :value="bill.externalBilling" color="copper-grey-400" @input="update($event, 'externalBilling')"
+          dense />
       </template>
       <template v-if="index === 0 && col.name === 'customer'">
         <span class="uppercase text-weight-bold">

--- a/src/modules/client/layouts/Layout.vue
+++ b/src/modules/client/layouts/Layout.vue
@@ -78,7 +78,7 @@ export default {
 
   .chevron
     background-color: white
-    border: 1px solid $grey-300
+    border: 1px solid $copper-grey-300
     top: 5px
     position: fixed
     z-index: 5000
@@ -93,7 +93,7 @@ export default {
     color: $primary
 
   .q-btn
-    color: $grey-800
+    color: $copper-grey-800
     &:hover
       color: $primary
 

--- a/src/modules/client/pages/auxiliaries/teams/TeamsDirectory.vue
+++ b/src/modules/client/pages/auxiliaries/teams/TeamsDirectory.vue
@@ -120,6 +120,6 @@ export default {
 
 <style lang="stylus" scoped>
 .sector-label
-  color: grey
+  color: $copper-grey-400
   font-size: 14px
 </style>

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -14,9 +14,9 @@
                   :style="col.style" :data-cy="`col-${col.name}`">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <q-btn flat round small color="grey" icon="history" @click="showHistory(col.value)"
+                      <q-btn flat round small color="primary" icon="history" @click="showHistory(col.value)"
                         data-cy="show-subscription-history" />
-                      <q-btn :disable="!getFunding(col.value).length" flat round small color="grey"
+                      <q-btn :disable="!getFunding(col.value).length" flat round small color="primary"
                         icon="mdi-calculator" @click="showFunding(col.value)" data-cy="show-fundings-history" />
                     </div>
                   </template>

--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -26,7 +26,7 @@
                 <div class="sector-name text-weight-bold">{{ sectorName(sector) }}</div>
                 <div class="month-label">{{ monthLabel }}</div>
               </div>
-              <q-circular-progress :value="Math.min(hoursRatio(sector), 100)" size="60px" track-color="grey-5"
+              <q-circular-progress :value="Math.min(hoursRatio(sector), 100)" size="60px" track-color="copper-grey-300"
                 color="primary" show-value :thickness="0.2" class="text-weight-bold">
                 {{ roundFrenchPercentage(hoursRatio(sector), 0).replace('&nbsp;', '') }}
               </q-circular-progress>
@@ -387,18 +387,18 @@ export default {
   font-style: italic
 
 .auxiliary
-  border-left: 1px solid $grey-300
-  border-right: 1px solid $grey-300
-  border-bottom: 1px solid $grey-300
+  border-left: 1px solid $copper-grey-300
+  border-right: 1px solid $copper-grey-300
+  border-bottom: 1px solid $copper-grey-300
   &:nth-child(1)
-    border-top: 1px solid $grey-300
+    border-top: 1px solid $copper-grey-300
   div
     padding: 5px
   &-cell
     display: flex
     flex-direction: column
     &:not(:nth-last-child(-n+2))
-      border-bottom: 1px solid $grey-300
+      border-bottom: 1px solid $copper-grey-300
     &-container
       padding: 0 16px
       width: 100%
@@ -406,7 +406,7 @@ export default {
         padding: 0 8px
 
 .auxiliary-label
-  border-right: 1px solid $grey-300
+  border-right: 1px solid $copper-grey-300
 
 .auxiliary-value
   justify-content: flex-end
@@ -439,7 +439,7 @@ export default {
     &:nth-child(2)
       color: $secondary
     &:nth-child(3)
-      color: $grey-400
+      color: $copper-grey-400
   &-value
     font-size: 48px
     @media screen and (max-width: 767px)

--- a/src/modules/client/pages/ni/auxiliaries/Directory.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Directory.vue
@@ -16,7 +16,7 @@
             color="secondary" size="1rem" />
         </template>
         <template v-else-if="col.name === 'active'">
-          <div :class="{ 'dot dot-active': col.value, 'dot dot-inactive': !col.value }" />
+          <div :class="{ 'dot dot-active': col.value, 'dot dot-error': !col.value }" />
         </template>
         <template v-else>{{ col.value }}</template>
       </template>

--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -28,9 +28,8 @@
             :style="col.style">
             <template v-if="col.name === 'actions'">
               <div class="row no-wrap table-actions">
-                <q-btn flat round color="grey" icon="remove_red_eye" size="12px"
-                  @click="goToCustomerBillingPage(col.value)" />
-                <q-btn flat round color="grey" icon="add" size="12px"
+                <ni-button icon="remove_red_eye" @click="goToCustomerBillingPage(col.value)" />
+                <ni-button icon="add"
                   @click="openPaymentCreationModal(props.row.customer, props.row.thirdPartyPayer)" />
               </div>
             </template>
@@ -65,6 +64,7 @@ import Payments from '@api/Payments';
 import Balances from '@api/Balances';
 import TaxCertificates from '@api/TaxCertificates';
 import SimpleTable from '@components/table/SimpleTable';
+import Button from '@components/Button';
 import PrefixedCellContent from '@components/table/PrefixedCellContent';
 import TitleHeader from '@components/TitleHeader';
 import Select from '@components/form/Select';
@@ -88,6 +88,7 @@ export default {
   metaInfo: { title: 'Balances clients' },
   components: {
     'ni-simple-table': SimpleTable,
+    'ni-button': Button,
     'ni-prefixed-cell-content': PrefixedCellContent,
     'ni-payment-creation-modal': PaymentCreationModal,
     'ni-title-header': TitleHeader,

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -11,9 +11,8 @@
             :style="col.style">
             <template v-if="col.name === 'actions'">
               <div class="row no-wrap table-actions" v-if="props.row.origin === COMPANI">
-                <q-btn flat round small color="grey" icon="edit"
-                  @click.native="openCreditNoteEditionModal(props.row)" />
-                <q-btn flat round small color="grey" icon="delete" :disable="!props.row.isEditable"
+                <ni-button icon="edit" @click="openCreditNoteEditionModal(props.row)" />
+                <ni-button icon="delete" :disable="!props.row.isEditable"
                   @click="validateCNDeletion(col.value, props.row)" />
               </div>
             </template>
@@ -22,8 +21,8 @@
         </q-tr>
       </template>
     </ni-simple-table>
-    <q-btn class="fixed fab-custom" no-caps rounded color="primary" icon="add" label="Créer un avoir"
-      @click="creditNoteCreationModal = true" :disable="tableLoading" />
+    <ni-button class="fixed fab-custom" icon="add" label="Créer un avoir" @click="creditNoteCreationModal = true"
+      :disable="tableLoading" />
 
     <!-- Credit note creation modal -->
     <credit-note-creation-modal v-model="creditNoteCreationModal" @submit="createNewCreditNote"
@@ -57,6 +56,7 @@ import isEqual from 'lodash/isEqual';
 import Events from '@api/Events';
 import Customers from '@api/Customers';
 import CreditNotes from '@api/CreditNotes';
+import Button from '@components/Button';
 import SimpleTable from '@components/table/SimpleTable';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import { COMPANI, REQUIRED_LABEL } from '@data/constants';
@@ -71,6 +71,7 @@ export default {
   name: 'CreditNotes',
   metaInfo: { title: 'Avoirs' },
   components: {
+    'ni-button': Button,
     'ni-simple-table': SimpleTable,
     'credit-note-edition-modal': CreditNoteEditionModal,
     'credit-note-creation-modal': CreditNoteCreationModal,

--- a/src/modules/client/pages/ni/config/CompanyConfig.vue
+++ b/src/modules/client/pages/ni/config/CompanyConfig.vue
@@ -64,9 +64,8 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <q-btn flat round small color="grey" icon="edit"
-                        @click="openEstablishmentEditionModal(col.value)" />
-                      <q-btn flat round small color="grey" icon="delete" :disable="props.row.usersCount > 0"
+                      <ni-button icon="edit" @click="openEstablishmentEditionModal(col.value)" />
+                      <ni-button icon="delete" :disable="props.row.usersCount > 0"
                         @click="validateEstablishmentDeletion(col.value)" />
                     </div>
                   </template>
@@ -76,8 +75,8 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter un établissement"
-              @click="establishmentCreationModal = true" :disable="establishmentsLoading" />
+            <ni-button icon="add" label="Ajouter un établissement" :disable="establishmentsLoading"
+              @click="establishmentCreationModal = true" />
           </q-card-actions>
         </q-card>
       </div>
@@ -102,6 +101,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import pick from 'lodash/pick';
 import { required, maxLength } from 'vuelidate/lib/validators';
 import Establishments from '@api/Establishments';
+import Button from '@components/Button';
 import Input from '@components/form/Input';
 import ResponsiveTable from '@components/table/ResponsiveTable';
 import SearchAddress from '@components/form/SearchAddress';
@@ -130,6 +130,7 @@ export default {
   metaInfo: { title: 'Configuration générale' },
   components: {
     'ni-input': Input,
+    'ni-button': Button,
     'ni-search-address': SearchAddress,
     'ni-responsive-table': ResponsiveTable,
     'establishment-creation-modal': EstablishmentCreationModal,

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -13,10 +13,8 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <q-btn flat round small dense color="grey" icon="edit"
-                        @click.native="openSurchargeEditionModal(col.value)" />
-                      <q-btn flat round small dense color="grey" icon="delete"
-                        @click="validateSurchargeDeletion(col.value, props.row)" />
+                      <ni-button icon="edit" @click.native="openSurchargeEditionModal(col.value)" />
+                      <ni-button icon="delete" @click="validateSurchargeDeletion(col.value, props.row)" />
                     </div>
                   </template>
                   <template v-else>{{ col.value }}</template>
@@ -25,8 +23,8 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter un plan de majoration"
-              @click="surchargeCreationModal = true" :disable="surchargesLoading" />
+            <ni-button icon="add" label="Ajouter un plan de majoration" @click="surchargeCreationModal = true"
+              :disable="surchargesLoading" />
           </q-card-actions>
         </q-card>
       </div>
@@ -41,11 +39,11 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <ni-btn icon="history" @click="showHistory(col.value)" />
-                      <ni-btn v-if="!props.row.isArchived" icon="edit" @click="openServiceEditionModal(col.value)" />
-                      <ni-btn v-if="props.row.subscriptionCount === 0" icon="delete"
+                      <ni-button icon="history" @click="showHistory(col.value)" />
+                      <ni-button v-if="!props.row.isArchived" icon="edit" @click="openServiceEditionModal(col.value)" />
+                      <ni-button v-if="props.row.subscriptionCount === 0" icon="delete"
                         @click="validateServiceDeletion(col.value, props.row)" />
-                      <ni-btn v-else-if="!props.row.isArchived" icon="mdi-archive"
+                      <ni-button v-else-if="!props.row.isArchived" icon="mdi-archive"
                         @click="validateServiceArchiving(col.value)" />
                       <div class="archived" v-else>archivé</div>
                     </div>
@@ -56,8 +54,8 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter un service"
-              @click="serviceCreationModal = true" :disable="servicesLoading" />
+            <ni-button icon="add" label="Ajouter un service" @click="serviceCreationModal = true"
+              :disable="servicesLoading" />
           </q-card-actions>
         </q-card>
       </div>
@@ -99,10 +97,9 @@
                   </template>
                   <template v-else-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <q-btn flat round small dense color="grey" icon="edit"
-                        @click="openThirdPartyPayerEditionModal(col.value)" />
-                      <q-btn :disable="isTppUsedInFundings(props.row)" flat round small dense color="grey"
-                        icon="delete" @click="validateTppDeletion(col.value, props.row)" />
+                      <ni-button icon="edit" @click="openThirdPartyPayerEditionModal(col.value)" />
+                      <ni-button :disable="isTppUsedInFundings(props.row)" icon="delete"
+                        @click="validateTppDeletion(col.value, props.row)" />
                     </div>
                   </template>
                   <template v-else>{{ col.value }}</template>
@@ -111,8 +108,8 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter un tiers payeur"
-              @click="thirdPartyPayerCreationModal = true" :disable="tppsLoading" />
+            <ni-button icon="add" label="Ajouter un tiers payeur" @click="thirdPartyPayerCreationModal = true"
+              :disable="tppsLoading" />
           </q-card-actions>
         </q-card>
       </div>
@@ -211,7 +208,7 @@ export default {
   components: {
     'ni-file-uploader': FileUploader,
     'ni-select': Select,
-    'ni-btn': Button,
+    'ni-button': Button,
     'ni-responsive-table': ReponsiveTable,
     'service-creation-modal': ServiceCreationModal,
     'service-edition-modal': ServiceEditionModal,

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -12,8 +12,7 @@
                 <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
-                    <q-btn flat round small color="grey" icon="delete"
-                      @click="validateInternalHourDeletion(props.row)" />
+                    <ni-button icon="delete" @click="validateInternalHourDeletion(props.row)" />
                   </template>
                   <template v-else>{{ col.value }}</template>
                 </q-td>
@@ -21,8 +20,7 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter une heure interne"
-              @click="internalHourCreationModal = true"
+            <ni-button icon="add" label="Ajouter une heure interne" @click="internalHourCreationModal = true"
               :disable="internalHours.length >= MAX_INTERNAL_HOURS_NUMBER || internalHoursLoading" />
           </q-card-actions>
         </q-card>
@@ -99,9 +97,9 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <q-btn flat round small color="primary" :href="getAdministrativeDocumentLink(props.row)" type="a"
-                        target="_blank" :disable="!getAdministrativeDocumentLink(props.row)" icon="file_download" />
-                      <q-btn flat round small color="grey" :disable="!getAdministrativeDocumentLink(props.row)"
+                      <ni-button :href="getAdministrativeDocumentLink(props.row)" type="a"
+                        :disable="!getAdministrativeDocumentLink(props.row)" icon="file_download" />
+                      <ni-button :disable="!getAdministrativeDocumentLink(props.row)"
                          icon="delete" @click="validateAdministrativeDocumentDeletion(props.row)" />
                     </div>
                   </template>
@@ -111,8 +109,8 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter un document"
-              @click="administrativeDocumentCreationModal = true" :disable="administrativeDocumentsLoading" />
+            <ni-button icon="add" label="Ajouter un document" :disable="administrativeDocumentsLoading"
+              @click="administrativeDocumentCreationModal = true" />
           </q-card-actions>
         </q-card>
       </div>
@@ -127,9 +125,8 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <q-btn flat round small color="grey" icon="edit"
-                        @click.native="openEditionModal(props.row._id)" />
-                      <q-btn flat round small color="grey" icon="delete" :disable="props.row.hasAuxiliaries"
+                      <ni-button icon="edit" @click.native="openEditionModal(props.row._id)" />
+                      <ni-button icon="delete" :disable="props.row.hasAuxiliaries"
                         @click="validateSectorDeletion(props.row)" />
                     </div>
                   </template>
@@ -139,8 +136,8 @@
             </template>
           </ni-responsive-table>
           <q-card-actions align="right">
-            <q-btn no-caps flat color="primary" icon="add" label="Ajouter une équipe"
-              @click="sectorCreationModal = true" :disable="sectorsLoading" />
+            <ni-button icon="add" label="Ajouter une équipe" @click="sectorCreationModal = true"
+              :disable="sectorsLoading" />
           </q-card-actions>
         </q-card>
       </div>
@@ -170,11 +167,12 @@ import Companies from '@api/Companies';
 import Sectors from '@api/Sectors';
 import AdministrativeDocument from '@api/AdministrativeDocuments';
 import InternalHours from '@api/InternalHours';
-import { positiveNumber } from '@helpers/vuelidateCustomVal';
-import { NotifyWarning, NotifyPositive, NotifyNegative } from '@components/popup/notify';
+import Button from '@components/Button';
 import Input from '@components/form/Input';
 import FileUploader from '@components/form/FileUploader';
+import { NotifyWarning, NotifyPositive, NotifyNegative } from '@components/popup/notify';
 import ResponsiveTable from '@components/table/ResponsiveTable';
+import { positiveNumber } from '@helpers/vuelidateCustomVal';
 import { configMixin } from 'src/modules/client/mixins/configMixin';
 import { validationMixin } from '@mixins/validationMixin';
 import { tableMixin } from 'src/modules/client/mixins/tableMixin';
@@ -188,6 +186,7 @@ export default {
   name: 'RhConfig',
   metaInfo: { title: 'Configuration rh' },
   components: {
+    'ni-button': Button,
     'ni-input': Input,
     'ni-file-uploader': FileUploader,
     'ni-responsive-table': ResponsiveTable,

--- a/src/modules/client/pages/ni/courses/Dashboard.vue
+++ b/src/modules/client/pages/ni/courses/Dashboard.vue
@@ -25,14 +25,14 @@
         <q-card flat class="fit q-pa-md">
           <div class="text-weight-bold q-mb-sm">Apprenants les plus assidus</div>
           <div class="row justify-end">
-            <div class="col-4 text-grey-800 text-center">Activités eLearning réalisées</div>
+            <div class="col-4 text-copper-grey-800 text-center">Activités eLearning réalisées</div>
           </div>
           <div v-for="(learner, index) in learnerList.slice(0, 5)" :key="learner._id"
             class="justify-between items-center row q-my-sm">
             <div class="flex no-wrap items-center col-8">
               <ni-e-learning-indicator :indicator="index + 1" />
               <img class="q-mx-md avatar" :src="learner.picture ? learner.picture.link : DEFAULT_AVATAR">
-              <div class="text-grey-800">{{ formatIdentity(learner.identity, 'FL') }}</div>
+              <div class="text-copper-grey-800">{{ formatIdentity(learner.identity, 'FL') }}</div>
             </div>
             <div class="col-4 text-center">{{ learner.activityCount }}</div>
           </div>
@@ -42,13 +42,13 @@
         <q-card flat class="fit q-pa-md">
           <div class="text-weight-bold q-mb-sm">Formations les plus suivies</div>
           <div class="row justify-end">
-            <div class="col-4 text-grey-800 text-center">Nombre d'apprenants actifs</div>
+            <div class="col-4 text-copper-grey-800 text-center">Nombre d'apprenants actifs</div>
           </div>
           <div v-for="(course, index) in courseList.slice(0, 5)" :key="course.name"
             class="justify-between items-center row q-my-sm">
             <div class="flex no-wrap items-center col-8">
               <ni-e-learning-indicator :indicator="index + 1" />
-              <div class="q-mx-md text-grey-800">{{ upperCaseFirstLetter(course.name) }}</div>
+              <div class="q-mx-md text-copper-grey-800">{{ upperCaseFirstLetter(course.name) }}</div>
             </div>
             <div class="col-4 text-center">{{ course.activeTraineesCount }}</div>
           </div>

--- a/src/modules/client/pages/ni/customers/CustomersDirectory.vue
+++ b/src/modules/client/pages/ni/customers/CustomersDirectory.vue
@@ -186,6 +186,7 @@ export default {
         this.firstInterventions = Object.freeze(firstInterventions);
         this.customers = Object.freeze(customers.map(customer => this.formatCustomer(customer)));
       } catch (e) {
+        this.customers = [];
         this.firstInterventions = [];
         console.error(e);
       } finally {
@@ -228,7 +229,7 @@ export default {
     getDotClass (value) {
       return {
         'dot dot-active': value === ACTIVATED,
-        'dot dot-stopped': value === STOPPED,
+        'dot dot-error': value === STOPPED,
         'dot dot-archived': value === ARCHIVED,
       };
     },

--- a/src/modules/client/pages/ni/pay/Absences.vue
+++ b/src/modules/client/pages/ni/pay/Absences.vue
@@ -14,13 +14,12 @@
             :style="col.style">
             <template v-if="col.name === 'actions'">
               <div class="row no-wrap table-actions">
-                <q-btn flat round small color="grey" icon="edit" @click="openAbsenceEditionModal(props.row)" />
+                <ni-button icon="edit" @click="openAbsenceEditionModal(props.row)" />
               </div>
             </template>
             <template v-if="col.name === 'attachment'">
               <div v-if="getAbsenceLink(props.row)" class="row no-wrap table-actions">
-                <q-btn flat round small color="primary" type="a" :href="getAbsenceLink(props.row)" target="_blank"
-                  icon="file_download" />
+                <ni-button type="a" :href="getAbsenceLink(props.row)" icon="file_download" />
               </div>
             </template>
             <template v-else>{{ col.value }}</template>
@@ -41,6 +40,7 @@
 <script>
 import get from 'lodash/get';
 import Events from '@api/Events';
+import Button from '@components/Button';
 import DateRange from '@components/form/DateRange';
 import TitleHeader from '@components/TitleHeader';
 import SimpleTable from '@components/table/SimpleTable';
@@ -55,6 +55,7 @@ export default {
   name: 'Absences',
   metaInfo: { title: 'Absences' },
   components: {
+    'ni-button': Button,
     'ni-date-range': DateRange,
     'ni-simple-table': SimpleTable,
     'ni-event-edition-modal': EventEditionModal,

--- a/src/modules/client/pages/ni/pay/ContractMonitoring.vue
+++ b/src/modules/client/pages/ni/pay/ContractMonitoring.vue
@@ -15,8 +15,8 @@
             :style="col.style">
             <template v-if="col.name === 'actions'">
               <div class="row no-wrap table-actions contract-actions">
-                <q-btn flat round small color="grey" icon="remove_red_eye" @click="goToUserContractPage(col.value)" />
-                <q-btn flat round small color="grey" icon="edit" @click="openVersionEditionModal(props.row)" />
+                <ni-button icon="remove_red_eye" @click="goToUserContractPage(col.value)" />
+                <ni-button icon="edit" @click="openVersionEditionModal(props.row)" />
               </div>
             </template>
             <template v-else>
@@ -39,6 +39,7 @@
 import get from 'lodash/get';
 import { required, minValue } from 'vuelidate/lib/validators';
 import Contracts from '@api/Contracts';
+import Button from '@components/Button';
 import DateRange from '@components/form/DateRange';
 import TitleHeader from '@components/TitleHeader';
 import SimpleTable from '@components/table/SimpleTable';
@@ -53,6 +54,7 @@ export default {
   metaInfo: { title: 'Suivi Contrats/Avenants' },
   mixins: [contractMixin],
   components: {
+    'ni-button': Button,
     'ni-date-range': DateRange,
     'ni-title-header': TitleHeader,
     'version-edition-modal': VersionEditionModal,

--- a/src/modules/vendor/components/programs/PublishedDot.vue
+++ b/src/modules/vendor/components/programs/PublishedDot.vue
@@ -1,12 +1,8 @@
 <template>
-  <div class="dot-container">
-    <q-icon v-if="status === PUBLISHED_DOT_WARNING"
-      size="12px" name="circle" color="orange-500" />
-    <q-icon v-if="isPublished && status === PUBLISHED_DOT_ACTIVE"
-      size="12px" name="check_circle" color="green-800" />
-    <span v-if="isPublished"
-      :class="[{'published-activity-text': status === PUBLISHED_DOT_ACTIVE},
-        {'published-activity-text-error': status === PUBLISHED_DOT_WARNING}]">
+  <div :class="['dot-container', containerClass]">
+    <q-icon v-if="status === PUBLISHED_DOT_WARNING" size="12px" name="circle" />
+    <q-icon v-if="isPublished && status === PUBLISHED_DOT_ACTIVE" size="12px" name="check_circle" />
+    <span v-if="isPublished" class="activity-text">
       Publiée
     </span>
   </div>
@@ -27,6 +23,13 @@ export default {
       PUBLISHED_DOT_WARNING,
     };
   },
+  computed: {
+    containerClass () {
+      if (this.status === PUBLISHED_DOT_ACTIVE) return 'info-active';
+      if (this.status === PUBLISHED_DOT_WARNING) return 'info-warning';
+      return '';
+    },
+  },
 };
 </script>
 
@@ -37,12 +40,7 @@ export default {
   align-items: center
   margin-left: 8px
 
-.published-activity-text
+.activity-text
   font-size: 12px
-  color: $green-800
   margin-left: 8px
-  &-error
-    font-size: 12px
-    color: $orange-500
-    margin-left: 8px
 </style>

--- a/src/modules/vendor/components/programs/cards/CardContainer.vue
+++ b/src/modules/vendor/components/programs/cards/CardContainer.vue
@@ -161,14 +161,14 @@ export default {
   &-selected
     justify-content: flex-end
     .card-cell
-      background-color: $pink-400
+      background-color: $copper-400
   &-locked
     .card-cell
-      background-color: $grey-100
+      background-color: $copper-grey-100
   &-locked-selected
     justify-content: flex-end
     .card-cell
-      background-color: $grey-800
+      background-color: $copper-grey-800
       color: white
   .dot
     margin: 0 0 0 3px
@@ -177,10 +177,10 @@ export default {
   display: flex
   flex-direction: column
 .locked-unselected
-  color: $grey-400
+  color: $copper-grey-400
 
 .card-cell
-  background-color: $pink-100
+  background-color: $copper-100
   border-radius: 4px
   height: fit-content
   @media screen and (min-width: 768px)

--- a/src/modules/vendor/components/programs/cards/CardCreationModal.vue
+++ b/src/modules/vendor/components/programs/cards/CardCreationModal.vue
@@ -160,8 +160,8 @@ h6
     grid-template-columns: repeat(auto-fill, 79px)
 
 .card-button
-  background-color: $grey-100
-  color: $grey-800
+  background-color: $copper-grey-100
+  color: $copper-grey-800
   border-radius: 10px
   font-size: 14px
   height: 120px
@@ -189,9 +189,9 @@ h6
         width: 30%
         height: 30px
     .flashcard-right
-      background-color: $grey-400
+      background-color: $copper-grey-400
     .flashcard-left
-      background-color: $grey-300
+      background-color: $copper-grey-300
 
   .fill-the-gaps
     font-size: 10px

--- a/src/modules/vendor/layouts/Layout.vue
+++ b/src/modules/vendor/layouts/Layout.vue
@@ -74,7 +74,7 @@ export default {
 
   .chevron
     background-color: white
-    border: 1px solid $grey-300
+    border: 1px solid $copper-grey-300
     top: 5px
     position: fixed
     z-index: 5000
@@ -89,7 +89,7 @@ export default {
     color: $primary
 
   .q-btn
-    color: $grey-800
+    color: $copper-grey-800
     &:hover
       color: $primary
 


### PR DESCRIPTION
1er jet de la refonte de la charte graphique 
- mise a jour de la police
- ajout des couleurs `copper`, `copper-grey` dans la charte graphique 
- mise a jour de la couleur `orange` de la charte graphique 
- mise a jour des logos
- passer tous les boutons d'actions en couleur primaire (homogénéisation)
les couleurs sont disponibles ici https://www.figma.com/file/PlYziIhmznu7y7EEK7uoBD/Prochain-Sprint?node-id=5654%3A95

les couleurs sur le planning ne correspondent pas a ce qu'il y a sur `prochainSprint` car j'ai simplifié les cas et les couleurs ne sont pas encore toutes définitives

Ce qu'il reste a faire :
- refonte du la gestion des couleurs pour le `dot` > tel que c'est fait ce n'est pas optimal, j'aimerais creuser un peu plus
- remplacer la couleur `black` par le `copper-grey-900`