### PR TITLE
COM-2089: change clear button in close button

### DIFF
--- a/src/core/components/PictureUploader.vue
+++ b/src/core/components/PictureUploader.vue
@@ -14,7 +14,7 @@
         @click="validateImageDeletion" />
       <q-btn v-if="disablePictureEdition && hasPicture" color="primary" round flat icon="save_alt" size="1rem"
         type="a" :href="pictureDlLink(pictureLink)" target="_blank" />
-      <q-btn v-if="!disablePictureEdition" color="primary" icon="clear" @click="closePictureEdition" round flat
+      <q-btn v-if="!disablePictureEdition" color="primary" icon="close" @click="closePictureEdition" round flat
         size="1rem" />
       <q-btn v-if="!disablePictureEdition" color="primary" icon="rotate_left" @click="croppa.rotate(-1)" round
         flat size="1rem" />

--- a/src/core/components/courses/CourseHistoryFeed.vue
+++ b/src/core/components/courses/CourseHistoryFeed.vue
@@ -3,7 +3,7 @@
     <div class="row history-container-title">
       <div class="col-11">Historique d'activité</div>
       <div class="col-1 cursor-pointer">
-        <ni-button icon="clear" size="sm" @click.native="close" />
+        <ni-button icon="close" size="sm" @click.native="close" />
       </div>
     </div>
     <div class="scroll-container" :style="{ height: `${height - 50}px` }" ref="scrollTarget">

--- a/src/core/components/modal/HtmlModal.vue
+++ b/src/core/components/modal/HtmlModal.vue
@@ -3,7 +3,7 @@
     <q-card class="full-height" style="width: 80vw">
       <q-card-section class="row justify-between no-wrap title-modal">
         <div class="q-ml-md q-mb-xs modal-title">{{ props.title }}</div>
-        <q-icon class="cursor-pointer" name="clear" size="1.5rem" v-close-popup />
+        <q-icon class="cursor-pointer" name="close" size="1.5rem" v-close-popup />
       </q-card-section>
       <q-card-section>
         <div v-show="!props.loading" v-html="props.html" class="modal-padding" />

--- a/src/core/components/modal/Modal.vue
+++ b/src/core/components/modal/Modal.vue
@@ -9,7 +9,7 @@
           </div>
           <div class="col-1 cursor-pointer modal-btn-close">
             <span>
-              <q-icon name="clear" v-close-popup data-cy="close-modal" size="sm" />
+              <q-icon name="close" v-close-popup data-cy="close-modal" size="sm" />
             </span>
           </div>
         </div>

--- a/src/modules/client/components/contracts/ContractEndingModal.vue
+++ b/src/modules/client/components/contracts/ContractEndingModal.vue
@@ -16,7 +16,7 @@
       required-field @blur="validations.otherMisc.$touch" :error="validations.otherMisc.$error"
       @input="update($event, 'otherMisc')" />
     <template slot="footer">
-      <q-btn no-caps class="full-width modal-btn" label="Mettre fin au contrat" icon-right="clear" color="primary"
+      <q-btn no-caps class="full-width modal-btn" label="Mettre fin au contrat" icon-right="close" color="primary"
         :loading="loading" @click="submit" />
     </template>
   </ni-modal>

--- a/src/modules/client/components/contracts/ContractsCell.vue
+++ b/src/modules/client/components/contracts/ContractsCell.vue
@@ -60,7 +60,7 @@
         <template v-if="displayActions && !contract.endDate">
           <ni-button icon="add" label="Ajouter un avenant"
             @click="openVersionCreation(contract)" :disable="contractsLoading" />
-          <ni-button icon="clear" label="Mettre fin au contrat"
+          <ni-button icon="close" label="Mettre fin au contrat"
             @click="openEndContract(contract)" :disable="contractsLoading" />
         </template>
       </q-card-actions>
@@ -69,7 +69,7 @@
     <q-dialog v-model="esignModal" @hide="refreshWithTimeout" full-height full-width>
       <q-card class="full-height" style="width: 80vw">
         <q-card-section class="row justify-end">
-          <ni-button icon="clear" size="sm" @click.native="esignModal = false" />
+          <ni-button icon="close" size="sm" @click.native="esignModal = false" />
         </q-card-section>
         <q-card-section class="full-height">
           <iframe :src="embeddedUrl" frameborder="0" class="iframe-normal" />

--- a/src/modules/client/components/planning/ChipAuxiliaryIndicator.vue
+++ b/src/modules/client/components/planning/ChipAuxiliaryIndicator.vue
@@ -24,7 +24,7 @@
             </div>
             <div class="col-1 cursor-pointer modal-btn-close">
               <span>
-                <q-icon name="clear" v-close-popup size="sm" />
+                <q-icon name="close" v-close-popup size="sm" />
               </span>
             </div>
           </div>

--- a/src/modules/client/components/planning/DeleteEventsModal.vue
+++ b/src/modules/client/components/planning/DeleteEventsModal.vue
@@ -19,7 +19,7 @@
     </template>
     <template slot="footer">
       <q-btn class="modal-btn full-width" color="primary" no-caps :loading="loading" label="Supprimer les interventions"
-        @click="validateEventsDeletion" icon-right="clear" />
+        @click="validateEventsDeletion" icon-right="close" />
     </template>
   </ni-modal>
 </template>

--- a/src/modules/client/components/planning/EventHistoryFeed.vue
+++ b/src/modules/client/components/planning/EventHistoryFeed.vue
@@ -3,7 +3,7 @@
     <div class="row history-container-title">
       <div class="col-11">Flux d'activité</div>
       <div class="col-1 cursor-pointer">
-        <ni-button icon="clear" size="sm" @click.native="close" />
+        <ni-button icon="close" size="sm" @click.native="close" />
       </div>
     </div>
     <div class="scroll-container" ref="scrollTargetRef">

--- a/src/modules/client/components/planning/PlanningModalHeader.vue
+++ b/src/modules/client/components/planning/PlanningModalHeader.vue
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="col-1 cursor-pointer modal-btn-close">
-      <ni-button icon="clear" @click.native="close" />
+      <ni-button icon="close" @click.native="close" />
     </div>
   </div>
 </template>

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -104,7 +104,7 @@
     <q-dialog v-model="newESignModal" @hide="checkMandates" full-height full-width data-cy="esign-modal">
       <q-card class="full-height" style="width: 80vw">
         <q-card-section class="row justify-end no-wrap">
-          <ni-button icon="clear" @click.native="newESignModal = false" />
+          <ni-button icon="close" @click.native="newESignModal = false" />
         </q-card-section>
         <q-card-section class="full-height">
           <iframe :src="embeddedUrl" frameborder="0" class="iframe-normal" />


### PR DESCRIPTION
-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : tous

- Périmetre roles : tous

- Cas d'usage : les boutons clear deviennent des boutons close.
Changements : 
- Croix pour supprimer sa photo de profil dans les infos du compte
- Croix pour fermer la modale des CGU et RGPD dans les infos du compte
- Croix pour fermer l’historique d’une formation sur le profil organisation d’une formation
- Croix pour fermer une modale
- Croix dans la cellule d’un contrat auxiliaire pour mettre fin au contrat et croix sur le bouton Mettre fin au contrat dans la modale associée
- Croix sur la modale des heures d’une auxiliaires dans le planning auxiliaire (lorsqu’on clique sur le compteur d’heures)
- Croix sur le bouton Supprimer les interventions dans la modale de suppression des événements
- Croix pour fermer le flux d’activité des historiques des événements
- Croix pour fermer la modale de signature de mandat côté aidant
