### PR TITLE
fix favicon error in console

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -14,7 +14,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="https://storage.googleapis.com/compani-main/icons/blue-apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="https://storage.googleapis.com/compani-main/icons/blue_favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="https://storage.googleapis.com/compani-main/icons/blue_favicon_16x16.png">
-    <link rel="manifest" href="favicon_metadata/blue_site.webmanifest">
+    <link rel="manifest" href="favicon_metadata/site.webmanifest">
     <link rel="mask-icon" href="https://storage.googleapis.com/compani-main/icons/blue_favicon.ico">
     <link rel="shortcut icon" href="https://storage.googleapis.com/compani-main/icons/blue_favicon.ico">
   </head>


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : np

- Périmetre roles : np

- Cas d'usage : Sur l'app quand j'ouvre la console, je n'ai plus d'erreur (cf image)
<img width="638" alt="Capture d’écran 2021-07-01 à 08 41 01" src="https://user-images.githubusercontent.com/22516544/124078412-1c2ace80-da48-11eb-8827-48617d706cb4.png">