### PR TITLE
COM-2229: no third state when sort column

### DIFF
--- a/src/core/components/table/ExpandingTable.vue
+++ b/src/core/components/table/ExpandingTable.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card class="relative-position table-spinner-container" flat>
     <q-table v-if="!loading" :data="data" :columns="columns" class="q-pa-md" :pagination="pagination" :row-key="rowKey"
-      :hide-bottom="hideBottom" :visible-columns="formattedVisibleColumns">
+      :hide-bottom="hideBottom" :visible-columns="formattedVisibleColumns" binary-state-sort>
       <template #header="props">
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props"> {{ col.label }} </q-th>


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client/vendeur

- Périmetre roles : coach/admin

- Cas d'usage : sur le tableau de progression des stagiaire, le tri n'a plus que 2 états au lieu de 3 (état "pas de tri" supprimé). 
