### PR TITLE
COM-2217 - fix display on safari

### DIFF
--- a/src/modules/client/components/planning/ChipCustomerIndicator.vue
+++ b/src/modules/client/components/planning/ChipCustomerIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="person-inner-cell">
+  <div class="person-inner-cell flex-column">
     <div class="person-name overflow-hidden-nowrap">{{ person.identity | formatIdentity('fL') }}</div>
     <div :class="[!staffingView && 'q-mb-sm']">
       <div class="chip-container">


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client

- Périmetre roles : Coach / Auxiliaire

- Cas d'usage : Sur safari, sur le planning bénéficiaire, je vois bien le nom du référent
