### PR TITLE
COM-2167: remove green popup when fail on email change

### DIFF
--- a/src/core/components/learners/ProfileInfo.vue
+++ b/src/core/components/learners/ProfileInfo.vue
@@ -38,7 +38,6 @@ import Users from '@api/Users';
 import Input from '@components/form/Input';
 import Button from '@components/Button';
 import PictureUploader from '@components/PictureUploader';
-import { NotifyNegative } from '@components/popup/notify';
 import { userMixin } from '@mixins/userMixin';
 import { required, email } from 'vuelidate/lib/validators';
 import { AUXILIARY_ROLES } from '@data/constants';
@@ -91,7 +90,7 @@ export default {
         await this.refreshUser();
       } catch (e) {
         console.error(e);
-        NotifyNegative('Erreur lors de la modifiation de l\'apprenant');
+        throw e;
       }
     },
     async refreshUser () {

--- a/src/core/pages/AccountInfo.vue
+++ b/src/core/pages/AccountInfo.vue
@@ -154,7 +154,7 @@ export default {
         await this.refreshUser();
       } catch (e) {
         console.error(e);
-        NotifyNegative('Erreur lors de la modifiation du profil');
+        throw e;
       }
     },
     async submitPasswordChange () {

--- a/src/modules/client/components/auxiliary/ProfileInfo.vue
+++ b/src/modules/client/components/auxiliary/ProfileInfo.vue
@@ -551,7 +551,7 @@ export default {
         await this.refreshUser();
       } catch (e) {
         console.error(e);
-        NotifyNegative('Erreur lors de la modifiation de l\'auxiliaire');
+        throw e;
       }
     },
     documentTitle (path) {

--- a/src/modules/vendor/components/trainers/ProfileInfo.vue
+++ b/src/modules/vendor/components/trainers/ProfileInfo.vue
@@ -34,7 +34,6 @@ import set from 'lodash/set';
 import Users from '@api/Users';
 import Input from '@components/form/Input';
 import Button from '@components/Button';
-import { NotifyNegative } from '@components/popup/notify';
 import { userMixin } from '@mixins/userMixin';
 import { required, email } from 'vuelidate/lib/validators';
 import { validationMixin } from '@mixins/validationMixin';
@@ -88,7 +87,7 @@ export default {
         await this.refreshUser();
       } catch (e) {
         console.error(e);
-        NotifyNegative('Erreur lors de la modifiation du formateur');
+        throw e;
       }
     },
     async refreshUser () {


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client/vendeur

- Périmetre roles : auxiliaire/admin/coach/formateur

- Cas d'usage : Si j’essaie de modifier l’adresse mail d’un utilisateur avec une adresse mail déjà existante je n'ai plus la pop-up verte et le mail erroné n'est pas gardé.
A vérifié pour : 
Fiche Auxiliaire
Fiche Apprenant (côté client et côté vendeur)
Fiche Formateur (coté vendeur)
Informations personnelles (côté formateur)
Mon compte (côté client et côté vendeur)
