### PR TITLE
Com 2192 menu

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -80,8 +80,6 @@ module.exports = function (ctx) {
         'QTime',
         'QTr',
         'QToggle',
-        'QToolbar',
-        'QToolbarTitle',
         'QUploader',
       ],
       directives: [

--- a/src/core/components/BiColorButton.vue
+++ b/src/core/components/BiColorButton.vue
@@ -2,7 +2,7 @@
   <div>
     <ni-button class="button" flat :icon="icon" color="primary" @click="click" :size="size" :href="href"
       :disable="disable" :type="type" />
-    <ni-button class="button" flat :label="label" color="black" @click="click" :size="size" :href="href"
+    <ni-button class="button" flat :label="label" color="copper-grey-700" @click="click" :size="size" :href="href"
       :disable="disable" :type="type" />
   </div>
 </template>

--- a/src/core/components/CopyButton.vue
+++ b/src/core/components/CopyButton.vue
@@ -2,7 +2,7 @@
   <div class="button-container">
     <ni-button class="button" flat :icon="icon" color="primary" :size="size"
       v-clipboard:copy="valueToCopy" v-clipboard:success="copySuccess" />
-    <ni-button class="button" flat :label="label" color="black" :size="size"
+    <ni-button class="button" flat :label="label" color="copper-grey-700" :size="size"
       v-clipboard:copy="valueToCopy" v-clipboard:success="copySuccess" />
   </div>
 </template>

--- a/src/core/components/courses/CourseCell.vue
+++ b/src/core/components/courses/CourseCell.vue
@@ -165,7 +165,7 @@ export default {
     margin-right: 10px;
   .infos-course
     &-nearest-date
-      color: $primary !important;
+      color: $copper-grey-900 !important;
       font-size: 14px;
     &-container
       align-items: center;

--- a/src/core/components/courses/QuestionAnswerChart.vue
+++ b/src/core/components/courses/QuestionAnswerChart.vue
@@ -65,7 +65,7 @@ export default {
 .bar-label
   font-size: 14px
   position: absolute
-  color: black
+  color: $copper-grey-700
   display: flex
   justify-content: space-between
   width: 100%

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -3,7 +3,7 @@
     <div class="q-mb-xl">
       <q-item class="slot-section-title">
         <q-item-section side>
-          <q-icon color="black" size="xl" :name="formatSlotTitle.icon" flat dense />
+          <q-icon color="copper-grey-700" size="xl" :name="formatSlotTitle.icon" flat dense />
         </q-item-section>
         <q-item-section>
           <div class="text-weight-bold">{{ formatSlotTitle.title }}</div>

--- a/src/core/components/courses/SurveyChart.vue
+++ b/src/core/components/courses/SurveyChart.vue
@@ -103,7 +103,6 @@ export default {
 .bar-label
   position: absolute
   font-size: 16px
-  color: black
   text-align: center
   width: 100%
 </style>

--- a/src/core/components/form/DateInput.vue
+++ b/src/core/components/form/DateInput.vue
@@ -1,14 +1,14 @@
 <template>
   <div :class="contentClass">
     <div v-if="caption" class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <q-input borderless dense :value="inputDate" bg-color="white" @input="input" placeholder="jj/mm/yyyy" :error="error"
       :disable="disable" :class="{ 'borders': inModal }" :error-message="errorMessage" @blur="blur" ref="dateInput"
       @focus="focus">
       <template #append>
-        <q-icon name="event" class="cursor-pointer" @click="focus" color="copper-grey-600">
+        <q-icon name="event" class="cursor-pointer" @click="focus" color="copper-grey-500">
           <q-menu ref="qDateMenu" anchor="bottom right" self="top right">
             <q-date minimal :value="date" @input="select" :options="dateOptions" :disable="disable" />
           </q-menu>
@@ -87,4 +87,7 @@ export default {
       padding-left: 14px
       padding-right: 14px
       border-radius: 3px
+
+  /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
+    color: $copper-grey-900
 </style>

--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="col-12">
     <div v-if="caption" class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <q-field dense borderless :error="hasError" :error-message="innerErrorMessage">
@@ -93,7 +93,7 @@ export default {
     background-color: white
     & .delimiter
       margin: 0
-      color: black
+      color: $copper-grey-700
 
   .date-item
     max-width: 150px

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="col-12 margin-input">
     <div v-if="caption" class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="hasError" name="error_outline" color="secondary" />
     </div>
     <q-field :error="hasError" error-message="Date(s) et heure(s) invalide(s)" borderless>
@@ -155,7 +155,7 @@ export default {
 
   .delimiter
     margin: 0
-    color: black
+    color: $copper-grey-700
     @media screen and (max-width: 767px)
       display: none
 </style>

--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="margin-input col-xs-12 col-md-6">
     <div v-if="displayCaption" class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <div v-if="document && imageSource" class="row justify-between" style="background: white">
@@ -15,7 +15,7 @@
     </div>
     <q-field borderless v-else :error="error" :error-message="errorMessage">
       <q-uploader ref="uploader" flat :bordered="inModal" color="white" :label="label" :url="url" with-credentials
-        text-color="black" @failed="failMsg" :form-fields="additionalFields" :max-file-size="maxFileSize"
+        text-color="copper-grey-700" @failed="failMsg" :form-fields="additionalFields" :max-file-size="maxFileSize"
         @uploaded="documentUploaded" auto-upload :accept="extensions" field-name="file" :multiple="multiple"
         @rejected="rejected" :disable="disable" @start="uploadStarted" @finish="uploadFinished" />
     </q-field>

--- a/src/core/components/form/Input.vue
+++ b/src/core/components/form/Input.vue
@@ -2,7 +2,7 @@
   <div v-if="!hidden" :class="{ 'col-xs-12 col-md-6': !inModal, 'margin-input full-width': inModal, last: last }"
     class="input">
     <div class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <template v-if="type === 'file'">
@@ -133,4 +133,7 @@ export default {
     line-height: 1
     font-size: 11px
     padding-top: 3px
+
+  /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
+    color: $copper-grey-900
 </style>

--- a/src/core/components/form/MultipleFilesUploader.vue
+++ b/src/core/components/form/MultipleFilesUploader.vue
@@ -11,7 +11,7 @@
     </template>
     <template v-if="documents && documents.length > 0">
       <div class="row" v-if="caption">
-        <p class="input-caption">{{ caption }}</p>
+        <p class="input-caption text-copper-grey-500">{{ caption }}</p>
       </div>
       <div class="row gutter-profile">
         <template v-for="(certificate, index) in documents">

--- a/src/core/components/form/OptionGroup.vue
+++ b/src/core/components/form/OptionGroup.vue
@@ -2,7 +2,7 @@
   <div :class="['row', 'margin-input', { last: last }]">
     <div class="col-12">
       <div v-if="displayCaption" class="row justify-between">
-        <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+        <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
         <q-icon v-if="error" name="error_outline" color="secondary" />
       </div>
       <q-field dense borderless :error="error" :error-message="errorMessage" class="col-12">
@@ -39,7 +39,7 @@ export default {
   .required::after
     content: ' *'
   /deep/.q-option-group
-    color: black !important
+    color: $copper-grey-700 !important
     .q-radio
       padding: 10px 0 !important
       .q-radio__label

--- a/src/core/components/form/SearchAddress.vue
+++ b/src/core/components/form/SearchAddress.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="{ 'col-12 col-md-6': !inModal, 'col-12': inModal }">
     <div class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
       <q-select dense borderless :value="value.fullAddress" @input="update" use-input fill-input hide-selected
@@ -85,4 +85,7 @@ export default {
       display: none
     .q-spinner
       display: none
+
+  /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
+    color: $copper-grey-900
 </style>

--- a/src/core/components/form/Select.vue
+++ b/src/core/components/form/Select.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="{ 'col-xs-12 col-md-6': !inModal, 'margin-input full-width': inModal, last: last }">
     <div v-if="caption" class="row justify-between">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <q-select dense borderless :value="model" :bg-color="bgColor" :options="innerOptions" :multiple="multiple"
@@ -94,4 +94,7 @@ export default {
       display: none
   .select-icon
     margin: 0
+
+  /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
+    color: $copper-grey-900
 </style>

--- a/src/core/components/form/SelectSector.vue
+++ b/src/core/components/form/SelectSector.vue
@@ -1,6 +1,7 @@
 <template>
   <ni-select :in-modal="inModal" :value="value" @input="updateSector" :options="sectors" :error-message="errorMessage"
-    @blur="blurHandler" @focus="focusHandler" filter-placeholder="Rechercher" :error="error" ref="selectSector" />
+    @blur="blurHandler" @focus="focusHandler" filter-placeholder="Rechercher" :error="error" ref="selectSector"
+    :caption="caption" :required-field="requiredField" />
 </template>
 
 <script>
@@ -19,6 +20,8 @@ export default {
     allowNullOption: { type: Boolean, default: false },
     error: { type: Boolean, default: false },
     errorMessage: { type: String, default: REQUIRED_LABEL },
+    caption: { type: String, default: 'Équipe' },
+    requiredField: { type: Boolean, default: false },
   },
   components: {
     'ni-select': Select,

--- a/src/core/components/form/TimeInput.vue
+++ b/src/core/components/form/TimeInput.vue
@@ -2,7 +2,7 @@
   <div :class="{ 'col-xs-12 col-md-6': !inModal, 'margin-input full-width': inModal }"
     class="input">
     <div class="row justify-between" v-if="caption">
-      <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
+      <p :class="['input-caption', 'text-copper-grey-500', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <q-input dense bg-color="white" borderless :value="value" @input="update" :class="{ borders: inModal }"
@@ -10,7 +10,7 @@
       data-cy="time-input">
       <template #append>
         <q-icon name="far fa-clock" class="cursor-pointer" @click.native="selectTime = !selectTime"
-          color="copper-grey-600">
+          color="copper-grey-500">
           <q-menu ref="qTimeMenu" anchor="bottom right" self="top right">
             <q-list dense padding>
               <q-item v-for="(hour, index) in hoursOptions" :key="index" clickable @click="select(hour.value)"
@@ -91,4 +91,7 @@ export default {
 <style lang="stylus" scoped>
   .q-list
     width: 100px
+
+  /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
+    color: $copper-grey-900
 </style>

--- a/src/core/components/learners/ProfileInfo.vue
+++ b/src/core/components/learners/ProfileInfo.vue
@@ -20,7 +20,7 @@
             :disable="emailLock" v-model.trim="userProfile.local.email" @focus="saveTmp('local.email')" />
         </div>
         <div :class="['col-xs-1', 'row', 'justify-end', { 'cursor-pointer': emailLock }]">
-          <ni-button color="black" :icon="lockIcon" @click="toggleEmailLock(!emailLock)" />
+          <ni-button color="copper-grey-500" :icon="lockIcon" @click="toggleEmailLock(!emailLock)" />
         </div>
       </div>
       <ni-input v-model.trim="userProfile.contact.phone" @focus="saveTmp('contact.phone')"

--- a/src/core/components/menu/MenuItem.vue
+++ b/src/core/components/menu/MenuItem.vue
@@ -1,6 +1,6 @@
 <template functional>
-  <q-item :to="{ name: props.name, params: props.params, query: props.query }" exact>
-    <q-item-section avatar><q-icon :name="props.icon" size="xs" /></q-item-section>
+  <q-item dense :to="{ name: props.name, params: props.params, query: props.query }" exact>
+    <q-item-section avatar><q-icon :name="props.icon" size="20px" /></q-item-section>
     <q-item-section>{{ props.label }}</q-item-section>
   </q-item>
 </template>

--- a/src/core/components/menu/MenuItem.vue
+++ b/src/core/components/menu/MenuItem.vue
@@ -1,5 +1,5 @@
 <template functional>
-  <q-item v-if="props.displayItem" :to="{ name: props.name, params: props.params, query: props.query }" exact>
+  <q-item :to="{ name: props.name, params: props.params, query: props.query }" exact>
     <q-item-section avatar><q-icon :name="props.icon" size="xs" /></q-item-section>
     <q-item-section>{{ props.label }}</q-item-section>
   </q-item>
@@ -7,13 +7,13 @@
 
 <script>
 export default {
+  name: 'MenuItem',
   props: {
     params: { type: Object, default: () => ({}) },
     query: { type: Object, default: () => ({}) },
     name: { type: String, default: '' },
     label: { type: String, default: '' },
     icon: { type: String, default: '' },
-    displayItem: { type: Boolean, default: true },
   },
 };
 </script>

--- a/src/core/components/table/EditableTd.vue
+++ b/src/core/components/table/EditableTd.vue
@@ -45,5 +45,5 @@ export default {
         min-width: 60px
         padding: 0 4px
       &__suffix
-        line-height: 19px
+        line-height: 20px
 </style>

--- a/src/core/components/table/PrefixedCellContent.vue
+++ b/src/core/components/table/PrefixedCellContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row no-wrap items-center">
-    <q-icon v-if="cellValue > 0" name="mdi-plus-circle-outline" color="copper-grey-400" class="balance-icon" />
+    <q-icon v-if="cellValue > 0" name="mdi-plus-circle-outline" color="copper-grey-500" class="balance-icon" />
     <q-icon v-if="cellValue < 0" name="mdi-minus-circle-outline" color="secondary" class="balance-icon" />
     <div>{{ content }}</div>
   </div>

--- a/src/core/pages/AccountInfo.vue
+++ b/src/core/pages/AccountInfo.vue
@@ -24,7 +24,7 @@
               :error-message="emailError($v.userProfile)" v-model.trim="userProfile.local.email" />
           </div>
           <div :class="['col-1', 'row', 'justify-end', { 'cursor-pointer': emailLock }]">
-            <ni-button :icon="lockIcon" @click.native="toggleEmailLock(!emailLock)" color="black" />
+            <ni-button :icon="lockIcon" @click.native="toggleEmailLock(!emailLock)" color="copper-grey-500" />
           </div>
         </div>
         <ni-input v-model.trim="userProfile.contact.phone" @focus="saveTmp('contact.phone')"

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -18,7 +18,7 @@
 }
 
 body
-  color: $copper-grey-900
+  color: $copper-grey-700
   font-family: 'AvenirLTStd-Light', 'Roboto', 'Helvetica', 'Arial'
   font-size: 16px
 

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -37,6 +37,7 @@ div h4:only-child
 .page-title
   font-size: 32px
   font-weight: 700
+  color: $copper-grey-900
 
 .gutter-profile
   margin-top: -24px

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -19,7 +19,7 @@
 
 body
   color: $copper-grey-900
-  font-family: 'AvenirLTStd-Light'
+  font-family: 'AvenirLTStd-Light', 'Roboto', 'Helvetica', 'Arial'
   font-size: 16px
 
   @media screen and (max-width: 767px)

--- a/src/css/chip.styl
+++ b/src/css/chip.styl
@@ -8,9 +8,11 @@
       left: 50%
       transform: translate(-50%, -50%)
   .q-chip
-    background: $copper-grey-800
+    background-color: $copper-grey-50
+    border: 1px solid $copper-grey-300
+    color: $copper-grey-700
     width: 100%
-    padding: 0 10px
+    padding: 0 8px
     justify-content: flex-end
     margin: 0
     @media screen and (max-width: 767px)
@@ -21,9 +23,13 @@
       padding: 0 2px
       min-width: fit-content
     &.high-occupation
-      background: $secondary !important
+      background-color: $orange-300
+      color: $orange-900
+      border: 1px solid $orange-300
     &.extreme-occupation
-      background: $red !important
+      border: 1px solid $red
+      background: $red
+      color: $copper-grey-50
     &__content
       display: flex
       justify-content: flex-end
@@ -31,7 +37,7 @@
   .avatar
     z-index: 2
     box-shadow: none
-    border: 1px solid $copper-grey-600
+    border: 1px solid $copper-grey-300
     @media screen and (min-width: $breakpoint-md-min)
       width: 2.5rem
       height: 2.5rem

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -1,6 +1,3 @@
-.q-layout-drawer .q-list .router-link-active
-    color: $primary !important
-
 .q-drawer
   min-width: 30px
   box-shadow: 0 3px 5px -1px rgba(0,0,0,0.2), 0 5px 8px rgba(0,0,0,0.14), 0 1px 14px rgba(0,0,0,0.12)
@@ -20,25 +17,34 @@
             height: 42px
       & .q-item__label
         font-size: 1.125rem
+
       & .q-expansion-item__content
-        padding: 8px 16px
+        padding: 8px 0
         & .q-item
           min-height: 20px
-          padding: 8px 16px 8px 0px
+          padding: 8px 16px
           & .q-item__section--main
             line-height: 20px
-          & .q-item__section--side
-            padding: 0
-            color: $copper-grey-600
           & .q-item__section--avatar
             min-width: 24px
           & .q-item__label
             font-size: 1rem
+
       & .q-item
         & .q-item__section--side
-          color: $copper-grey-600
+          padding: 0
+          color: $copper-grey-500
+        & .q-item__section--main
+          color: $copper-grey-700
         & .q-item__section--avatar
           min-width: 38px
+
+        &.q-router-link--active
+          background-color: $copper-100
+          .q-item__section--main
+            color: $copper-700
+          .q-item__section--side
+            color: $copper-500
 
       & .sidemenu-footer
         flex-grow: 1

--- a/src/css/drawer.styl
+++ b/src/css/drawer.styl
@@ -8,23 +8,20 @@
       flex-direction: column
       min-height: 100%
       & .sidemenu-header
-        padding: 15px 16px
+        padding: 16px
         & .q-item__label--header
-          padding: 12px 9px
+          padding: 12px 8px
           display: flex
           img
             width: 200px
-            height: 42px
+            height: 40px
       & .q-item__label
         font-size: 1.125rem
 
       & .q-expansion-item__content
         padding: 8px 0
         & .q-item
-          min-height: 20px
           padding: 8px 16px
-          & .q-item__section--main
-            line-height: 20px
           & .q-item__section--avatar
             min-width: 24px
           & .q-item__label
@@ -38,6 +35,7 @@
           color: $copper-grey-700
         & .q-item__section--avatar
           min-width: 38px
+          justify-content: flex-start;
 
         &.q-router-link--active
           background-color: $copper-100

--- a/src/css/modal.styl
+++ b/src/css/modal.styl
@@ -40,11 +40,6 @@
     & .q-icon
       font-size: 21px
 
-.q-toolbar
-  padding: 20px 58px
-  background-color: white
-  color: black
-
 .q-dialog
   .full-height
     .q-card__section

--- a/src/css/planning.styl
+++ b/src/css/planning.styl
@@ -74,7 +74,7 @@
         align-items: center;
     &-name
       font-size: 1.125rem
-      color: $copper-grey-400
+      color: $copper-grey-500
     &-number
       font-size: 1.5rem
       font-weight: 600
@@ -163,6 +163,7 @@
     bottom: -3px
 
 .person-name
+  color: $copper-grey-900
   display: flex
   flex-direction: row
   align-items: center
@@ -195,8 +196,8 @@
     margin-top: 4px
 
 .holiday
-  background-color: $primary
-  color: white
+  background-color: $copper-100
+  color: $copper-700
   font-size: 12px
   border-radius: 5px
   width: 20px

--- a/src/modules/client/components/auxiliary/AuxiliaryCreationModal.vue
+++ b/src/modules/client/components/auxiliary/AuxiliaryCreationModal.vue
@@ -22,16 +22,9 @@
       <ni-search-address :value="newUser.contact.address" color="white" inverted-light
         @blur="validations.contact.address.$touch" error-message="Adresse non valide"
         :error="validations.contact.address.$error" in-modal @input="updateUser($event, 'contact.address')" />
-      <div class="row margin-input">
-        <div class="col-12">
-          <div class="row justify-between">
-            <p class="input-caption required">Équipe</p>
-            <q-icon v-if="validations.sector.$error" name="error_outline" color="secondary" />
-          </div>
-          <ni-select-sector :value="newUser.sector" @blur="validations.sector.$touch" :error-message="REQUIRED_LABEL"
-            :company-id="companyId" :error="validations.sector.$error" in-modal @input="updateUser($event, 'sector')" />
-        </div>
-      </div>
+      <ni-select-sector :value="newUser.sector" @blur="validations.sector.$touch" :error-message="REQUIRED_LABEL"
+        :company-id="companyId" :error="validations.sector.$error" in-modal @input="updateUser($event, 'sector')"
+        required-field />
       <div class="row margin-input last">
         <q-checkbox :value="sendWelcomeMsg" label="Envoyer SMS d'accueil" dense @input="updateSendWelcome" />
       </div>

--- a/src/modules/client/components/auxiliary/ProfileInfo.vue
+++ b/src/modules/client/components/auxiliary/ProfileInfo.vue
@@ -1,11 +1,8 @@
 <template>
   <div v-if="isLoaded">
     <div v-if="isCoach" class="row gutter-profile q-mb-xl">
-      <div class="col-xs-12 col-md-6">
-        <p class="input-caption">Équipe</p>
-        <ni-select-sector v-model="userProfile.sector" @blur="updateUser('sector')" @focus="saveTmp('sector')"
-          :company-id="loggedUser.company._id" />
-      </div>
+      <ni-select-sector v-model="userProfile.sector" @blur="updateUser('sector')" @focus="saveTmp('sector')"
+        :company-id="loggedUser.company._id" />
       <ni-input v-model="userProfile.mentor" caption="Marraine/parrain" @focus="saveTmp('mentor')"
         @blur="updateUser('mentor')" />
       <ni-select v-model="userProfile.role.client._id" caption="Rôle" :options="auxiliaryRolesOptions"
@@ -75,7 +72,7 @@
               :error-message="emailError($v.userProfile)" v-model.trim="userProfile.local.email" />
           </div>
           <div :class="['col-xs-1', 'row', 'justify-end', { 'cursor-pointer': emailLock }]">
-            <ni-button :icon="lockIcon" @click.native="toggleEmailLock(!emailLock)" color="black" />
+            <ni-button :icon="lockIcon" @click.native="toggleEmailLock(!emailLock)" color="copper-grey-500" />
           </div>
         </div>
         <ni-search-address v-model="userProfile.contact.address" color="white"
@@ -194,9 +191,9 @@
           </div>
           <q-field dense :error="$v.userProfile.administrative.mutualFund.has.$error"
             :error-message="requiredLabel">
-            <q-btn-toggle class="full-width" color="white" text-color="black" toggle-color="primary"
-              v-model="userProfile.administrative.mutualFund.has"
-              @input="updateUser('administrative.mutualFund.has')" :options="mutualOptions" />
+            <q-btn-toggle class="full-width" color="white" text-color="copper-grey-700" toggle-color="primary"
+              v-model="userProfile.administrative.mutualFund.has" :options="mutualOptions"
+              @input="updateUser('administrative.mutualFund.has')" />
           </q-field>
         </div>
         <div class="col-xs-12 col-md-6" v-if="hasMutual">

--- a/src/modules/client/components/contracts/ContractsCell.vue
+++ b/src/modules/client/components/contracts/ContractsCell.vue
@@ -305,9 +305,6 @@ export default {
     margin:  0 10px 10px
     font-size: 14px
 
-  .toolbar-padding
-    padding: 20px 58px
-
   /deep/ .q-layout-header
     box-shadow: none
 

--- a/src/modules/client/components/planning/ChipAuxiliaryIndicator.vue
+++ b/src/modules/client/components/planning/ChipAuxiliaryIndicator.vue
@@ -3,7 +3,7 @@
     <div :class="[!staffingView && 'q-mb-sm']">
       <div class="chip-container" @click="openIndicatorsModal">
         <img :src="getAvatar(person.picture)" class="avatar">
-        <q-chip v-if="hasContractOnEvent" :class="[`${occupationLevel}-occupation`]" small text-color="white">
+        <q-chip v-if="hasContractOnEvent" :class="[`${occupationLevel}-occupation`]" small>
           <q-spinner-dots v-if="loading" />
           <span v-else class="chip-indicator">
             {{ Math.round(workingStats.workedHours) }}h / {{ Math.round(workingStats.hoursToWork) }}

--- a/src/modules/client/components/planning/ChipCustomerIndicator.vue
+++ b/src/modules/client/components/planning/ChipCustomerIndicator.vue
@@ -3,7 +3,7 @@
     <div class="person-name overflow-hidden-nowrap">{{ person.identity | formatIdentity('fL') }}</div>
     <div :class="[!staffingView && 'q-mb-sm']">
       <div class="chip-container">
-        <q-chip small text-color="white">
+        <q-chip small>
           <span class="chip-indicator">{{ indicators.weeklyHours }}h - {{ indicators.auxiliariesNumber }}</span>
           <q-icon size="14px" name="mdi-human-male" />
         </q-chip>

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -9,7 +9,7 @@
           @input="update($event, 'auxiliary')" />
         <div class="modal-subtitle">
           <q-btn-toggle no-wrap :value="newEvent.type" unelevated toggle-color="primary" :options="eventTypeOptions"
-            @input="updateType($event)" text-color="black" />
+            @input="updateType($event)" text-color="copper-grey-700" />
         </div>
         <template v-if="newEvent.type !== ABSENCE">
           <ni-datetime-range caption="Dates et heures de l'évènement" :value="newEvent.dates" required-field

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -89,7 +89,7 @@
         <div class="q-mb-lg">
           <div class="flex-row items-center justify-between">
             <div class="flex-row items-center">
-              <q-icon size="sm" name="history" class="q-mr-sm" color="copper-grey-400" />
+              <q-icon size="sm" name="history" class="q-mr-sm" color="copper-grey-500" />
               <div class="history-list-title text-weight-bold">Activité</div>
             </div>
             <ni-button :label="historyButtonLabel" color="copper-grey-800" class="bg-copper-grey-100"

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -4,8 +4,8 @@
       <div class="col-xs-12 col-md-5 planning-search">
         <ni-chips-autocomplete ref="refFilter" v-model="terms" :disable="displayAllSectors" :filters="filters"
           data-cy="planning-search" />
-        <q-btn v-if="!isCustomerPlanning && isCoach" flat round :icon="displayAllSectors ? 'arrow_forward' : 'people'"
-          @click="toggleAllSectors" :color="displayAllSectors ? 'primary' : ''" />
+        <ni-button v-if="!isCustomerPlanning && isCoach" :icon="displayAllSectors ? 'arrow_forward' : 'people'"
+          @click="toggleAllSectors" color="copper-grey-500" />
       </div>
       <div class="col-xs-12 col-md-7">
         <planning-navigation :timeline-title="timelineTitle()" :target-date="targetDate" :type="PLANNING"
@@ -19,7 +19,7 @@
       <table :class="[staffingView ? 'staffing' : 'non-staffing', 'planning-table']">
         <thead>
           <th :style="{ top: `${planningHeaderHeight}px`}" :class="{ 'bottom-border': uniqPersons.length > 0 }">
-            <q-btn v-if="!isCustomerPlanning" flat round icon="view_week" :color="staffingView ? 'primary' : ''"
+            <ni-button v-if="!isCustomerPlanning" icon="view_week" color="copper-grey-500"
               @click="staffingView = !staffingView" />
           </th>
           <th :style="{ top: `${planningHeaderHeight}px`}" :class="{ 'bottom-border': uniqPersons.length > 0 }"
@@ -46,7 +46,7 @@
                 <div class="person-inner-cell">
                   <div :class="[!staffingView && 'q-mb-md', 'chip-container']">
                     <img :src="UNKNOWN_AVATAR" class="avatar">
-                    <q-chip small text-color="white">
+                    <q-chip small>
                       <span class="chip-indicator">{{ Math.round(unassignedHourCount(sectorId)) }}h</span>
                     </q-chip>
                   </div>
@@ -101,6 +101,7 @@ import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
 import uniqBy from 'lodash/uniqBy';
 import Customers from '@api/Customers';
+import Button from '@components/Button';
 import { NotifyNegative, NotifyWarning } from '@components/popup/notify';
 import {
   PLANNING,
@@ -128,6 +129,7 @@ export default {
   name: 'PlanningManager',
   mixins: [planningTimelineMixin, planningEventMixin],
   components: {
+    'ni-button': Button,
     'ni-planning-event-cell': NiPlanningEvent,
     'ni-chips-autocomplete': ChipsAutocomplete,
     'planning-navigation': PlanningNavigation,

--- a/src/modules/client/layouts/Layout.vue
+++ b/src/modules/client/layouts/Layout.vue
@@ -89,9 +89,6 @@ export default {
     @media screen and (max-width: $breakpoint-sm-max)
       display: none
 
-  .q-toolbar
-    color: $primary
-
   .q-btn
     color: $copper-grey-800
     &:hover

--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -421,10 +421,6 @@ export default {
   @media screen and (max-width: 767px)
     font-size: 12px
 
-/deep/ .q-circular-progress__text
-  font-size: 15px
-  color: black
-
 .customer
   display: flex
   flex-direction: column

--- a/src/modules/client/pages/ni/courses/Dashboard.vue
+++ b/src/modules/client/pages/ni/courses/Dashboard.vue
@@ -6,7 +6,7 @@
       <ni-date-range v-model="dates" class="dates" borders />
     </div>
     <q-card flat class="q-pa-md row">
-      <div class="text-weight-bold q-mb-sm col-md-4 col-xs-12">Le eLearning dans ma structure</div>
+      <div class="text-weight-bold q-mb-sm col-md-4 col-xs-12 text-copper-grey-700">Le eLearning dans ma structure</div>
       <div class="row justify-around col-md-8 col-xs-12">
         <div class="column items-center">
           <ni-e-learning-indicator :indicator="activeLearners" />
@@ -21,9 +21,9 @@
     <div class="row q-mt-md">
       <div class="col-xs-12 col-md-6 left-card">
         <q-card flat class="fit q-pa-md">
-          <div class="text-weight-bold q-mb-sm">Apprenants les plus assidus</div>
+          <div class="text-weight-bold q-mb-sm text-copper-grey-700">Apprenants les plus assidus</div>
           <div class="row justify-end">
-            <div class="col-4 text-copper-grey-800 text-center">Activités eLearning réalisées</div>
+            <div class="col-4 text-copper-grey-500 text-center">Activités eLearning réalisées</div>
           </div>
           <div v-for="(learner, index) in learnerList.slice(0, 5)" :key="learner._id"
             class="justify-between items-center row q-my-sm">
@@ -38,9 +38,9 @@
       </div>
       <div class="col-xs-12 col-md-6 right-card">
         <q-card flat class="fit q-pa-md">
-          <div class="text-weight-bold q-mb-sm">Formations les plus suivies</div>
+          <div class="text-weight-bold q-mb-sm text-copper-grey-700">Formations les plus suivies</div>
           <div class="row justify-end">
-            <div class="col-4 text-copper-grey-800 text-center">Nombre d'apprenants actifs</div>
+            <div class="col-4 text-copper-grey-500 text-center">Nombre d'apprenants actifs</div>
           </div>
           <div v-for="(course, index) in courseList.slice(0, 5)" :key="course.name"
             class="justify-between items-center row q-my-sm">
@@ -188,4 +188,5 @@ export default {
 
 .section-title
   font-size: 24px;
+  color: $copper-grey-900
 </style>

--- a/src/modules/client/pages/ni/customers/CustomersFundingsMonitoring.vue
+++ b/src/modules/client/pages/ni/customers/CustomersFundingsMonitoring.vue
@@ -7,8 +7,7 @@
       <template slot="content">
         <div class=" col-xs-12 row items-baseline justify-end fill-width">
           <div class="col-xs-12 col-sm-6 col-md-4">
-            <ni-select-sector class="q-pl-sm" v-model="selectedSector" @input="onInputSector"
-              allow-null-option />
+            <ni-select-sector class="q-pl-sm" v-model="selectedSector" @input="onInputSector" allow-null-option />
           </div>
           <div class="col-xs-12 col-sm-6 col-md-4">
             <ni-select class="q-pl-sm" :options="thirdPartyPayerOptions" v-model="selectedThirdPartyPayer"

--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -14,7 +14,7 @@
           <q-card-section class="step-head cursor-pointer row" :id="step._id">
             <div class="step-info" @click="showActivities(step._id)">
               <q-item-section side>
-                <q-icon :name="getStepTypeIcon(step.type)" size="sm" color="black" />
+                <q-icon :name="getStepTypeIcon(step.type)" size="sm" color="copper-grey-500" />
               </q-item-section>
               <q-item-section>
                 <div class="flex-direction row">
@@ -670,7 +670,7 @@ export default {
       padding-right: 10px
 
 .no-activity
-  color: black
+  color: $copper-grey-700
   font-size: 14px
   margin: 10px
 

--- a/src/modules/vendor/components/questionnaires/ProfileEdition.vue
+++ b/src/modules/vendor/components/questionnaires/ProfileEdition.vue
@@ -4,7 +4,7 @@
       <div class="row body">
         <ni-input v-model.trim="questionnaire.name" required-field caption="Nom" @blur="updateQuestionnaire"
           @focus="saveTmpName" :error="$v.questionnaire.name.$error" :disable="nameLock" />
-        <ni-button v-if="isQuestionnairePublished" color="black" :icon="lockIcon"
+        <ni-button v-if="isQuestionnairePublished" color="copper-grey-500" :icon="lockIcon"
           @click="nameLock = !nameLock" />
       </div>
       <div class="publish-button">

--- a/src/modules/vendor/components/trainers/ProfileInfo.vue
+++ b/src/modules/vendor/components/trainers/ProfileInfo.vue
@@ -13,7 +13,7 @@
             :disable="emailLock" v-model.trim="userProfile.local.email" @focus="saveTmp('local.email')" />
         </div>
         <div :class="['col-xs-1', 'row', 'justify-end', { 'cursor-pointer': emailLock }]">
-          <ni-button :icon="lockIcon" color="black" @click.native="toggleEmailLock(!emailLock)" />
+          <ni-button :icon="lockIcon" color="copper-grey-500" @click.native="toggleEmailLock(!emailLock)" />
         </div>
       </div>
       <ni-input v-model.trim="userProfile.contact.phone" @focus="saveTmp('contact.phone')"

--- a/src/modules/vendor/layouts/Layout.vue
+++ b/src/modules/vendor/layouts/Layout.vue
@@ -85,9 +85,6 @@ export default {
     @media screen and (max-width: $breakpoint-sm-max)
       display: none
 
-  .q-toolbar
-    color: $primary
-
   .q-btn
     color: $copper-grey-800
     &:hover


### PR DESCRIPTION
MIse en place de la nouvelle charte graphique

- Cas d'usage : 

Cote menu : 
- le menu séléctionné est en copper-500 pour l'icone, copper-700 pour le texte et copper-100 pour le fond
- pour les autres éléments du menu : icones en copper-grey-500 et texte en copper-grey-700

Toolbar : je l'ai supprimé car je ne voyais pas ou c'était utilisé

Planning : 
- les indicteurs ont un fond en copper-grey-50 / bordure en copper-grey-300 quand les heures travaillées sont en dessous du contrat

Général
- la couleur de texte principal est le copper-grey-700
- les labels des champs (texte / selecteur / date / ....) sont en copper-grey-500 et le texte en copper-grey-900
- j'ai enlevé le noir partout (sauf dans `PictureUploader` il n'acceptait pas copper-grey-900) et je l'ai remplacé par copper-grey-... selon les cas
- j'ai uniformisé `SectorSelector` avec les autres composants réutilisables
- j'ai remis les polices secondaires au cas ou Avenir ne fonctionne pas