### PR TITLE
COM-2211 - Fix gcs use and add dynamic name

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -9,6 +9,7 @@ export const DOC_EXTENSIONS = 'image/jpg, image/jpeg, application/pdf';
 export const IMAGE_EXTENSIONS = 'image/jpg, image/jpeg, image/png';
 export const VIDEO_EXTENSIONS = 'video/*';
 export const AUDIO_EXTENSIONS = 'audio/*';
+export const HTML_EXTENSIONS = '.html';
 
 // CUSTOMER
 export const CIVILITY_OPTIONS = [

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -33,9 +33,13 @@
           <div class="col-xs-12">
             <q-checkbox v-model="customer.subscriptionsAccepted" class="q-mr-sm" @input="confirmAgreement"
               :disable="customer.subscriptionsAccepted" dense />
-            <span style="vertical-align: middle">J'accepte les conditions d’abonnement présentées ci-dessus ainsi que
-              les <a href="#cgs" @click.prevent="cgsModal = true">conditions générales de services
-                Alenvi</a>.<span class="text-weight-thin text-italic" data-cy="agreement"> {{ agreement }}</span></span>
+            <span style="vertical-align: middle">
+              J'accepte les conditions d’abonnement présentées ci-dessus ainsi que les
+              <a href="#gcs" @click.prevent="gcsModal = true">
+                conditions générales de services {{ helper.company.name }}.
+              </a>
+              <span class="text-weight-thin text-italic" data-cy="agreement">{{ agreement }}</span>
+            </span>
           </div>
         </div>
       </div>
@@ -109,8 +113,8 @@
     </q-dialog>
 
     <!-- CSG modal -->
-    <ni-html-modal title="Conditions Générales de Service Alenvi" v-model="cgsModal" :html="cgs" @show="openCgsModal"
-      @hide="closeCgsModal" :loading="!showCgs" />
+    <ni-html-modal :title="htmlModalTitle" v-model="gcsModal" :html="gcs" @show="openGcsModal" @hide="closeGcsModal"
+      :loading="!showGcs" />
 
     <!-- Subscription history modal -->
     <ni-modal v-model="subscriptionHistoryModal" @hide="resetSubscriptionHistoryData">
@@ -174,9 +178,9 @@ export default {
   mixins: [customerMixin, subscriptionMixin, financialCertificatesMixin, fundingMixin, tableMixin],
   data () {
     return {
-      cgs: null,
-      cgsModal: false,
-      showCgs: false,
+      gcs: null,
+      gcsModal: false,
+      showGcs: false,
       agreed: false,
       tmpInput: null,
       newESignModal: false,
@@ -249,6 +253,9 @@ export default {
         ? `${process.env.API_HOSTNAME}/customers/${this.customer._id}/gdrive/${this.customer.driveFolder.driveId}`
           + '/upload'
         : '';
+    },
+    htmlModalTitle () {
+      return `Conditions Générales de Services ${this.helper.company.name}`;
     },
   },
   async created () {
@@ -429,20 +436,20 @@ export default {
       this.fundingData = [];
       this.fundingModal = false;
     },
-    async openCgsModal () {
+    async openGcsModal () {
       try {
-        this.showCgs = false;
-        const cgsDriveId = get(this.helper, 'company.customersConfig.templates.cgs.driveId');
-        if (!cgsDriveId) return;
-        const file = await Drive.downloadFileById(cgsDriveId);
-        this.cgs = file.data;
-        this.showCgs = true;
+        this.showGcs = false;
+        const gcsDriveId = get(this.helper, 'company.customersConfig.templates.gcs.driveId');
+        if (!gcsDriveId) return;
+        const file = await Drive.downloadFileById(gcsDriveId);
+        this.gcs = file.data;
+        this.showGcs = true;
       } catch (e) {
         console.error(e);
       }
     },
-    closeCgsModal () {
-      this.cgs = null;
+    closeGcsModal () {
+      this.gcs = null;
     },
   },
 };

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -114,7 +114,7 @@
 
     <!-- CSG modal -->
     <ni-html-modal :title="htmlModalTitle" v-model="gcsModal" :html="gcs" @show="openGcsModal" @hide="closeGcsModal"
-      :loading="!showGcs" />
+      :loading="!gcsLoading" />
 
     <!-- Subscription history modal -->
     <ni-modal v-model="subscriptionHistoryModal" @hide="resetSubscriptionHistoryData">
@@ -180,7 +180,7 @@ export default {
     return {
       gcs: null,
       gcsModal: false,
-      showGcs: false,
+      gcsLoading: false,
       agreed: false,
       tmpInput: null,
       newESignModal: false,
@@ -438,14 +438,18 @@ export default {
     },
     async openGcsModal () {
       try {
-        this.showGcs = false;
+        this.gcsLoading = false;
         const gcsDriveId = get(this.helper, 'company.customersConfig.templates.gcs.driveId');
         if (!gcsDriveId) return;
+
         const file = await Drive.downloadFileById(gcsDriveId);
+
         this.gcs = file.data;
-        this.showGcs = true;
+        this.gcsLoading = true;
       } catch (e) {
         console.error(e);
+      } finally {
+        this.gcsLoading = false;
       }
     },
     closeGcsModal () {

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -86,7 +86,7 @@
               alt="document conditions générales de services" name="gcs" @uploaded="documentUploaded"
               :additional-value="`gcs_${company.name}`" :url="docsUploadUrl" drive-storage :entity="company"
               @delete="validateDocumentDeletion(company.customersConfig.templates.gcs.driveId,'gcs','customersConfig')"
-              />
+              :extensions="HTML_EXTENSIONS" />
           </div>
         </div>
       </div>
@@ -195,6 +195,7 @@ import {
   FIXED,
   COMPANY,
   REQUIRED_LABEL,
+  HTML_EXTENSIONS,
 } from '@data/constants';
 import moment from '@helpers/moment';
 import { roundFrenchPercentage, formatHoursWithMinutes } from '@helpers/utils';
@@ -534,6 +535,7 @@ export default {
         sortBy: 'startDate',
         descending: true,
       },
+      HTML_EXTENSIONS,
     };
   },
   validations: {


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : admin / aidant

- Cas d'usage : 
ETQ aidant, lorsque je clique sur 'les conditions générales de services Alenvi Home SAS.' dans mon onglet 'Abonnement', je vois le template de cgs d'Alenvi. Attention, ce fichier ne peut-être que un HTML pour l'instant. Je ne pense pas que ça soit le comportement voulu mais ça sort du périmètre du ticket, donc si vous êtes d'accord, je préviendrai Romain.

Si je suis un aidant d'une autre structure, je vois bien le template de ma structure ainsi que le nom de ma structure sur le lien
