### PR TITLE
COM-2207 create customerNote decription history

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -485,3 +485,4 @@ export const MANUAL_TIME_STAMPING_REASONS = {
 };
 // NOTE
 export const NOTE_CREATION = 'note_creation';
+export const NOTE_UPDATE = 'note_update';

--- a/src/modules/client/components/customers/infos/CustomerNoteEditionModal.vue
+++ b/src/modules/client/components/customers/infos/CustomerNoteEditionModal.vue
@@ -54,7 +54,7 @@ export default {
     lastHistoryMessage () {
       if (!get(this.editedNote, 'histories.length')) return '';
 
-      const lastHistory = this.editedNote.histories[this.editedNote.histories.length - 1];
+      const lastHistory = this.editedNote.histories[0];
       const name = `${formatIdentity(lastHistory.createdBy.identity, 'FL')}`;
 
       return `dernière modification le ${formatDate(lastHistory.createdAt)} par ${name}`;

--- a/src/modules/client/components/customers/infos/CustomerNoteHistory.vue
+++ b/src/modules/client/components/customers/infos/CustomerNoteHistory.vue
@@ -29,12 +29,9 @@ export default {
     historyInfos () {
       switch (this.history.action) {
         case NOTE_UPDATE:
-          if (this.history.description) {
-            return [
-              { label: 'Nouvelle description: ', details: this.history.description },
-            ];
-          }
-          return;
+          return this.history.description
+            ? [{ label: 'Nouvelle description : ', details: this.history.description }]
+            : [];
         case NOTE_CREATION:
         default:
           return [

--- a/src/modules/client/components/customers/infos/CustomerNoteHistory.vue
+++ b/src/modules/client/components/customers/infos/CustomerNoteHistory.vue
@@ -16,7 +16,7 @@
 
 <script>
 import get from 'lodash/get';
-import { NOTE_CREATION, DEFAULT_AVATAR } from '@data/constants';
+import { NOTE_CREATION, NOTE_UPDATE, DEFAULT_AVATAR } from '@data/constants';
 import { formatIdentity, formatHoursWithMinutes } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 
@@ -28,6 +28,13 @@ export default {
   computed: {
     historyInfos () {
       switch (this.history.action) {
+        case NOTE_UPDATE:
+          if (this.history.description) {
+            return [
+              { label: 'Nouvelle description: ', details: this.history.description },
+            ];
+          }
+          return;
         case NOTE_CREATION:
         default:
           return [

--- a/src/modules/client/components/table/CustomerNoteCell.vue
+++ b/src/modules/client/components/table/CustomerNoteCell.vue
@@ -20,7 +20,7 @@ export default {
     lastHistoryMessage () {
       if (!get(this.note, 'histories.length')) return '';
 
-      const lastHistory = this.note.histories[this.note.histories.length - 1];
+      const lastHistory = this.note.histories[0];
       const name = `${formatIdentity(lastHistory.createdBy.identity, 'FL')}`;
 
       return `dernière modification le ${formatDate(lastHistory.createdAt)} par ${name}`;


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : auxilaire/coach/admin

- Cas d'usage : Lorsque l'on modifie la description d'une note de suivi, c'est enregistré dans l'historique.
