### PR TITLE
COM-2202

### DIFF
--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -431,7 +431,7 @@ export default {
     },
     // Administrative document
     getAdministrativeDocumentLink (doc) {
-      return get(doc, 'driveFile.link') || false;
+      return get(doc, 'driveFile.link') || '';
     },
     async getAdministrativeDocuments () {
       try {


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface :  client

- Périmetre roles : Coach/Admin client

- Bug: ETQ Coach ou admin, lorsque je vais sur la page `Configuration RH`, une erreur apparait dans la console: `[Vue warn]: Invalid prop: type check failed for prop "href". Expected String, got Boolean with value false.`
